### PR TITLE
feat(sdk): publish a goreleaser tarball alongside the binaries

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,6 +24,64 @@ archives:
     ids:
     - vinberod
     - vinbero
+  # SDK tarball: distributed alongside the binaries so plugin authors can
+  # `curl | sudo tar xz -C /usr/local/` and start building without cloning
+  # the vinbero repo. Layout matches docs/plan/plugin-sdk-3-tarball-distribution.md §2.
+  - id: sdk
+    builds: []
+    name_template: "vinbero-sdk-{{ .Version }}"
+    formats:
+      - 'tar.gz'
+    # wrap_in_directory must stay false: the user command is
+    # `tar xz -C /usr/local/`, which assumes the tarball's top level is
+    # `include/` and `share/` directly. Re-wrapping would force users to
+    # pass --strip-components=1.
+    wrap_in_directory: false
+    files:
+      # Public ABI headers.
+      - src: sdk/c/include/vinbero/*.h
+        dst: include/vinbero/
+      # Internal headers that the public ones #include via "core/...".
+      # These are listed individually (not src/core/*.h) to keep the public
+      # surface explicit; srv6.h / esi.h / xdp_stats.h stay private.
+      - src: src/core/xdp_map.h
+        dst: include/core/
+      - src: src/core/xdp_prog.h
+        dst: include/core/
+      - src: src/core/xdp_tailcall.h
+        dst: include/core/
+      - src: src/core/xdp_tailcall_helpers.h
+        dst: include/core/
+      - src: src/core/xdp_tailcall_macros.h
+        dst: include/core/
+      # xdp_stats.h is required transitively: xdp_tailcall_helpers.h
+      # implements tailcall_epilogue using stats_action_inc / slot_stats_inc
+      # from this header, so plugins that go through the epilogue (the
+      # SDK's required return contract) cannot build without it.
+      - src: src/core/xdp_stats.h
+        dst: include/core/
+      # Build template — drop next to the public headers so the
+      # one-liner Makefile (`include /usr/local/include/vinbero/Makefile.plugin`)
+      # works out of the box.
+      - src: sdk/c/Makefile.plugin
+        dst: include/vinbero/Makefile.plugin
+      # Static data (docs / examples) live under share/ per FHS.
+      - src: sdk/README.md
+        dst: share/vinbero-sdk/README.md
+      - src: LICENSE
+        dst: share/vinbero-sdk/LICENSE
+      - src: sdk/examples/plugin-counter/Makefile
+        dst: share/vinbero-sdk/examples/plugin-counter/Makefile
+      - src: sdk/examples/plugin-counter/plugin.c
+        dst: share/vinbero-sdk/examples/plugin-counter/plugin.c
+      - src: sdk/examples/plugin-counter/README.md
+        dst: share/vinbero-sdk/examples/plugin-counter/README.md
+      - src: sdk/examples/simple-acl/Makefile
+        dst: share/vinbero-sdk/examples/simple-acl/Makefile
+      - src: sdk/examples/simple-acl/plugin.c
+        dst: share/vinbero-sdk/examples/simple-acl/plugin.c
+      - src: sdk/examples/simple-acl/README.md
+        dst: share/vinbero-sdk/examples/simple-acl/README.md
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,43 @@ sdk-clean: ## Clean every sample plugin under sdk/examples/
 		$(MAKE) -C $$d clean; \
 	done
 
+## SDK packaging:
+# SDK_VERSION follows the host repo's git description so a local tarball
+# built from a tagged commit lines up with the goreleaser-generated one.
+# Falls back to "dev" when git metadata is unavailable (CI shallow clones).
+SDK_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+SDK_STAGE := out/sdk-stage
+SDK_TARBALL := out/vinbero-sdk-$(SDK_VERSION).tar.gz
+
+.PHONY: sdk-archive
+sdk-archive: ## Build SDK tarball into out/
+	@rm -rf $(SDK_STAGE)
+	@install -d $(SDK_STAGE)/include/vinbero
+	@install -d $(SDK_STAGE)/include/core
+	@install -d $(SDK_STAGE)/share/vinbero-sdk/examples
+	@install -m 644 sdk/c/include/vinbero/*.h $(SDK_STAGE)/include/vinbero/
+	@install -m 644 sdk/c/Makefile.plugin $(SDK_STAGE)/include/vinbero/Makefile.plugin
+	@install -m 644 src/core/xdp_map.h $(SDK_STAGE)/include/core/
+	@install -m 644 src/core/xdp_prog.h $(SDK_STAGE)/include/core/
+	@install -m 644 src/core/xdp_tailcall.h $(SDK_STAGE)/include/core/
+	@install -m 644 src/core/xdp_tailcall_helpers.h $(SDK_STAGE)/include/core/
+	@install -m 644 src/core/xdp_tailcall_macros.h $(SDK_STAGE)/include/core/
+	@install -m 644 src/core/xdp_stats.h $(SDK_STAGE)/include/core/
+	@install -m 644 sdk/README.md $(SDK_STAGE)/share/vinbero-sdk/
+	@install -m 644 LICENSE $(SDK_STAGE)/share/vinbero-sdk/
+	@for d in sdk/examples/plugin-counter sdk/examples/simple-acl; do \
+		name=$$(basename $$d); \
+		install -d $(SDK_STAGE)/share/vinbero-sdk/examples/$$name; \
+		install -m 644 $$d/Makefile $$d/plugin.c $$d/README.md \
+			$(SDK_STAGE)/share/vinbero-sdk/examples/$$name/; \
+	done
+	@cd $(SDK_STAGE) && tar czf ../vinbero-sdk-$(SDK_VERSION).tar.gz .
+	@echo "Created: $(SDK_TARBALL)"
+
+.PHONY: sdk-archive-verify
+sdk-archive-verify: sdk-archive build ## Verify tarball end-to-end
+	./scripts/sdk_archive_verify.sh $(SDK_TARBALL)
+
 ## Env:
 .PHONY: remove-ebpfmap show-trace_pipe
 remove-ebpfmap: ## remove all ebpf maps

--- a/scripts/sdk_archive_verify.sh
+++ b/scripts/sdk_archive_verify.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Verify the SDK tarball is self-contained and produces a valid plugin.
+# Layout assertions match docs/plan/plugin-sdk-3-tarball-distribution.md §2.
+set -euo pipefail
+
+TARBALL="${1:?usage: sdk_archive_verify.sh <tarball>}"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# 1. Extract tarball to a fake /usr/local prefix.
+mkdir -p "$WORK/prefix"
+tar xzf "$TARBALL" -C "$WORK/prefix"
+
+# 2. Confirm the expected files landed at the documented paths.
+required=(
+  "$WORK/prefix/include/vinbero/plugin.h"
+  "$WORK/prefix/include/vinbero/maps.h"
+  "$WORK/prefix/include/vinbero/types.h"
+  "$WORK/prefix/include/vinbero/helpers.h"
+  "$WORK/prefix/include/vinbero/Makefile.plugin"
+  "$WORK/prefix/include/core/xdp_tailcall.h"
+  "$WORK/prefix/include/core/xdp_prog.h"
+  "$WORK/prefix/share/vinbero-sdk/README.md"
+  "$WORK/prefix/share/vinbero-sdk/LICENSE"
+  "$WORK/prefix/share/vinbero-sdk/examples/plugin-counter/Makefile"
+  "$WORK/prefix/share/vinbero-sdk/examples/plugin-counter/plugin.c"
+  "$WORK/prefix/share/vinbero-sdk/examples/simple-acl/Makefile"
+  "$WORK/prefix/share/vinbero-sdk/examples/simple-acl/plugin.c"
+)
+for f in "${required[@]}"; do
+  test -f "$f" || { echo "missing: $f" >&2; exit 1; }
+done
+
+# 3. Build each example using only headers from the tarball; this fails
+#    immediately if a #include path is wrong or a header is missing.
+#    MAKEFILE_PLUGIN points at the template shipped inside the tarball
+#    so the in-tree relative include (../../c/Makefile.plugin) is bypassed.
+for ex in plugin-counter simple-acl; do
+  exdir="$WORK/prefix/share/vinbero-sdk/examples/$ex"
+  echo "[verify] building $ex"
+  make -C "$exdir" \
+    VINBERO_SDK_ROOT="$WORK/prefix/include" \
+    VINBERO_CORE_ROOT="$WORK/prefix/include" \
+    MAKEFILE_PLUGIN="$WORK/prefix/include/vinbero/Makefile.plugin" \
+    BPF_CLANG="${BPF_CLANG:-clang}"
+done
+
+# 4. Validate the plugin contract using the in-tree CLI. This catches any
+#    regressions in the tailcall_epilogue / forbidden-helper rules.
+#    Note: the binary is named `vinbero` in this repo (not `vbctl`); the
+#    `plugin validate` subcommand is provided by cmd/vinbero.
+VBCTL="${VBCTL:-./out/bin/vinbero}"
+if [ ! -x "$VBCTL" ]; then
+  echo "vinbero CLI not found at $VBCTL — run 'make build' first" >&2
+  exit 1
+fi
+"$VBCTL" plugin validate \
+  --prog "$WORK/prefix/share/vinbero-sdk/examples/plugin-counter/plugin.o" \
+  --program plugin_counter
+"$VBCTL" plugin validate \
+  --prog "$WORK/prefix/share/vinbero-sdk/examples/simple-acl/plugin.o" \
+  --program simple_acl
+
+echo "[verify] OK"

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -36,13 +36,37 @@ VINBERO_PLUGIN(my_plugin)
 char _license[] SEC("license") = "GPL";
 ```
 
+## Installation
+
+Two options:
+
+### From a release tarball (recommended for plugin authors)
+
+```bash
+curl -L https://github.com/takehaya/Vinbero/releases/download/vX.Y.Z/vinbero-sdk-vX.Y.Z.tar.gz \
+  | sudo tar xz -C /usr/local/
+```
+
+This installs:
+
+- `/usr/local/include/vinbero/*.h` — public ABI headers
+- `/usr/local/include/core/*.h` — internal headers referenced by the public ones
+- `/usr/local/include/vinbero/Makefile.plugin` — build template for plugin projects
+- `/usr/local/share/vinbero-sdk/{README.md,LICENSE,examples/}` — docs and worked examples
+
+### From an in-tree checkout (for vinbero developers)
+
+```bash
+git clone https://github.com/takehaya/Vinbero
+cd Vinbero
+sudo make install-sdk
+```
+
+This installs the same files from the working tree without producing a tarball.
+
 ## Build
 
-1. Install the SDK headers:
-   ```
-   sudo make install-sdk   # from vinbero source
-   ```
-2. Create a one-line Makefile that includes the SDK template:
+1. Create a one-line Makefile that includes the SDK template:
    ```
    echo 'include /usr/local/include/vinbero/Makefile.plugin' > Makefile
    make
@@ -50,11 +74,11 @@ char _license[] SEC("license") = "GPL";
    The template picks up every `*.c` in the directory and builds `*.o`.
    See `sdk/examples/*/Makefile` for the in-tree pattern (overrides
    `VINBERO_SDK_ROOT` / `VINBERO_CORE_ROOT` for local builds).
-3. Validate locally before uploading:
+2. Validate locally before uploading:
    ```
    vinbero plugin validate --prog plugin.o --program my_plugin
    ```
-4. Register with a running vinbero:
+3. Register with a running vinbero:
    ```
    vinbero -s http://localhost:8080 plugin register \
        --type endpoint --index 32 --prog plugin.o --program my_plugin

--- a/sdk/examples/plugin-counter/Makefile
+++ b/sdk/examples/plugin-counter/Makefile
@@ -1,4 +1,8 @@
 VINBERO_SDK_ROOT  ?= ../../c/include
 VINBERO_CORE_ROOT ?= ../../../src
+# Allow overriding the include path so the same Makefile works both
+# in-tree (default, ../../c/Makefile.plugin) and from an extracted SDK
+# tarball (override to <prefix>/include/vinbero/Makefile.plugin).
+MAKEFILE_PLUGIN   ?= ../../c/Makefile.plugin
 
-include ../../c/Makefile.plugin
+include $(MAKEFILE_PLUGIN)

--- a/sdk/examples/simple-acl/Makefile
+++ b/sdk/examples/simple-acl/Makefile
@@ -1,4 +1,8 @@
 VINBERO_SDK_ROOT  ?= ../../c/include
 VINBERO_CORE_ROOT ?= ../../../src
+# Allow overriding the include path so the same Makefile works both
+# in-tree (default, ../../c/Makefile.plugin) and from an extracted SDK
+# tarball (override to <prefix>/include/vinbero/Makefile.plugin).
+MAKEFILE_PLUGIN   ?= ../../c/Makefile.plugin
 
-include ../../c/Makefile.plugin
+include $(MAKEFILE_PLUGIN)


### PR DESCRIPTION
## Summary

外部プラグイン作者向けの SDK 配布チャネルを整備。`curl | sudo tar xz -C /usr/local/` の 1 行で SDK ヘッダ + Makefile.plugin + examples を導入できる tarball を、本体バイナリと並列に goreleaser で発行する。

- `.goreleaser.yaml` に `id: sdk` archive 追加 (`wrap_in_directory: false` で `tar xz -C /usr/local/` 直接展開可)。
- レイアウト: `include/vinbero/{plugin,maps,types,helpers}.h` + `include/core/xdp_*.h` + `share/vinbero-sdk/{README,LICENSE,examples/}`
- `xdp_stats.h` も `include/core/` に同梱。`xdp_tailcall_helpers.h` 経由で `tailcall_epilogue` の依存に乗っているため、これがないとプラグインがビルドできない (設計書からの逸脱として記録)。
- `Makefile`: `sdk-archive` (ローカル生成) + `sdk-archive-verify` (E2E 検証 = tarball 展開 → examples build → `vinbero plugin validate` で contract 確認)。
- `scripts/sdk_archive_verify.sh` 新規。
- `sdk/examples/{plugin-counter,simple-acl}/Makefile` を `MAKEFILE_PLUGIN ?=` で in-tree / tarball 両対応に。
- `sdk/README.md` のインストール手順を tarball / in-tree の二択に書き換え。

## Stacked PR base

このブランチは Phase 1c/1d (PR #23) の上に積んでいます。PR #23 がマージされるまでは base が `feat/plugin-sdk-1c-map-classification` のままです。

## Test plan

- [x] `make sdk-archive` で 23KB tarball 生成、`tar tzf` で構成確認
- [x] `make sdk-archive-verify` で E2E (tarball 展開 → both examples build with tarball-only headers → `vinbero plugin validate` で plugin_counter / simple_acl が contract pass)
- [x] `go build ./...` / `go vet ./...` clean
- [ ] Reviewer: `goreleaser release --snapshot --clean` で `dist/` 配下に出来上がる tarball が `tar tzf` でトップレベル wrap なしになっていること
- [ ] 設計書: `docs/plan/plugin-sdk-3-tarball-distribution.md` (gitignore 配下、未コミット)