### PR TITLE
feat(plugin): asm-level RO write enforcement for plugin ELFs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,9 +112,15 @@ install-dev-tools: ## install development tools
 ## SDK:
 SDK_PREFIX ?= /usr/local
 SDK_EXAMPLES := $(wildcard sdk/examples/*/Makefile)
-SDK_EXAMPLE_DIRS := $(patsubst %/Makefile,%,$(SDK_EXAMPLES))
+SDK_ALL_DIRS := $(patsubst %/Makefile,%,$(SDK_EXAMPLES))
+# Negative examples are plugins authored to violate the contract on
+# purpose. They MUST be excluded from sdk-build / sdk-test (which assume
+# every example passes `vbctl plugin validate`) and instead run through
+# sdk-test-negative, which expects validate to fail.
+SDK_NEGATIVE_DIRS := sdk/examples/plugin-counter-evil
+SDK_EXAMPLE_DIRS := $(filter-out $(SDK_NEGATIVE_DIRS),$(SDK_ALL_DIRS))
 
-.PHONY: install-sdk sdk-build sdk-test sdk-clean
+.PHONY: install-sdk sdk-build sdk-test sdk-test-negative sdk-clean
 install-sdk: ## Install plugin SDK headers into $(SDK_PREFIX)/include/vinbero
 	install -d $(SDK_PREFIX)/include/vinbero
 	install -m 644 sdk/c/include/vinbero/*.h $(SDK_PREFIX)/include/vinbero/
@@ -122,7 +128,7 @@ install-sdk: ## Install plugin SDK headers into $(SDK_PREFIX)/include/vinbero
 	install -m 644 src/core/*.h $(SDK_PREFIX)/include/core/
 	install -m 644 sdk/c/Makefile.plugin $(SDK_PREFIX)/include/vinbero/Makefile.plugin
 
-sdk-build: ## Build every sample plugin under sdk/examples/
+sdk-build: ## Build every sample plugin under sdk/examples/ (positive examples only)
 	@for d in $(SDK_EXAMPLE_DIRS); do \
 		echo "[sdk-build] $$d"; \
 		$(MAKE) -C $$d || exit 1; \
@@ -140,8 +146,26 @@ sdk-test: sdk-build build-targets ## Validate every built sample plugin via the 
 		./out/bin/vinbero plugin validate --prog "$$obj" --program "$$name" || exit 1; \
 	done
 
-sdk-clean: ## Clean every sample plugin under sdk/examples/
-	@for d in $(SDK_EXAMPLE_DIRS); do \
+# Phase 2 RO-write enforcement regression check: every plugin under
+# SDK_NEGATIVE_DIRS is expected to fail `vbctl plugin validate`. If one
+# of them ever passes, the validator silently regressed — fail loudly.
+sdk-test-negative: build-targets ## Confirm validator rejects intentionally-bad sample plugins
+	@for d in $(SDK_NEGATIVE_DIRS); do \
+		echo "[sdk-test-negative] build $$d"; \
+		$(MAKE) -C $$d || exit 1; \
+		obj="$$d/plugin.o"; \
+		name=$$(basename $$d | tr '-' '_'); \
+		echo "[sdk-test-negative] expect-reject $$obj"; \
+		if ./out/bin/vinbero plugin validate --prog "$$obj" --program "$$name" >/dev/null 2>&1; then \
+			echo "FAIL: $$obj passed validate but should be rejected"; \
+			exit 1; \
+		else \
+			echo "OK: $$obj correctly rejected"; \
+		fi; \
+	done
+
+sdk-clean: ## Clean every sample plugin under sdk/examples/ (positive + negative)
+	@for d in $(SDK_ALL_DIRS); do \
 		$(MAKE) -C $$d clean; \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ sdk-test: sdk-build build-targets ## Validate every built sample plugin via the 
 		./out/bin/vinbero plugin validate --prog "$$obj" --program "$$name" || exit 1; \
 	done
 
-# Phase 2 RO-write enforcement regression check: every plugin under
+# RO-write enforcement regression check: every plugin under
 # SDK_NEGATIVE_DIRS is expected to fail `vbctl plugin validate`. If one
 # of them ever passes, the validator silently regressed — fail loudly.
 sdk-test-negative: build-targets ## Confirm validator rejects intentionally-bad sample plugins

--- a/docs/design/ja/plugin-sdk.md
+++ b/docs/design/ja/plugin-sdk.md
@@ -124,7 +124,7 @@ vinbero plugin validate --prog plugin.o --program my_plugin
 | **Read-Only** (14 本) | `sid_function_map`, `sid_aux_map`, `headend_v4_map`, `headend_v6_map`, `headend_l2_map`, `fdb_map`, `bd_peer_map`, `bd_peer_reverse_map`, `esi_map`, `bd_peer_l2_ext_map`, `headend_l2_ext_map`, `bd_local_esi_map`, `dx2v_map`, `tailcall_ctx_map` | ルーティング / BD / ESI などの制御状態 | プラグインから書き換えるとデータプレーンが壊れる。必ず読み取りのみ |
 | **Read-Write** (8 本) | `scratch_map`, `stats_map`, `slot_stats_endpoint`, `slot_stats_headend_v4`, `slot_stats_headend_v6`, `sid_endpoint_progs`, `headend_v4_progs`, `headend_v6_progs` | 統計 / scratch / PROG_ARRAY | 書き込み可 (ただし `slot_stats_*` は epilogue 経由、PROG_ARRAY は `bpf_tail_call` 専用) |
 
-プラグイン ELF が RO カテゴリのマップに write 命令を含んでいると、将来バージョン (Phase 2) では register 時に reject される予定です。現状は audit ログ (`slog` の `plugin map linkage` イベント) に記録されるのみ。
+プラグイン ELF が RO カテゴリのマップに write 命令 (`BPF_ST` / `BPF_STX` / `BPF_ATOMIC`) を含んでいると、Phase 2 の asm レベル静的検証 (`pkg/bpf/plugin_validate.go::checkROWrites`) が **load 前に検出**します。書き込み先レジスタが静的に追えない場合 (例: `bpf_map_lookup_elem` の戻り値経由) も保守的に reject します。CLI (`vbctl plugin validate`) は常に enforce で動き、サーバー側は段階導入のため `settings.validate.ro_enforce` で `warn` (audit ログのみ、デフォルト) と `enforce` (RPC 拒否) を切替できます。BPF stack (`R10` = frame pointer) への書き込みはローカル変数のためのもので map 書込ではないので除外されます。
 
 ### プラグイン固有マップ
 

--- a/docs/dev/plugin-sdk-implementation.md
+++ b/docs/dev/plugin-sdk-implementation.md
@@ -515,3 +515,56 @@ func (p *PluginAux[T]) Free(ctx context.Context, idx uint32) error
 - `make test-runnable` : 両バイナリ起動 OK
 - `make sdk-test` : `plugin-counter` / `plugin-acl-prefix` / `simple-acl` 全サンプルが validate 通過
 - `sdk/examples/plugin-counter/test.sh` : 既存 embed フロー + Phase 1d の alloc/bind フロー両方で E2E 通過
+
+---
+
+## Phase 2: asm レベル RO write enforce
+
+設計書: `docs/plan/plugin-sdk-2-asm-ro-enforce.md`
+
+### 追加した CFG analyzer
+
+`pkg/bpf/plugin_validate.go::checkROWrites` がメインプログラムを線形走査し、
+`BPF_ST` / `BPF_STX` / `BPF_ATOMIC` ファミリの命令を全て検出する。書き込み先
+レジスタの直近上書きを後ろから探し、`LoadMapPtr` ならその map 名と RO 集合を
+照合、それ以外なら `(dynamic)` として **保守的 reject**。
+
+スコープはメインプログラム本体に限定 (`Symbol() != ""` で停止)。プラグイン ELF
+末尾に展開される `tailcall_epilogue` 等のサブプログラム本体を巻き込まないため。
+
+`R10` (frame pointer) を Dst にするストアは BPF stack 書き込みなので除外
+(`isStackStore`)。clang は C のローカル変数 (`struct foo key;`) を必ず stack に
+落とすため、ここを map 書込として扱うと全プラグインが (dynamic) reject される
+(`simple-acl` 例で実観測した false positive)。
+
+### 段階導入
+
+`settings.validate.ro_enforce` (`warn` | `enforce`、デフォルト `warn`)。
+`bpf.ROEnforceMode` enum + `ParseROEnforceMode` で string→enum 変換。
+violation は `bpf.ErrPluginROWrite` をラップして返し、`PluginRegister` が
+`errors.Is` で warn-eligible 判定する。**CLI は常に enforce 固定** (shift-left)。
+
+### 静的 helper
+
+CLI は `MapOperations` インスタンスを持たないため、`pkg/bpf/maps.go` に
+`SharedReadOnlyMapNames()` / `SharedReadWriteMapNames()` / `SharedReadOnlyMapNamesSet()`
+を追加。`TestSharedMapPartitioning` を拡張し、live getter と完全一致 (双方向)
+を assert することで分類のドリフトを実行時に防ぐ。新たに `TestSharedMapNamesStatic`
+も追加し、BPF load 不要 (sudo 不要) のサンドボックスでも分類のドリフトを検出
+できるようにした。
+
+### 負例サンプル
+
+`sdk/examples/plugin-counter-evil/` を新設。`sid_function_map` を
+`bpf_map_lookup_elem` 経由で書き換える plugin。CI ターゲット
+`make sdk-test-negative` が `vbctl plugin validate` の reject を確認する。
+通常の `sdk-test` には含めない (Makefile の `SDK_NEGATIVE_DIRS` で除外)。
+
+### 検証
+
+- `go build ./...` / `go vet ./...` : 0 issue
+- `go test -race -count=1 -run 'TestValidatePlugin|TestSharedMapNamesStatic|TestParseROEnforceMode' ./pkg/bpf/... ./pkg/server/...` : 全 25+ ケース pass
+- 実 plugin (`sdk/examples/simple-acl/plugin.o`) を `vbctl plugin validate` に
+  通し、stack-store filter 追加後は OK (false positive なし)
+- BPF objects のビルド (clang) はサンドボックス外でのみ実行可能 (kernel header の
+  `linux/in6.h` 解決問題)。`make sdk-test-negative` の実行は実機側で確認

--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -19,7 +19,7 @@ import (
 var pinnedControlMaps = []string{
 	"sid_function_map",
 	"sid_aux_map",
-	"aux_owner_map", // Phase 2: persistent owner tags paired with sid_aux_map
+	"aux_owner_map", // persistent owner tags paired with sid_aux_map
 	"headend_v4_map",
 	"headend_v6_map",
 	"headend_l2_map",

--- a/pkg/bpf/maps.go
+++ b/pkg/bpf/maps.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -61,9 +62,8 @@ type MapOperations struct {
 // NewMapOperations creates a new MapOperations instance.
 // The aux index allocator capacity is derived from the actual sid_aux_map MaxEntries.
 // When the BPF AuxOwnerMap is available it is wired into the allocator so
-// owner tags persist across daemon restarts (Phase 2 BPF pinning); a nil
-// AuxOwnerMap leaves the allocator in the in-memory-only behavior of
-// Phase 1d.
+// owner tags persist across daemon restarts via aux_owner_map; a nil
+// AuxOwnerMap leaves the allocator in-memory-only.
 func NewMapOperations(objs *BpfObjects) *MapOperations {
 	auxMax := uint32(512) // fallback
 	if info, err := objs.SidAuxMap.Info(); err == nil {
@@ -77,30 +77,26 @@ func NewMapOperations(objs *BpfObjects) *MapOperations {
 	}
 }
 
-// AuxOwnerBuiltin tags aux indices that belong to vinbero-managed SID
-// behaviors (End.X / End.DT2 / End.B6 / etc.). Plugin-owned indices use
-// AuxOwnerPluginTag with (mapType, slot).
-//
-// In-memory uses still rely on this short form. Persistence to
-// aux_owner_map writes the version-stamped AuxOwnerBuiltinTag so old pins
-// remain readable when the format evolves.
-const AuxOwnerBuiltin = "builtin"
-
-// AuxOwnerVersion is bumped when the on-wire owner tag format changes.
-// Tags written by older versions are accepted by ParseAuxOwnerTag for
-// forward migration; tags newly minted by AuxOwnerPluginTag /
-// AuxOwnerBuiltinTag always use the current version.
+// AuxOwnerVersion is bumped when the owner tag format changes. Tags
+// written by older versions are accepted by ParseAuxOwnerTag for forward
+// migration; tags newly minted by AuxOwnerPluginTag / AuxOwnerBuiltin use
+// the current version.
 const AuxOwnerVersion = "v1"
 
-// AuxOwnerBuiltinTag is the version-stamped builtin owner tag persisted
-// in aux_owner_map. Returned as a constant rather than the bare
-// AuxOwnerBuiltin so persisted tags survive future format changes.
-var AuxOwnerBuiltinTag = "builtin:" + AuxOwnerVersion
+// AuxOwnerBuiltin tags aux indices that belong to vinbero-managed SID
+// behaviors (End.X / End.DT2 / End.B6 / etc.). Plugin-owned indices use
+// AuxOwnerPluginTag with (mapType, slot). The same string is used for
+// in-memory comparisons and for persistence in aux_owner_map.
+const AuxOwnerBuiltin = "builtin:" + AuxOwnerVersion
+
+// AuxOwnerBuiltinTag is preserved as an alias of AuxOwnerBuiltin for
+// callers that have already adopted the explicit "Tag" naming.
+const AuxOwnerBuiltinTag = AuxOwnerBuiltin
 
 // AuxOwnerPluginTag returns the persisted plugin owner tag. Format is
-// "plugin:<version>:<mapType>:<slot>" (Phase 2). Phase 1d shipped the
-// short form "plugin:<mapType>:<slot>"; ParseAuxOwnerTag accepts both so
-// reading an older pin is loss-less.
+// "plugin:<version>:<mapType>:<slot>". ParseAuxOwnerTag also accepts the
+// unversioned legacy form "plugin:<mapType>:<slot>" so older pins
+// remain readable.
 func AuxOwnerPluginTag(mapType string, slot uint32) string {
 	return fmt.Sprintf("plugin:%s:%s:%d", AuxOwnerVersion, mapType, slot)
 }
@@ -180,7 +176,7 @@ var ErrAuxPayloadTooLarge = errors.New("plugin aux payload exceeds SidAuxPluginR
 // auxOwnerMap is the persistence backing for indexAllocator.owners.
 // A nil receiver means pinning is disabled (or AuxOwnerMap was never
 // loaded); Put/Delete become no-ops in that case so the allocator
-// falls back to the Phase 1d in-memory-only behavior.
+// falls back to in-memory-only behavior.
 type auxOwnerMap struct {
 	m *ebpf.Map
 }
@@ -270,8 +266,8 @@ type indexAllocator struct {
 	// ownerMap is the optional BPF-side persistence of owners. When non-nil,
 	// AllocOwner / freeOwnerLocked mirror their in-memory updates here so
 	// owner identity survives daemon restart. Nil means in-memory-only
-	// (Phase 1d) -- typically because pin_maps is disabled or the
-	// aux_owner_map handle is not available.
+	// — typically because pin_maps is disabled or the aux_owner_map
+	// handle is not available.
 	ownerMap *auxOwnerMap
 }
 
@@ -288,17 +284,6 @@ func newIndexAllocator(max uint32) *indexAllocator {
 		nextNew:  1,
 		owners:   make(map[uint32]string),
 	}
-}
-
-// persistedOwnerTag returns the on-wire form of an in-memory owner tag.
-// Phase 1d's bare "builtin" is rewritten to the version-stamped
-// "builtin:v1" so old pins migrate forward; plugin tags already carry
-// their version prefix and are passed through unchanged.
-func persistedOwnerTag(owner string) string {
-	if owner == AuxOwnerBuiltin {
-		return AuxOwnerBuiltinTag
-	}
-	return owner
 }
 
 // allocLocked is the core allocation primitive; callers must hold a.mu.
@@ -335,7 +320,7 @@ func (a *indexAllocator) AllocOwner(owner string) (uint32, error) {
 	if err != nil {
 		return 0, err
 	}
-	if err := a.ownerMap.Put(idx, persistedOwnerTag(owner)); err != nil {
+	if err := a.ownerMap.Put(idx, owner); err != nil {
 		// Roll back: return idx to the free list so a retry can reissue
 		// it. We cannot leave it in a.owners because the on-wire pin has
 		// no record of it.
@@ -449,18 +434,18 @@ func (a *indexAllocator) RecoverWithOwners(owners map[uint32]string) {
 
 // RecoverAuxIndices rebuilds the in-memory allocator state at startup.
 //
-// Phase 2 path (preferred): when aux_owner_map carries persisted tags,
-// iterate it and feed RecoverWithOwners directly. This recovers
-// stand-alone PluginAuxAlloc indices that are not yet bound to a SID
-// function -- something the legacy sid_function_map iterate cannot do.
+// Persisted path (preferred): when aux_owner_map carries tags, iterate
+// it and feed RecoverWithOwners directly. Stand-alone PluginAuxAlloc
+// indices that are not yet bound to a SID function are recovered too —
+// something the sid_function_map walk below cannot do.
 //
-// Phase 1d fallback: when aux_owner_map is empty (fresh pin path, or the
-// feature is disabled), reconstruct owners from sid_function_map by
-// looking at each entry's action -- actions below EndpointPluginBase are
-// vinbero-managed (AuxOwnerBuiltin), the rest are plugin-owned at the
-// endpoint PROG_ARRAY slot indicated by action. This branch runs once
-// per pin lifecycle: if persistence is on, we write the recovered tags
-// back into aux_owner_map so subsequent restarts take the v2 path.
+// SID-function reconstruction fallback: when aux_owner_map is empty
+// (fresh pin path, or pin_maps disabled), rebuild owners from
+// sid_function_map by looking at each entry's action — actions below
+// EndpointPluginBase are vinbero-managed (AuxOwnerBuiltin), the rest
+// are plugin-owned at the endpoint PROG_ARRAY slot indicated by action.
+// If persistence is on, recovered tags are then written back into
+// aux_owner_map so subsequent restarts take the persisted path.
 //
 // Entries whose action is in the plugin range but >= EndpointProgMax are
 // considered corrupt (no AllocPluginAux path can produce them today; they
@@ -468,7 +453,7 @@ func (a *indexAllocator) RecoverWithOwners(owners map[uint32]string) {
 // skipped -- the idx is left unowned so a fresh alloc can reuse it after
 // the operator cleans up the SID entry.
 func (m *MapOperations) RecoverAuxIndices() error {
-	// Phase 2: try aux_owner_map first when present.
+	// Persisted path: try aux_owner_map first when present.
 	if m.auxAlloc.ownerMap != nil {
 		owners, err := m.auxAlloc.ownerMap.Iterate()
 		if err != nil {
@@ -533,18 +518,18 @@ func (m *MapOperations) RecoverAuxIndices() error {
 	// reconstruction.
 	if m.auxAlloc.ownerMap != nil {
 		for idx, tag := range owners {
-			_ = m.auxAlloc.ownerMap.Put(idx, persistedOwnerTag(tag))
+			_ = m.auxAlloc.ownerMap.Put(idx, tag)
 		}
 	}
 	return nil
 }
 
-// FreeAllByOwner releases every index whose owner tag equals ownerTag.
-// The in-memory map and aux_owner_map are cleared in the same critical
-// section as the per-idx free, but the caller is responsible for any
-// payload zero-write on sid_aux_map -- see MapOperations.FreeAllByOwner
-// for that combined operation. Returns the number of indices that were
-// freed.
+
+// FreeAllByOwner releases every index whose owner tag equals ownerTag,
+// clearing both the in-memory allocator and aux_owner_map. Used by tests
+// that exercise allocator semantics without a BPF map; production purge
+// callers go through MapOperations.FreeAllByOwner so each freed index
+// also gets a sid_aux_map zero-write.
 func (a *indexAllocator) FreeAllByOwner(ownerTag string) int {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -582,12 +567,10 @@ func (a *indexAllocator) listByOwner(mapTypeFilter string, slotFilter uint32, ma
 	defer a.mu.Unlock()
 	out := make([]AuxIndexInfo, 0, len(a.owners))
 	for idx, tag := range a.owners {
-		persisted := persistedOwnerTag(tag)
 		if mapTypeFilter == "" {
-			out = append(out, AuxIndexInfo{Index: idx, Owner: persisted})
+			out = append(out, AuxIndexInfo{Index: idx, Owner: tag})
 			continue
 		}
-		// Filter is set: only plugin-owned indices that match.
 		kind, mt, slot, err := ParseAuxOwnerTag(tag)
 		if err != nil || kind != AuxOwnerKindPlugin {
 			continue
@@ -598,14 +581,9 @@ func (a *indexAllocator) listByOwner(mapTypeFilter string, slotFilter uint32, ma
 		if matchSlot && slot != slotFilter {
 			continue
 		}
-		out = append(out, AuxIndexInfo{Index: idx, Owner: persisted})
+		out = append(out, AuxIndexInfo{Index: idx, Owner: tag})
 	}
-	// Sort ascending by idx for deterministic responses.
-	for i := 1; i < len(out); i++ {
-		for j := i; j > 0 && out[j-1].Index > out[j].Index; j-- {
-			out[j-1], out[j] = out[j], out[j-1]
-		}
-	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Index < out[j].Index })
 	return out
 }
 
@@ -1829,7 +1807,8 @@ func FormatSegments(segments [MaxSegments][IPv6AddrLen]uint8, numSegments uint8)
 
 // GetSharedReadOnlyMaps returns BPF maps that vinbero manages and plugins may
 // only read. Writes from a plugin into one of these maps will be flagged by the
-// validator (Phase 2 will escalate to a hard reject; today it only warns).
+// validator escalates these into a load-time error when ro_enforce is on;
+// otherwise the violation is logged and the load proceeds.
 func (m *MapOperations) GetSharedReadOnlyMaps() map[string]*ebpf.Map {
 	return map[string]*ebpf.Map{
 		"sid_function_map":    m.objs.SidFunctionMap,
@@ -2213,19 +2192,19 @@ func (m *MapOperations) CountAuxByOwner(ownerTag string) int {
 // per-index error path mirrors freeOwnerLocked's "advance regardless"
 // stance for exactly the same ABA-avoidance reason.
 func (m *MapOperations) FreeAllByOwner(ownerTag string) int {
-	// Collect first (under the allocator lock indirectly via OwnerOf-style
-	// snapshot) so the zero-writes happen outside the lock and a long
-	// purge cannot starve concurrent PluginAux RPCs. We accept the small
-	// race that a concurrent FreeOwner could free an index between snap
-	// and zero-write -- the zero-write of an already-cleared slot is a
-	// harmless duplicate.
+	// Snapshot first so the zero-write + free per index can run outside a
+	// shared critical section. Each index is then released through the
+	// same WithOwnerLocked path the per-RPC FreePluginAux uses, so any
+	// concurrent FreeOwner that races us shows up as ErrOwnerMismatch on
+	// the loser and the slot is freed exactly once.
 	idxs := m.auxAlloc.snapshotByOwner(ownerTag)
+	freed := 0
 	for _, idx := range idxs {
-		var zero SidAuxEntry
-		_ = m.objs.SidAuxMap.Put(idx, &zero)
+		if err := m.FreePluginAux(idx, ownerTag); err == nil {
+			freed++
+		}
 	}
-	// Then collapse the allocator state in one critical section.
-	return m.auxAlloc.FreeAllByOwner(ownerTag)
+	return freed
 }
 
 // snapshotByOwner returns a copy of every index currently tagged with

--- a/pkg/bpf/maps.go
+++ b/pkg/bpf/maps.go
@@ -1867,6 +1867,60 @@ func (m *MapOperations) GetSharedReadWriteMaps() map[string]*ebpf.Map {
 	}
 }
 
+// SharedReadOnlyMapNames returns the names of every shared map that vinbero
+// treats as plugin-readable but not plugin-writable. The list mirrors
+// GetSharedReadOnlyMaps; TestSharedMapPartitioning enforces the invariant
+// so the asm-level RO write enforcer in the validator keeps in sync with
+// the runtime classification.
+//
+// Used by callers (notably `vbctl plugin validate`) that want the RO set
+// without instantiating MapOperations against a live BPF object.
+func SharedReadOnlyMapNames() []string {
+	return []string{
+		"sid_function_map",
+		"sid_aux_map",
+		"headend_v4_map",
+		"headend_v6_map",
+		"headend_l2_map",
+		"fdb_map",
+		"bd_peer_map",
+		"bd_peer_reverse_map",
+		"esi_map",
+		"bd_peer_l2_ext_map",
+		"headend_l2_ext_map",
+		"bd_local_esi_map",
+		"dx2v_map",
+		"tailcall_ctx_map",
+	}
+}
+
+// SharedReadWriteMapNames returns the names of every shared map plugins may
+// write to (or that the kernel verifier needs writable for normal operation).
+// Mirrors GetSharedReadWriteMaps; same partitioning invariant applies.
+func SharedReadWriteMapNames() []string {
+	return []string{
+		"scratch_map",
+		"stats_map",
+		"slot_stats_endpoint",
+		"slot_stats_headend_v4",
+		"slot_stats_headend_v6",
+		MapNameSidEndpointProgs,
+		MapNameHeadendV4Progs,
+		MapNameHeadendV6Progs,
+	}
+}
+
+// SharedReadOnlyMapNamesSet returns SharedReadOnlyMapNames in set form so
+// the validator can do O(1) membership tests without rebuilding a map per
+// plugin.
+func SharedReadOnlyMapNamesSet() map[string]struct{} {
+	out := make(map[string]struct{}, 16)
+	for _, n := range SharedReadOnlyMapNames() {
+		out[n] = struct{}{}
+	}
+	return out
+}
+
 // ========== Plugin Registration ==========
 
 const (

--- a/pkg/bpf/maps_test.go
+++ b/pkg/bpf/maps_test.go
@@ -11,10 +11,53 @@ import (
 	"github.com/takehaya/vinbero/pkg/config"
 )
 
+// TestSharedMapNamesStatic verifies the BPF-free helpers used by the CLI
+// validator: SharedReadOnlyMapNames / SharedReadWriteMapNames must be
+// disjoint and the set-form helper must agree with the slice form. This
+// test runs without sudo so CI sandboxes that can't load BPF still catch
+// classification regressions.
+func TestSharedMapNamesStatic(t *testing.T) {
+	ro := SharedReadOnlyMapNames()
+	rw := SharedReadWriteMapNames()
+	if len(ro) == 0 {
+		t.Fatal("SharedReadOnlyMapNames is empty")
+	}
+	if len(rw) == 0 {
+		t.Fatal("SharedReadWriteMapNames is empty")
+	}
+	roSet := make(map[string]struct{}, len(ro))
+	for _, n := range ro {
+		if _, dup := roSet[n]; dup {
+			t.Errorf("SharedReadOnlyMapNames duplicate %q", n)
+		}
+		roSet[n] = struct{}{}
+	}
+	for _, n := range rw {
+		if _, clash := roSet[n]; clash {
+			t.Errorf("map %q listed in both RO and RW slices", n)
+		}
+	}
+	gotSet := SharedReadOnlyMapNamesSet()
+	if len(gotSet) != len(roSet) {
+		t.Errorf("SharedReadOnlyMapNamesSet size %d != %d", len(gotSet), len(roSet))
+	}
+	for n := range roSet {
+		if _, ok := gotSet[n]; !ok {
+			t.Errorf("SharedReadOnlyMapNamesSet missing %q", n)
+		}
+	}
+}
+
 // TestSharedMapPartitioning verifies that every map returned by the
 // plugin-visible getters is classified into exactly one of RO / RW. Both the
 // validator (plugin_validate_btf.go) and PluginRegister rely on this
 // invariant to audit plugin-ELF map usage.
+//
+// Also verifies that the static helpers SharedReadOnlyMapNames /
+// SharedReadWriteMapNames (used by the CLI validator, which has no live
+// MapOperations) carry the same key set. Drift would mean the asm-level
+// RO-write enforcer rejects in one path but lets the same plugin through
+// in another.
 func TestSharedMapPartitioning(t *testing.T) {
 	h := newXDPTestHelper(t)
 
@@ -31,6 +74,62 @@ func TestSharedMapPartitioning(t *testing.T) {
 	}
 	if len(rw) == 0 {
 		t.Error("GetSharedReadWriteMaps returned an empty set")
+	}
+
+	// Static helper agrees with the live getter, in both directions. The
+	// helper is what `vbctl plugin validate` consumes, so any divergence
+	// would create a CLI-vs-server validation gap.
+	staticRO := make(map[string]struct{})
+	for _, n := range SharedReadOnlyMapNames() {
+		if _, dup := staticRO[n]; dup {
+			t.Errorf("SharedReadOnlyMapNames duplicate entry %q", n)
+		}
+		staticRO[n] = struct{}{}
+	}
+	if len(staticRO) != len(ro) {
+		t.Errorf("RO size mismatch: static=%d, live=%d", len(staticRO), len(ro))
+	}
+	for name := range ro {
+		if _, ok := staticRO[name]; !ok {
+			t.Errorf("live RO map %q missing from SharedReadOnlyMapNames", name)
+		}
+	}
+	for name := range staticRO {
+		if _, ok := ro[name]; !ok {
+			t.Errorf("static RO map %q missing from GetSharedReadOnlyMaps", name)
+		}
+	}
+
+	staticRW := make(map[string]struct{})
+	for _, n := range SharedReadWriteMapNames() {
+		if _, dup := staticRW[n]; dup {
+			t.Errorf("SharedReadWriteMapNames duplicate entry %q", n)
+		}
+		staticRW[n] = struct{}{}
+	}
+	if len(staticRW) != len(rw) {
+		t.Errorf("RW size mismatch: static=%d, live=%d", len(staticRW), len(rw))
+	}
+	for name := range rw {
+		if _, ok := staticRW[name]; !ok {
+			t.Errorf("live RW map %q missing from SharedReadWriteMapNames", name)
+		}
+	}
+	for name := range staticRW {
+		if _, ok := rw[name]; !ok {
+			t.Errorf("static RW map %q missing from GetSharedReadWriteMaps", name)
+		}
+	}
+
+	// Set-form helper covers the same keys as the slice form.
+	roSet := SharedReadOnlyMapNamesSet()
+	if len(roSet) != len(staticRO) {
+		t.Errorf("SharedReadOnlyMapNamesSet size %d != slice %d", len(roSet), len(staticRO))
+	}
+	for name := range staticRO {
+		if _, ok := roSet[name]; !ok {
+			t.Errorf("SharedReadOnlyMapNamesSet missing %q", name)
+		}
 	}
 
 	// sanity check: the validator's expected value types should all refer to

--- a/pkg/bpf/plugin_aux_alloc_test.go
+++ b/pkg/bpf/plugin_aux_alloc_test.go
@@ -174,10 +174,10 @@ func TestIndexAllocatorWithOwnerLockedSerializesFree(t *testing.T) {
 
 // TestParseAuxOwnerTag covers every persisted format we promise to
 // understand: the legacy unversioned "plugin:endpoint:32" / "builtin" of
-// Phase 1d, the version-stamped "plugin:v1:endpoint:32" / "builtin:v1"
-// of Phase 2, and well-formed errors for malformed inputs. Tests pin the
-// migration contract: ParseAuxOwnerTag must accept old pins so Phase 2
-// daemons can read pins written by Phase 1d.
+// the version-stamped "plugin:v1:endpoint:32" / "builtin:v1", and
+// well-formed errors for malformed inputs. The migration contract:
+// ParseAuxOwnerTag must accept the legacy unversioned pins so old pin
+// directories remain readable.
 func TestParseAuxOwnerTag(t *testing.T) {
 	cases := []struct {
 		name        string

--- a/pkg/bpf/plugin_validate.go
+++ b/pkg/bpf/plugin_validate.go
@@ -372,13 +372,60 @@ func checkROWrites(spec *ebpf.ProgramSpec, roMaps map[string]struct{}) error {
 		if in.OpCode.Class() == asm.StClass || in.OpCode.Class() == asm.StXClass {
 			continue
 		}
+		// BPF helper / subprogram calls. The kernel ABI hands the return
+		// value back in R0 and treats R1..R5 as caller-saved. For map
+		// lookup helpers we additionally propagate the map identity from
+		// R1 (the &map argument established by a preceding LoadMapPtr)
+		// into R0 — without this every `*(u64 *)(r0 + 0) += ...` after a
+		// bpf_map_lookup_elem looks "dynamic" to the analyzer and trips
+		// a false-positive RO violation on plugins that legitimately
+		// mutate their own RW maps.
+		if in.OpCode.JumpOp() == asm.Call {
+			fn := asm.BuiltinFunc(in.Constant)
+			r1Map := lastMap[1]
+			for r := 1; r <= 5; r++ {
+				lastMap[r] = ""
+			}
+			switch fn {
+			case asm.FnMapLookupElem, asm.FnMapLookupPercpuElem:
+				lastMap[0] = r1Map
+			default:
+				lastMap[0] = ""
+			}
+			continue
+		}
+		// Register-to-register MOV propagates the map identity from src
+		// to dst. clang frequently emits `Rn = R0` between a lookup and
+		// the subsequent store; without this propagation the dst is
+		// treated as dynamic and the write is flagged spuriously.
+		op := in.OpCode
+		if (op.Class() == asm.ALU64Class || op.Class() == asm.ALUClass) &&
+			op.ALUOp() == asm.Mov && op.Source() == asm.RegSource {
+			src := int(in.Src)
+			dst := int(in.Dst)
+			if dst >= 0 && dst < numRegs && src >= 0 && src < numRegs {
+				lastMap[dst] = lastMap[src]
+				continue
+			}
+		}
+		// Only load / ALU classes actually write Dst. Jump and Jump32
+		// reference Dst as the left-hand operand of a compare; clobbering
+		// lastMap[Dst] for those would erase the just-propagated lookup
+		// result on the canonical clang `if (r0 == 0) goto ...; *(r0 +
+		// 0) += rN` pattern emitted after every bpf_map_lookup_elem and
+		// resurface the very false-positive we are trying to kill.
+		cls := in.OpCode.Class()
+		if cls != asm.LdClass && cls != asm.LdXClass &&
+			cls != asm.ALUClass && cls != asm.ALU64Class {
+			continue
+		}
 		dst := int(in.Dst)
 		if dst < 0 || dst >= numRegs {
 			continue
 		}
 		if in.IsLoadFromMap() {
 			lastMap[dst] = in.Reference()
-		} else if in.Dst != 0 || in.OpCode != 0 { // any real instruction with Dst
+		} else {
 			lastMap[dst] = ""
 		}
 	}

--- a/pkg/bpf/plugin_validate.go
+++ b/pkg/bpf/plugin_validate.go
@@ -326,6 +326,25 @@ func isStackStore(ins asm.Instruction) bool {
 	return ins.Dst == asm.RFP
 }
 
+// knownSubprogNames returns the set of subprogram names actually invoked
+// from somewhere in ins via a BPF2BPF call. Cilium's ELF loader places
+// per-symbol metadata on instructions wherever an ELF STT_FUNC sits,
+// including symbols a malicious author injects mid-main. Trusting
+// in.Symbol() == "" as the only "still in main" signal lets such a forged
+// symbol terminate the scan early while the kernel verifier — which
+// resolves subprogram boundaries from BPF2BPF call instructions, not
+// symbol metadata — happily executes the writes that follow. Restricting
+// the break trigger to names that something actually calls keeps the
+// kernel and validator on the same view of what counts as a subprogram.
+func knownSubprogNames(ins asm.Instructions) map[string]struct{} {
+	names := ins.FunctionReferences()
+	out := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		out[n] = struct{}{}
+	}
+	return out
+}
+
 // roViolation describes one disallowed map write detected during static
 // analysis. Aggregated across the program so a single error message can
 // list every offender; mapName == "" means the store target could not be
@@ -358,10 +377,17 @@ func checkROWrites(spec *ebpf.ProgramSpec, roMaps map[string]struct{}) error {
 	var lastMap [numRegs]string
 	var violations []roViolation
 	ins := spec.Instructions
+	subprogs := knownSubprogNames(ins)
 	for i, in := range ins {
-		// Stop at the start of any subprogram past the entry point.
-		if i > 0 && in.Symbol() != "" {
-			break
+		// Stop at the start of a real subprogram (one something actually
+		// calls). A bare Symbol() with no caller is metadata noise — or
+		// an injected fake — and must not terminate the scan.
+		if i > 0 {
+			if sym := in.Symbol(); sym != "" {
+				if _, ok := subprogs[sym]; ok {
+					break
+				}
+			}
 		}
 		if isMapWrite(in) {
 			// Stack stores (Dst == R10) are local-variable assignments,
@@ -483,11 +509,17 @@ func checkROWrites(spec *ebpf.ProgramSpec, roMaps map[string]struct{}) error {
 // model does not warrant.
 func checkExitProximity(spec *ebpf.ProgramSpec) error {
 	ins := spec.Instructions
+	subprogs := knownSubprogNames(ins)
 	for i, in := range ins {
-		// Stop at the start of any subprogram past the entry point;
-		// subprogram bodies are appended after the main program.
-		if i > 0 && in.Symbol() != "" {
-			break
+		// See knownSubprogNames: only Symbol()s that match a called
+		// subprogram terminate the scan. A forged symbol mid-main must
+		// not let an exit-without-epilogue slip through.
+		if i > 0 {
+			if sym := in.Symbol(); sym != "" {
+				if _, ok := subprogs[sym]; ok {
+					break
+				}
+			}
 		}
 		if in.OpCode.JumpOp() != asm.Exit {
 			continue

--- a/pkg/bpf/plugin_validate.go
+++ b/pkg/bpf/plugin_validate.go
@@ -290,14 +290,30 @@ func findTailCallMapName(prev asm.Instructions) string {
 	return findStaticMapPtrSource(prev, asm.R2)
 }
 
+// loadAcqAtomicOp is the AtomicOp value encoded by BPF_LOAD_ACQ. cilium's
+// loadAcquire constant is package-private, so we reconstruct it once from
+// the LoadAcquire constructor and compare in the hot path.
+var loadAcqAtomicOp = asm.LoadAcquire(asm.R0, asm.R0, asm.DWord, 0).OpCode.AtomicOp()
+
 // isMapWrite reports whether ins writes to memory through a register-based
-// destination. We treat both classic stores (BPF_ST/BPF_STX, regardless of
-// MemMode vs immediate) and atomic RMW operations (BPF_STX | AtomicMode,
-// which covers BPF_ATOMIC and the legacy BPF_XADD) as writes; LDX (read)
-// is intentionally excluded.
+// destination. Classic stores (BPF_ST/BPF_STX MemMode) and atomic RMW ops
+// (BPF_STX | AtomicMode — Add/And/Or/Xor, the Fetch* variants, Xchg,
+// CmpXchg, StoreRelease) are writes; BPF_LOAD_ACQ also encodes as
+// StXClass | AtomicMode but is a load with acquire semantics, so it must
+// not be flagged. Plain BPF_LDX (read) is excluded by class.
 func isMapWrite(ins asm.Instruction) bool {
 	cls := ins.OpCode.Class()
-	return cls == asm.StClass || cls == asm.StXClass
+	switch cls {
+	case asm.StClass:
+		return true
+	case asm.StXClass:
+		if ins.OpCode.Mode() == asm.AtomicMode &&
+			ins.OpCode.AtomicOp() == loadAcqAtomicOp {
+			return false
+		}
+		return true
+	}
+	return false
 }
 
 // isStackStore reports whether the store targets the BPF stack frame

--- a/pkg/bpf/plugin_validate.go
+++ b/pkg/bpf/plugin_validate.go
@@ -107,7 +107,7 @@ const ExitProximityWindow = 64
 //     plugins built with VINBERO_PLUGIN always pass because the macro
 //     produces a single exit; hand-written plugins must keep each return
 //     close to an epilogue or tail-call.
-//  6. Stores into vinbero shared read-only maps are rejected (Phase 2
+//  6. Stores into vinbero shared read-only maps are rejected (the
 //     RO-enforce). roMaps == nil disables the check; production callers
 //     pass SharedReadOnlyMapNamesSet().
 func ValidatePluginProgram(spec *ebpf.ProgramSpec, roMaps map[string]struct{}) error {
@@ -260,25 +260,34 @@ func isBpfTailCall(ins asm.Instruction) bool {
 	return ins.IsBuiltinCall() && ins.Constant == int64(asm.FnTailCall)
 }
 
-// findTailCallMapName walks backwards to find the most recent instruction
-// that wrote R2 (the map argument of bpf_tail_call). Returns the map name
-// when R2 was set by a static LoadMapPtr; "" otherwise.
+// findStaticMapPtrSource walks back to the most recent instruction that
+// wrote dstReg and returns the map name when that origin is a static
+// LoadMapPtr. Anything else (BPF_CALL return value, register copy from
+// another register, stack reload) yields "" so the caller can reject
+// the access conservatively.
 //
-// Assumes clang's canonical `LoadMapPtr R2, <map>; ...; bpf_tail_call`
-// emission pattern. Inline assembly or hand-edited BPF that derives R2
-// from a non-map-pointer source is reported as "(dynamic)" and rejected.
-func findTailCallMapName(prev asm.Instructions) string {
+// Assumes clang's canonical `LoadMapPtr Rx, &m; ...; <use Rx>` emission
+// pattern. Optimised paths that move the map pointer through the stack
+// or another register fall through to the conservative empty result.
+func findStaticMapPtrSource(prev asm.Instructions, dstReg asm.Register) string {
 	for i := len(prev) - 1; i >= 0; i-- {
 		ins := prev[i]
-		if ins.Dst != asm.R2 {
+		if ins.Dst != dstReg {
 			continue
 		}
 		if ins.IsLoadFromMap() {
 			return ins.Reference()
 		}
-		return ""
+		return "" // overwritten by something we can't trace statically
 	}
 	return ""
+}
+
+// findTailCallMapName resolves the map argument (R2) of a bpf_tail_call.
+// Thin specialization of findStaticMapPtrSource fixed to R2; "(dynamic)"
+// pointers are reported as "" and rejected upstream.
+func findTailCallMapName(prev asm.Instructions) string {
+	return findStaticMapPtrSource(prev, asm.R2)
 }
 
 // isMapWrite reports whether ins writes to memory through a register-based
@@ -299,31 +308,6 @@ func isMapWrite(ins asm.Instruction) bool {
 // false-positives on every plugin that uses a stack-allocated key.
 func isStackStore(ins asm.Instruction) bool {
 	return ins.Dst == asm.RFP
-}
-
-// findStoreTargetMapName walks back to the most recent instruction that
-// wrote dstReg and returns the map name when that origin is a static
-// LoadMapPtr. Anything else (BPF_CALL return value, register copy from
-// another register, stack reload) yields "" so the caller can reject the
-// store conservatively.
-//
-// Mirrors findTailCallMapName but generalised over the destination
-// register: clang emits `LoadMapPtr Rx, &m; ...; *(Rx + off) = ...` for
-// the canonical "static map pointer + write" pattern. Optimised paths
-// that move the pointer through the stack or another register fall
-// through to the conservative reject.
-func findStoreTargetMapName(prev asm.Instructions, dstReg asm.Register) string {
-	for i := len(prev) - 1; i >= 0; i-- {
-		p := prev[i]
-		if p.Dst != dstReg {
-			continue
-		}
-		if p.IsLoadFromMap() {
-			return p.Reference()
-		}
-		return "" // overwritten by something we can't trace statically
-	}
-	return ""
 }
 
 // roViolation describes one disallowed map write detected during static
@@ -350,6 +334,12 @@ func checkROWrites(spec *ebpf.ProgramSpec, roMaps map[string]struct{}) error {
 	if len(roMaps) == 0 {
 		return nil
 	}
+	// One forward pass: track the most recent LoadMapPtr-sourced map name
+	// per destination register. Anything else that writes a register
+	// invalidates the entry. This avoids a quadratic reverse-scan per
+	// store on adversarial inputs.
+	const numRegs = 11 // R0..R10
+	var lastMap [numRegs]string
 	var violations []roViolation
 	ins := spec.Instructions
 	for i, in := range ins {
@@ -357,30 +347,39 @@ func checkROWrites(spec *ebpf.ProgramSpec, roMaps map[string]struct{}) error {
 		if i > 0 && in.Symbol() != "" {
 			break
 		}
-		if !isMapWrite(in) {
+		if isMapWrite(in) {
+			// Stack stores (Dst == R10) are local-variable assignments,
+			// not map writes — clang emits one for every `struct k key;`
+			// that later feeds bpf_map_lookup_elem.
+			if !isStackStore(in) {
+				dst := int(in.Dst)
+				var mapName string
+				if dst >= 0 && dst < numRegs {
+					mapName = lastMap[dst]
+				}
+				if mapName == "" {
+					violations = append(violations, roViolation{insIdx: i})
+				} else if _, ro := roMaps[mapName]; ro {
+					violations = append(violations, roViolation{insIdx: i, mapName: mapName})
+				}
+			}
+		}
+		// Update the map-pointer table for this instruction's Dst.
+		// LoadMapPtr writes a known map name; any other write to a
+		// register invalidates whatever was there. Stores (BPF_ST*) do
+		// not modify Dst (they write *through* it), so they leave the
+		// table alone.
+		if in.OpCode.Class() == asm.StClass || in.OpCode.Class() == asm.StXClass {
 			continue
 		}
-		// Stack stores (Dst == R10) are local-variable assignments, not
-		// map writes — clang emits one for every `struct k key;` that
-		// later feeds bpf_map_lookup_elem. Treating them as map writes
-		// would dynamic-reject every plugin that uses a stack-built key.
-		if isStackStore(in) {
+		dst := int(in.Dst)
+		if dst < 0 || dst >= numRegs {
 			continue
 		}
-		mapName := findStoreTargetMapName(ins[:i], in.Dst)
-		if mapName == "" {
-			// Conservative reject: clang typically emits a static
-			// LoadMapPtr right before the store, so a non-trace-able
-			// destination usually means lookup-return-value writes
-			// (e.g. *(map_lookup_elem(&m, &k)) = ...) which would
-			// still be writing into some map's values; rather than
-			// chase the lookup origin we ask the plugin author to
-			// route writes through an RW map.
-			violations = append(violations, roViolation{insIdx: i})
-			continue
-		}
-		if _, ro := roMaps[mapName]; ro {
-			violations = append(violations, roViolation{insIdx: i, mapName: mapName})
+		if in.IsLoadFromMap() {
+			lastMap[dst] = in.Reference()
+		} else if in.Dst != 0 || in.OpCode != 0 { // any real instruction with Dst
+			lastMap[dst] = ""
 		}
 	}
 	if len(violations) == 0 {
@@ -390,8 +389,9 @@ func checkROWrites(spec *ebpf.ProgramSpec, roMaps map[string]struct{}) error {
 	for _, v := range violations {
 		if v.mapName == "" {
 			details = append(details, fmt.Sprintf(
-				"instruction #%d: store target is a (dynamic) map pointer "+
-					"(LoadMapPtr-sourced register expected)", v.insIdx))
+				"instruction #%d: store target could not be resolved to a "+
+					"known map; route writes through scratch_map / stats_map "+
+					"or a plugin-owned map", v.insIdx))
 		} else {
 			details = append(details, fmt.Sprintf(
 				"instruction #%d: store into read-only map %q",

--- a/pkg/bpf/plugin_validate.go
+++ b/pkg/bpf/plugin_validate.go
@@ -11,9 +11,58 @@ import (
 	"github.com/cilium/ebpf/btf"
 )
 
+// ErrPluginROWrite is the sentinel returned (wrapped via fmt.Errorf("%w"))
+// by the validator when a plugin writes to a vinbero shared RO map or to
+// a map pointer that cannot be statically resolved. Callers (notably the
+// daemon's PluginRegister) use errors.Is to decide whether the staged
+// warn-only rollout applies; CLI shift-left always rejects.
+var ErrPluginROWrite = errors.New("plugin RO map write")
+
 // SymTailcallEpilogue is the BPF subprogram every plugin must call before
 // returning an XDP action so per-action stats are recorded.
 const SymTailcallEpilogue = "tailcall_epilogue"
+
+// ROEnforceMode selects how the asm-level RO-write violation is surfaced.
+// The validator itself always returns the violation as an error; the mode
+// is consumed by callers (typically PluginRegister) to decide whether to
+// reject the request or just log a warning. CLI shift-left uses the
+// returned error directly and ignores the mode.
+type ROEnforceMode int
+
+const (
+	// ROEnforceWarn is the default: the violation is logged but the
+	// register/load proceeds. Used during the staged rollout so existing
+	// plugins keep working while ops watches the warn audit log.
+	ROEnforceWarn ROEnforceMode = iota
+	// ROEnforceEnforce hard-rejects the register call. CLI's `plugin
+	// validate` is always effectively in this mode regardless of config.
+	ROEnforceEnforce
+)
+
+// String renders the mode as the same token accepted by ParseROEnforceMode
+// so logs and config dumps stay reversible.
+func (m ROEnforceMode) String() string {
+	switch m {
+	case ROEnforceEnforce:
+		return "enforce"
+	default:
+		return "warn"
+	}
+}
+
+// ParseROEnforceMode converts a config string into a mode. Empty / "warn"
+// map to warn-only; "enforce" maps to hard-reject. Anything else is a
+// config error so typos don't silently downgrade the policy.
+func ParseROEnforceMode(s string) (ROEnforceMode, error) {
+	switch s {
+	case "", "warn":
+		return ROEnforceWarn, nil
+	case "enforce":
+		return ROEnforceEnforce, nil
+	default:
+		return 0, fmt.Errorf("invalid ro_enforce: %q (expected 'warn' or 'enforce')", s)
+	}
+}
 
 // ValidTailCallMaps lists the vinbero-managed PROG_ARRAYs a plugin is allowed
 // to bpf_tail_call into. Dispatching back to a vinbero PROG_ARRAY is how a
@@ -58,7 +107,10 @@ const ExitProximityWindow = 64
 //     plugins built with VINBERO_PLUGIN always pass because the macro
 //     produces a single exit; hand-written plugins must keep each return
 //     close to an epilogue or tail-call.
-func ValidatePluginProgram(spec *ebpf.ProgramSpec) error {
+//  6. Stores into vinbero shared read-only maps are rejected (Phase 2
+//     RO-enforce). roMaps == nil disables the check; production callers
+//     pass SharedReadOnlyMapNamesSet().
+func ValidatePluginProgram(spec *ebpf.ProgramSpec, roMaps map[string]struct{}) error {
 	if spec == nil {
 		return fmt.Errorf("plugin ProgramSpec is nil")
 	}
@@ -129,13 +181,21 @@ func ValidatePluginProgram(spec *ebpf.ProgramSpec) error {
 		return err
 	}
 
+	if err := checkROWrites(spec, roMaps); err != nil {
+		return err
+	}
+
 	return nil
 }
 
 // ValidatePluginCollection locates the named program in spec, forces its
 // type to XDP, and enforces the plugin contract on it. Used by the server,
 // the CLI, and the SDK to keep the lookup/validation flow consistent.
-func ValidatePluginCollection(spec *ebpf.CollectionSpec, program string) (*ebpf.ProgramSpec, error) {
+//
+// roMaps == nil skips the asm-level RO-write check (back-compat for tests
+// that exercise the rest of the pipeline). Production callers must pass
+// SharedReadOnlyMapNamesSet().
+func ValidatePluginCollection(spec *ebpf.CollectionSpec, program string, roMaps map[string]struct{}) (*ebpf.ProgramSpec, error) {
 	if spec == nil {
 		return nil, fmt.Errorf("plugin CollectionSpec is nil")
 	}
@@ -148,7 +208,7 @@ func ValidatePluginCollection(spec *ebpf.CollectionSpec, program string) (*ebpf.
 		return nil, fmt.Errorf("program %q not found in ELF; available: %v", program, names)
 	}
 	target.Type = ebpf.XDP
-	if err := ValidatePluginProgram(target); err != nil {
+	if err := ValidatePluginProgram(target, roMaps); err != nil {
 		return nil, err
 	}
 	if err := validatePluginMapTypes(spec); err != nil {
@@ -219,6 +279,131 @@ func findTailCallMapName(prev asm.Instructions) string {
 		return ""
 	}
 	return ""
+}
+
+// isMapWrite reports whether ins writes to memory through a register-based
+// destination. We treat both classic stores (BPF_ST/BPF_STX, regardless of
+// MemMode vs immediate) and atomic RMW operations (BPF_STX | AtomicMode,
+// which covers BPF_ATOMIC and the legacy BPF_XADD) as writes; LDX (read)
+// is intentionally excluded.
+func isMapWrite(ins asm.Instruction) bool {
+	cls := ins.OpCode.Class()
+	return cls == asm.StClass || cls == asm.StXClass
+}
+
+// isStackStore reports whether the store targets the BPF stack frame
+// (R10 / RFP). R10 is the read-only frame pointer; clang lowers C local
+// variables (including the `struct foo key;` pattern feeding
+// bpf_map_lookup_elem) to *(R10 + off) = ... stores. These are not map
+// writes and must be excluded from the RO-write enforcer to avoid
+// false-positives on every plugin that uses a stack-allocated key.
+func isStackStore(ins asm.Instruction) bool {
+	return ins.Dst == asm.RFP
+}
+
+// findStoreTargetMapName walks back to the most recent instruction that
+// wrote dstReg and returns the map name when that origin is a static
+// LoadMapPtr. Anything else (BPF_CALL return value, register copy from
+// another register, stack reload) yields "" so the caller can reject the
+// store conservatively.
+//
+// Mirrors findTailCallMapName but generalised over the destination
+// register: clang emits `LoadMapPtr Rx, &m; ...; *(Rx + off) = ...` for
+// the canonical "static map pointer + write" pattern. Optimised paths
+// that move the pointer through the stack or another register fall
+// through to the conservative reject.
+func findStoreTargetMapName(prev asm.Instructions, dstReg asm.Register) string {
+	for i := len(prev) - 1; i >= 0; i-- {
+		p := prev[i]
+		if p.Dst != dstReg {
+			continue
+		}
+		if p.IsLoadFromMap() {
+			return p.Reference()
+		}
+		return "" // overwritten by something we can't trace statically
+	}
+	return ""
+}
+
+// roViolation describes one disallowed map write detected during static
+// analysis. Aggregated across the program so a single error message can
+// list every offender; mapName == "" means the store target could not be
+// resolved to a static map reference.
+type roViolation struct {
+	insIdx  int
+	mapName string
+}
+
+// checkROWrites scans the main program (subprograms excluded) for stores
+// whose target is a vinbero shared RO map, or whose target cannot be
+// statically resolved. The check is a no-op when roMaps is empty, for
+// back-compat with callers that don't yet supply the set (notably tests).
+//
+// Subprogram exclusion mirrors checkExitProximity. Plugin ELFs that pull
+// in tailcall_epilogue end up with the epilogue body appended after the
+// main program; that body legitimately writes to slot_stats_* (currently
+// RW, but we don't want to lock out the epilogue if/when it migrates to
+// RO), so scanning past the first sub-program would risk false positives
+// on every plugin.
+func checkROWrites(spec *ebpf.ProgramSpec, roMaps map[string]struct{}) error {
+	if len(roMaps) == 0 {
+		return nil
+	}
+	var violations []roViolation
+	ins := spec.Instructions
+	for i, in := range ins {
+		// Stop at the start of any subprogram past the entry point.
+		if i > 0 && in.Symbol() != "" {
+			break
+		}
+		if !isMapWrite(in) {
+			continue
+		}
+		// Stack stores (Dst == R10) are local-variable assignments, not
+		// map writes — clang emits one for every `struct k key;` that
+		// later feeds bpf_map_lookup_elem. Treating them as map writes
+		// would dynamic-reject every plugin that uses a stack-built key.
+		if isStackStore(in) {
+			continue
+		}
+		mapName := findStoreTargetMapName(ins[:i], in.Dst)
+		if mapName == "" {
+			// Conservative reject: clang typically emits a static
+			// LoadMapPtr right before the store, so a non-trace-able
+			// destination usually means lookup-return-value writes
+			// (e.g. *(map_lookup_elem(&m, &k)) = ...) which would
+			// still be writing into some map's values; rather than
+			// chase the lookup origin we ask the plugin author to
+			// route writes through an RW map.
+			violations = append(violations, roViolation{insIdx: i})
+			continue
+		}
+		if _, ro := roMaps[mapName]; ro {
+			violations = append(violations, roViolation{insIdx: i, mapName: mapName})
+		}
+	}
+	if len(violations) == 0 {
+		return nil
+	}
+	details := make([]string, 0, len(violations))
+	for _, v := range violations {
+		if v.mapName == "" {
+			details = append(details, fmt.Sprintf(
+				"instruction #%d: store target is a (dynamic) map pointer "+
+					"(LoadMapPtr-sourced register expected)", v.insIdx))
+		} else {
+			details = append(details, fmt.Sprintf(
+				"instruction #%d: store into read-only map %q",
+				v.insIdx, v.mapName))
+		}
+	}
+	return fmt.Errorf(
+		"%w: plugin program %q has %d disallowed map write(s); shared RO "+
+			"maps are read-only from plugins (use scratch_map / stats_map "+
+			"or plugin-owned maps for state). Violations:\n  - %s",
+		ErrPluginROWrite, spec.Name, len(violations), strings.Join(details, "\n  - "),
+	)
 }
 
 // checkExitProximity verifies every exit instruction in the main program

--- a/pkg/bpf/plugin_validate_test.go
+++ b/pkg/bpf/plugin_validate_test.go
@@ -3,6 +3,7 @@ package bpf
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"strings"
 	"testing"
 
@@ -66,7 +67,7 @@ func TestValidatePluginProgram_Valid(t *testing.T) {
 		callToSymbol(SymTailcallEpilogue),
 		asm.Return(),
 	}
-	if err := ValidatePluginProgram(buildSpec("p", ebpf.XDP, ins)); err != nil {
+	if err := ValidatePluginProgram(buildSpec("p", ebpf.XDP, ins), nil); err != nil {
 		t.Fatalf("expected valid spec to pass, got: %v", err)
 	}
 }
@@ -76,7 +77,7 @@ func TestValidatePluginProgram_MissingEpilogueAndTailCall(t *testing.T) {
 		asm.Mov.Imm(asm.R0, 2),
 		asm.Return(),
 	}
-	err := ValidatePluginProgram(buildSpec("p", ebpf.XDP, ins))
+	err := ValidatePluginProgram(buildSpec("p", ebpf.XDP, ins), nil)
 	if err == nil {
 		t.Fatal("expected error when neither epilogue nor tail call present")
 	}
@@ -91,14 +92,14 @@ func TestValidatePluginProgram_WrongProgType(t *testing.T) {
 		callToSymbol(SymTailcallEpilogue),
 		asm.Return(),
 	}
-	err := ValidatePluginProgram(buildSpec("tc", ebpf.SchedCLS, ins))
+	err := ValidatePluginProgram(buildSpec("tc", ebpf.SchedCLS, ins), nil)
 	if err == nil || !strings.Contains(err.Error(), "xdp") {
 		t.Fatalf("expected 'xdp' in error, got: %v", err)
 	}
 }
 
 func TestValidatePluginProgram_NilSpec(t *testing.T) {
-	if err := ValidatePluginProgram(nil); err == nil {
+	if err := ValidatePluginProgram(nil, nil); err == nil {
 		t.Fatal("expected error for nil spec")
 	}
 }
@@ -109,7 +110,7 @@ func TestValidatePluginProgram_CallsOtherSymbol(t *testing.T) {
 		callToSymbol("some_helper"),
 		asm.Return(),
 	}
-	if err := ValidatePluginProgram(buildSpec("p", ebpf.XDP, ins)); err == nil {
+	if err := ValidatePluginProgram(buildSpec("p", ebpf.XDP, ins), nil); err == nil {
 		t.Fatal("expected error when tailcall_epilogue absent even with other calls")
 	}
 }
@@ -118,7 +119,7 @@ func TestValidatePluginProgram_CallsOtherSymbol(t *testing.T) {
 func TestValidatePluginProgram_ValidTailCallOnly(t *testing.T) {
 	ins := append(asm.Instructions{}, tailCallTo("sid_endpoint_progs", 33)...)
 	ins = append(ins, asm.Mov.Imm(asm.R0, 2), asm.Return())
-	if err := ValidatePluginProgram(buildSpec("dispatch", ebpf.XDP, ins)); err != nil {
+	if err := ValidatePluginProgram(buildSpec("dispatch", ebpf.XDP, ins), nil); err != nil {
 		t.Fatalf("expected tail-call-only plugin to pass, got: %v", err)
 	}
 }
@@ -126,7 +127,7 @@ func TestValidatePluginProgram_ValidTailCallOnly(t *testing.T) {
 func TestValidatePluginProgram_ValidTailCallHeadendV4(t *testing.T) {
 	ins := append(asm.Instructions{}, tailCallTo("headend_v4_progs", 20)...)
 	ins = append(ins, asm.Mov.Imm(asm.R0, 2), asm.Return())
-	if err := ValidatePluginProgram(buildSpec("dispatch", ebpf.XDP, ins)); err != nil {
+	if err := ValidatePluginProgram(buildSpec("dispatch", ebpf.XDP, ins), nil); err != nil {
 		t.Fatalf("expected tail-call into headend_v4_progs to pass, got: %v", err)
 	}
 }
@@ -135,7 +136,7 @@ func TestValidatePluginProgram_ValidTailCallHeadendV4(t *testing.T) {
 func TestValidatePluginProgram_BothEpilogueAndTailCall(t *testing.T) {
 	ins := append(asm.Instructions{}, tailCallTo("sid_endpoint_progs", 40)...)
 	ins = append(ins, callToSymbol(SymTailcallEpilogue), asm.Return())
-	if err := ValidatePluginProgram(buildSpec("mixed", ebpf.XDP, ins)); err != nil {
+	if err := ValidatePluginProgram(buildSpec("mixed", ebpf.XDP, ins), nil); err != nil {
 		t.Fatalf("expected leaf+dispatch plugin to pass, got: %v", err)
 	}
 }
@@ -144,7 +145,7 @@ func TestValidatePluginProgram_BothEpilogueAndTailCall(t *testing.T) {
 func TestValidatePluginProgram_ForeignTailCall(t *testing.T) {
 	ins := append(asm.Instructions{}, tailCallTo("my_private_progs", 0)...)
 	ins = append(ins, callToSymbol(SymTailcallEpilogue), asm.Return())
-	err := ValidatePluginProgram(buildSpec("escape", ebpf.XDP, ins))
+	err := ValidatePluginProgram(buildSpec("escape", ebpf.XDP, ins), nil)
 	if err == nil {
 		t.Fatal("expected error for tail-call into unauthorized map")
 	}
@@ -163,7 +164,7 @@ func TestValidatePluginProgram_DynamicTailCall(t *testing.T) {
 		callToSymbol(SymTailcallEpilogue),
 		asm.Return(),
 	}
-	err := ValidatePluginProgram(buildSpec("dyn", ebpf.XDP, ins))
+	err := ValidatePluginProgram(buildSpec("dyn", ebpf.XDP, ins), nil)
 	if err == nil {
 		t.Fatal("expected error for dynamic (non-static-map) tail call")
 	}
@@ -181,7 +182,7 @@ func TestValidatePluginProgram_ForbiddenHelper_RedirectMap(t *testing.T) {
 		callToSymbol(SymTailcallEpilogue),
 		asm.Return(),
 	}
-	err := ValidatePluginProgram(buildSpec("p", ebpf.XDP, ins))
+	err := ValidatePluginProgram(buildSpec("p", ebpf.XDP, ins), nil)
 	if err == nil {
 		t.Fatal("expected error for bpf_redirect_map call")
 	}
@@ -205,7 +206,7 @@ func TestValidatePluginProgram_KfuncCall_Allowed(t *testing.T) {
 		callToSymbol(SymTailcallEpilogue),
 		asm.Return(),
 	}
-	if err := ValidatePluginProgram(buildSpec("p", ebpf.XDP, ins)); err != nil {
+	if err := ValidatePluginProgram(buildSpec("p", ebpf.XDP, ins), nil); err != nil {
 		t.Fatalf("expected kfunc call to pass validation, got: %v", err)
 	}
 }
@@ -227,7 +228,7 @@ func TestValidatePluginProgram_ExitWithoutEpilogueNearby(t *testing.T) {
 		callToSymbol(SymTailcallEpilogue),
 		asm.Return(),
 	)
-	err := ValidatePluginProgram(buildSpec("p", ebpf.XDP, ins))
+	err := ValidatePluginProgram(buildSpec("p", ebpf.XDP, ins), nil)
 	if err == nil {
 		t.Fatal("expected error for exit with no epilogue in proximity")
 	}
@@ -257,7 +258,7 @@ func TestValidatePluginCollection_BTF_MapValueTypeMismatch(t *testing.T) {
 			},
 		},
 	}
-	if _, err := ValidatePluginCollection(spec, "xdp_entry"); err == nil {
+	if _, err := ValidatePluginCollection(spec, "xdp_entry", nil); err == nil {
 		t.Fatal("expected BTF type mismatch to be rejected")
 	} else if !strings.Contains(err.Error(), "sid_function_entry") {
 		t.Errorf("error should name the expected type, got: %v", err)
@@ -338,6 +339,207 @@ func TestValidatePluginAuxType_AnchorMissing(t *testing.T) {
 	}
 }
 
+// roSet is the canonical Phase 2 RO set used across the asm-level write
+// tests. Keeping the helper close to the tests makes intent obvious — a
+// real-world miswire would be a no-op for the dispatch tests above
+// (which pass nil) but invalidate the tests below (which need a non-nil
+// set to exercise checkROWrites).
+func roSet() map[string]struct{} {
+	return SharedReadOnlyMapNamesSet()
+}
+
+// roSpec wraps a sequence of instructions in the minimal "valid plugin"
+// shell (epilogue call + return) so individual write tests don't have to
+// duplicate boilerplate. The caller provides the lead-in instructions
+// that exercise the RO-write detection.
+func roSpec(name string, lead asm.Instructions) *ebpf.ProgramSpec {
+	ins := append(asm.Instructions{}, lead...)
+	ins = append(ins, callToSymbol(SymTailcallEpilogue), asm.Return())
+	return buildSpec(name, ebpf.XDP, ins)
+}
+
+// Direct store into a vinbero-managed read-only map must reject. Mirrors
+// the canonical clang sequence `LoadMapPtr Rx, &m; *(Rx + off) = imm`.
+func TestValidatePluginROWrites_DirectROWrite(t *testing.T) {
+	lead := asm.Instructions{
+		asm.LoadMapPtr(asm.R1, 0).WithReference("sid_function_map"),
+		asm.StoreImm(asm.R1, 0, 99, asm.Word),
+	}
+	err := ValidatePluginProgram(roSpec("evil", lead), roSet())
+	if err == nil {
+		t.Fatal("expected RO write to be rejected")
+	}
+	if !errors.Is(err, ErrPluginROWrite) {
+		t.Errorf("expected ErrPluginROWrite, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "sid_function_map") {
+		t.Errorf("error should name the RO map, got: %v", err)
+	}
+}
+
+// Atomic RMW (BPF_ATOMIC family, e.g. __sync_fetch_and_add) into an RO
+// map must also reject — atomic encodes as StXClass with AtomicMode and
+// is a write as far as the kernel verifier is concerned.
+func TestValidatePluginROWrites_DirectROAtomic(t *testing.T) {
+	lead := asm.Instructions{
+		asm.LoadMapPtr(asm.R1, 0).WithReference("sid_function_map"),
+		asm.Mov.Imm(asm.R2, 1),
+		asm.FetchAdd.Mem(asm.R1, asm.R2, asm.DWord, 0),
+	}
+	err := ValidatePluginProgram(roSpec("evil_atomic", lead), roSet())
+	if err == nil {
+		t.Fatal("expected atomic RO write to be rejected")
+	}
+	if !errors.Is(err, ErrPluginROWrite) {
+		t.Errorf("expected ErrPluginROWrite, got: %v", err)
+	}
+}
+
+// Writes targeting an RW map (scratch_map / stats_map) are the supported
+// way for plugins to keep mutable state and must pass.
+func TestValidatePluginROWrites_RWAllowed(t *testing.T) {
+	lead := asm.Instructions{
+		asm.LoadMapPtr(asm.R1, 0).WithReference("scratch_map"),
+		asm.StoreImm(asm.R1, 0, 7, asm.Word),
+	}
+	if err := ValidatePluginProgram(roSpec("ok", lead), roSet()); err != nil {
+		t.Fatalf("write into scratch_map (RW) should pass, got: %v", err)
+	}
+}
+
+// A store whose destination register cannot be traced back to a static
+// LoadMapPtr must reject conservatively — typical case is writing
+// through a map_lookup_elem return value (R0 after a BPF_CALL).
+func TestValidatePluginROWrites_DynamicReject(t *testing.T) {
+	// Sequence simulates: `R1 = bpf_map_lookup_elem(...); *(R1 + 0) = 1;`
+	// The R1 source is the helper return (R0 → R1 mov), not a LoadMapPtr,
+	// so findStoreTargetMapName returns "" and the violation is reported
+	// as "(dynamic)".
+	lead := asm.Instructions{
+		asm.FnMapLookupElem.Call(),    // R0 = lookup result
+		asm.Mov.Reg(asm.R1, asm.R0),   // hide the origin
+		asm.StoreImm(asm.R1, 0, 1, asm.Word),
+	}
+	err := ValidatePluginProgram(roSpec("dyn", lead), roSet())
+	if err == nil {
+		t.Fatal("expected dynamic store target to be rejected")
+	}
+	if !errors.Is(err, ErrPluginROWrite) {
+		t.Errorf("expected ErrPluginROWrite, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "(dynamic)") {
+		t.Errorf("error should mention (dynamic), got: %v", err)
+	}
+}
+
+// Subprogram body sitting after the main program (clang appends them
+// after the entry point) must NOT be scanned. Otherwise legitimate
+// epilogue writes to slot_stats_* would trip the check the moment we
+// re-classify those maps as RO.
+func TestValidatePluginROWrites_SubprogramSkipped(t *testing.T) {
+	main := asm.Instructions{
+		asm.Mov.Imm(asm.R0, 2),
+		callToSymbol(SymTailcallEpilogue),
+		asm.Return(),
+	}
+	// Subprogram boundary: an instruction with a non-empty Symbol().
+	// We simulate `slot_stats_endpoint` (currently RW, classified as
+	// such; for the purposes of the test we treat it as RO via the set
+	// override below) being written from inside the subprogram.
+	subStart := asm.LoadMapPtr(asm.R1, 0).
+		WithReference("slot_stats_endpoint").
+		WithSymbol("subprogram_body")
+	sub := asm.Instructions{
+		subStart,
+		asm.StoreImm(asm.R1, 0, 1, asm.Word),
+		asm.Return(),
+	}
+	prog := buildSpec("with_sub", ebpf.XDP, append(main, sub...))
+
+	// Force "slot_stats_endpoint" into the RO set so the test can prove
+	// the scope guard wins even when the map name would otherwise match.
+	ro := map[string]struct{}{"slot_stats_endpoint": {}}
+	if err := ValidatePluginProgram(prog, ro); err != nil {
+		t.Fatalf("subprogram writes must be skipped, got: %v", err)
+	}
+}
+
+// A plugin-owned map (not in any vinbero shared set) is fine; the
+// validator only enforces the RO contract for vinbero-managed names.
+func TestValidatePluginROWrites_OwnedMapAllowed(t *testing.T) {
+	lead := asm.Instructions{
+		asm.LoadMapPtr(asm.R1, 0).WithReference("plugin_counter_map"),
+		asm.StoreImm(asm.R1, 0, 42, asm.Word),
+	}
+	if err := ValidatePluginProgram(roSpec("owned", lead), roSet()); err != nil {
+		t.Fatalf("plugin-owned map write should pass, got: %v", err)
+	}
+}
+
+// Stack writes (Dst == R10/RFP) are how clang lowers C local variables
+// such as `struct ipv6_key key;`. They must not be flagged as map
+// writes — otherwise every plugin that builds a lookup key on the
+// stack would be rejected as (dynamic). Regression test pinning the
+// fix that landed alongside the simple-acl example.
+func TestValidatePluginROWrites_StackStoreIgnored(t *testing.T) {
+	lead := asm.Instructions{
+		// `*(R10 - 8) = 0;` — clang's typical stack-zero before key
+		// construction. Should be silently ignored.
+		asm.StoreImm(asm.RFP, -8, 0, asm.DWord),
+		// And a register store to the stack as well, to cover both
+		// StClass (immediate) and StXClass (register) opcodes.
+		asm.Mov.Imm(asm.R1, 42),
+		asm.StoreMem(asm.RFP, -16, asm.R1, asm.Word),
+	}
+	if err := ValidatePluginProgram(roSpec("stack", lead), roSet()); err != nil {
+		t.Fatalf("stack stores must be ignored, got: %v", err)
+	}
+}
+
+// Back-compat path: when roMaps is nil the check is a no-op even if the
+// plugin clearly writes to an RO map. Tests and any internal callers
+// that don't supply the set must keep working.
+func TestValidatePluginROWrites_NilROSet(t *testing.T) {
+	lead := asm.Instructions{
+		asm.LoadMapPtr(asm.R1, 0).WithReference("sid_function_map"),
+		asm.StoreImm(asm.R1, 0, 99, asm.Word),
+	}
+	if err := ValidatePluginProgram(roSpec("legacy", lead), nil); err != nil {
+		t.Fatalf("nil roMaps must skip the RO check, got: %v", err)
+	}
+}
+
+// ParseROEnforceMode round-trip: empty / "warn" → ROEnforceWarn,
+// "enforce" → ROEnforceEnforce, anything else is an error so a typo in
+// vinbero.yaml can't silently downgrade the policy.
+func TestParseROEnforceMode(t *testing.T) {
+	cases := []struct {
+		in     string
+		want   ROEnforceMode
+		hasErr bool
+	}{
+		{"", ROEnforceWarn, false},
+		{"warn", ROEnforceWarn, false},
+		{"enforce", ROEnforceEnforce, false},
+		{"strict", 0, true},
+	}
+	for _, c := range cases {
+		got, err := ParseROEnforceMode(c.in)
+		if (err != nil) != c.hasErr {
+			t.Errorf("ParseROEnforceMode(%q) err=%v hasErr=%v", c.in, err, c.hasErr)
+			continue
+		}
+		if !c.hasErr && got != c.want {
+			t.Errorf("ParseROEnforceMode(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+	// Stringer round-trips so log output stays parseable.
+	if ROEnforceWarn.String() != "warn" || ROEnforceEnforce.String() != "enforce" {
+		t.Errorf("String() round-trip mismatch: warn=%q enforce=%q",
+			ROEnforceWarn.String(), ROEnforceEnforce.String())
+	}
+}
+
 // BTF absent (stripped ELF): validation falls back to asm-level checks and
 // must succeed if those pass.
 func TestValidatePluginCollection_BTF_MissingOK(t *testing.T) {
@@ -359,7 +561,7 @@ func TestValidatePluginCollection_BTF_MissingOK(t *testing.T) {
 			},
 		},
 	}
-	if _, err := ValidatePluginCollection(spec, "xdp_entry"); err != nil {
+	if _, err := ValidatePluginCollection(spec, "xdp_entry", nil); err != nil {
 		t.Fatalf("expected stripped-BTF plugin to pass, got: %v", err)
 	}
 }

--- a/pkg/bpf/plugin_validate_test.go
+++ b/pkg/bpf/plugin_validate_test.go
@@ -559,8 +559,14 @@ func TestValidatePluginROWrites_MovPropagatesRO(t *testing.T) {
 // epilogue writes to slot_stats_* would trip the check the moment we
 // re-classify those maps as RO.
 func TestValidatePluginROWrites_SubprogramSkipped(t *testing.T) {
+	// Real subprograms in compiled BPF show up in FunctionReferences()
+	// because something in main calls them. Without a matching call,
+	// the scanner now ignores the Symbol() boundary on purpose (see
+	// ForgedSymbolDoesNotBypass below). Plant a real call so this test
+	// keeps exercising the legitimate-subprogram path.
 	main := asm.Instructions{
 		asm.Mov.Imm(asm.R0, 2),
+		callToSymbol("subprogram_body"),
 		callToSymbol(SymTailcallEpilogue),
 		asm.Return(),
 	}
@@ -583,6 +589,34 @@ func TestValidatePluginROWrites_SubprogramSkipped(t *testing.T) {
 	ro := map[string]struct{}{"slot_stats_endpoint": {}}
 	if err := ValidatePluginProgram(prog, ro); err != nil {
 		t.Fatalf("subprogram writes must be skipped, got: %v", err)
+	}
+}
+
+// ForgedSymbolDoesNotBypass guards the validator against ELF symbol
+// tampering. A hand-edited STT_FUNC entry can plant a fake Symbol()
+// midway through main; cilium's loader propagates that metadata to the
+// instruction it lands on. Pre-fix, the scanner saw any non-empty
+// Symbol() past index 0 as a subprogram boundary and broke out — letting
+// the writes that followed run unscanned even though the kernel
+// verifier (which keys off BPF2BPF call instructions, not symbols)
+// happily executes them. Post-fix the boundary only triggers on names
+// that something actually calls, so the forged symbol is ignored and
+// the RO write is caught.
+func TestValidatePluginROWrites_ForgedSymbolDoesNotBypass(t *testing.T) {
+	lead := asm.Instructions{
+		asm.Mov.Imm(asm.R0, 0).WithSymbol("not_actually_called"),
+		asm.LoadMapPtr(asm.R1, 0).WithReference("sid_function_map"),
+		asm.StoreImm(asm.R1, 0, 99, asm.Word),
+	}
+	err := ValidatePluginProgram(roSpec("forged", lead), roSet())
+	if err == nil {
+		t.Fatal("RO write hiding behind a forged symbol must still be detected")
+	}
+	if !errors.Is(err, ErrPluginROWrite) {
+		t.Errorf("expected ErrPluginROWrite, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "sid_function_map") {
+		t.Errorf("error should name the RO map, got: %v", err)
 	}
 }
 

--- a/pkg/bpf/plugin_validate_test.go
+++ b/pkg/bpf/plugin_validate_test.go
@@ -451,6 +451,44 @@ func TestValidatePluginROWrites_LookupOwnedRW_Allowed(t *testing.T) {
 	}
 }
 
+// BPF_LOAD_ACQ encodes as StXClass | AtomicMode but is a read with
+// acquire semantics. The validator must not classify it as a write —
+// otherwise every plugin doing a load-acquire from a shared RO map
+// (e.g. atomically reading a config field that another updater
+// store-releases) gets rejected. clang 17+ emits this for
+// __atomic_load_n with __ATOMIC_ACQUIRE.
+func TestValidatePluginROWrites_LoadAcquireFromRO_Allowed(t *testing.T) {
+	lead := asm.Instructions{
+		asm.LoadMapPtr(asm.R1, 0).WithReference("sid_function_map"),
+		asm.LoadAcquire(asm.R2, asm.R1, asm.DWord, 0),
+	}
+	if err := ValidatePluginProgram(roSpec("ldacq", lead), roSet()); err != nil {
+		t.Fatalf("load-acquire on RO map is a read, must pass: %v", err)
+	}
+}
+
+// Symmetric to the above: BPF_STORE_REL *is* a write (release-store
+// semantics), so storing into an RO map via store-release must still
+// reject. This catches the easy mistake of widening the load-acquire
+// exception to all atomic ops.
+func TestValidatePluginROWrites_StoreReleaseToRO_Rejected(t *testing.T) {
+	lead := asm.Instructions{
+		asm.LoadMapPtr(asm.R1, 0).WithReference("sid_function_map"),
+		asm.Mov.Imm(asm.R2, 99),
+		asm.StoreRelease(asm.R1, asm.R2, asm.DWord, 0),
+	}
+	err := ValidatePluginProgram(roSpec("strel", lead), roSet())
+	if err == nil {
+		t.Fatal("store-release into RO map must reject")
+	}
+	if !errors.Is(err, ErrPluginROWrite) {
+		t.Errorf("expected ErrPluginROWrite, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "sid_function_map") {
+		t.Errorf("error should name the RO map, got: %v", err)
+	}
+}
+
 // Same lookup-then-write pattern but with the clang-canonical NULL
 // check (`if (r0 == 0) goto skip`) between the helper and the store.
 // JEq references R0 as the compare LHS but does not write it; the

--- a/pkg/bpf/plugin_validate_test.go
+++ b/pkg/bpf/plugin_validate_test.go
@@ -413,11 +413,11 @@ func TestValidatePluginROWrites_RWAllowed(t *testing.T) {
 func TestValidatePluginROWrites_DynamicReject(t *testing.T) {
 	// Sequence simulates: `R1 = bpf_map_lookup_elem(...); *(R1 + 0) = 1;`
 	// The R1 source is the helper return (R0 → R1 mov), not a LoadMapPtr,
-	// so findStoreTargetMapName returns "" and the violation is reported
-	// as "(dynamic)".
+	// so findStaticMapPtrSource returns "" and the violation falls into
+	// the "could not be resolved" branch.
 	lead := asm.Instructions{
-		asm.FnMapLookupElem.Call(),    // R0 = lookup result
-		asm.Mov.Reg(asm.R1, asm.R0),   // hide the origin
+		asm.FnMapLookupElem.Call(),  // R0 = lookup result
+		asm.Mov.Reg(asm.R1, asm.R0), // hide the origin
 		asm.StoreImm(asm.R1, 0, 1, asm.Word),
 	}
 	err := ValidatePluginProgram(roSpec("dyn", lead), roSet())
@@ -427,8 +427,8 @@ func TestValidatePluginROWrites_DynamicReject(t *testing.T) {
 	if !errors.Is(err, ErrPluginROWrite) {
 		t.Errorf("expected ErrPluginROWrite, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "(dynamic)") {
-		t.Errorf("error should mention (dynamic), got: %v", err)
+	if !strings.Contains(err.Error(), "could not be resolved") {
+		t.Errorf("error should describe the unresolved store, got: %v", err)
 	}
 }
 

--- a/pkg/bpf/plugin_validate_test.go
+++ b/pkg/bpf/plugin_validate_test.go
@@ -432,6 +432,90 @@ func TestValidatePluginROWrites_DynamicReject(t *testing.T) {
 	}
 }
 
+// `bpf_map_lookup_elem(&owned_rw, &key); lock *(u64 *)(r0 + 0) += rN`
+// is what clang emits for `__sync_fetch_and_add(counter, step)` against
+// a plugin-owned PERCPU_ARRAY. R0 is the helper return, so without the
+// lookup-aware propagation the analyzer sees a "dynamic" store target
+// and falsely flags every plugin-owned counter update. The fix tracks
+// LoadMapPtr → R1 → call FnMapLookupElem → R0 so the write resolves to
+// the plugin-owned map name and clears the RO contract.
+func TestValidatePluginROWrites_LookupOwnedRW_Allowed(t *testing.T) {
+	lead := asm.Instructions{
+		asm.LoadMapPtr(asm.R1, 0).WithReference("plugin_counter_map"),
+		asm.FnMapLookupElem.Call(),
+		asm.Mov.Imm(asm.R7, 1),
+		asm.FetchAdd.Mem(asm.R0, asm.R7, asm.DWord, 0),
+	}
+	if err := ValidatePluginProgram(roSpec("owned_atomic", lead), roSet()); err != nil {
+		t.Fatalf("atomic into looked-up plugin-owned RW map should pass, got: %v", err)
+	}
+}
+
+// Same lookup-then-write pattern but with the clang-canonical NULL
+// check (`if (r0 == 0) goto skip`) between the helper and the store.
+// JEq references R0 as the compare LHS but does not write it; the
+// validator must not invalidate lastMap[R0] on that read, otherwise
+// every plugin that follows the kernel-mandated NULL check (i.e. every
+// real plugin) trips a false positive.
+func TestValidatePluginROWrites_LookupThenNullCheck_Allowed(t *testing.T) {
+	lead := asm.Instructions{
+		asm.LoadMapPtr(asm.R1, 0).WithReference("plugin_counter_map"),
+		asm.FnMapLookupElem.Call(),
+		asm.Mov.Imm(asm.R7, 1),
+		asm.JEq.Imm(asm.R0, 0, "skip"), // NULL check; reads R0, must not clear lastMap[R0]
+		asm.FetchAdd.Mem(asm.R0, asm.R7, asm.DWord, 0),
+		asm.Mov.Imm(asm.R0, 0).WithSymbol("skip"),
+	}
+	if err := ValidatePluginProgram(roSpec("nullcheck", lead), roSet()); err != nil {
+		t.Fatalf("lookup → null check → atomic update should pass, got: %v", err)
+	}
+}
+
+// Symmetric to the case above but with an RO map: lookup-aware
+// propagation must not become a hole — a write through R0 (or any
+// reg-MOV-derived alias) into an RO map must still be flagged with the
+// proper map name, not as "unresolved".
+func TestValidatePluginROWrites_LookupROReject(t *testing.T) {
+	lead := asm.Instructions{
+		asm.LoadMapPtr(asm.R1, 0).WithReference("sid_function_map"),
+		asm.FnMapLookupElem.Call(),
+		asm.Mov.Reg(asm.R2, asm.R0), // alias R0 through R2
+		asm.StoreImm(asm.R2, 0, 1, asm.Word),
+	}
+	err := ValidatePluginProgram(roSpec("lookup_ro", lead), roSet())
+	if err == nil {
+		t.Fatal("write through lookup of RO map must reject")
+	}
+	if !errors.Is(err, ErrPluginROWrite) {
+		t.Errorf("expected ErrPluginROWrite, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "sid_function_map") {
+		t.Errorf("error should name the RO map, got: %v", err)
+	}
+}
+
+// Register-to-register MOV must propagate the tracked map identity so
+// `LoadMapPtr R1, &ro_map; R2 = R1; *(R2 + 0) = ...` is still caught.
+// Without this propagation an attacker could trivially launder the
+// origin through a single MOV.
+func TestValidatePluginROWrites_MovPropagatesRO(t *testing.T) {
+	lead := asm.Instructions{
+		asm.LoadMapPtr(asm.R1, 0).WithReference("sid_function_map"),
+		asm.Mov.Reg(asm.R2, asm.R1),
+		asm.StoreImm(asm.R2, 0, 99, asm.Word),
+	}
+	err := ValidatePluginProgram(roSpec("ro_via_mov", lead), roSet())
+	if err == nil {
+		t.Fatal("RO write laundered through MOV must still reject")
+	}
+	if !errors.Is(err, ErrPluginROWrite) {
+		t.Errorf("expected ErrPluginROWrite, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "sid_function_map") {
+		t.Errorf("error should name the RO map, got: %v", err)
+	}
+}
+
 // Subprogram body sitting after the main program (clang appends them
 // after the entry point) must NOT be scanned. Otherwise legitimate
 // epilogue writes to slot_stats_* would trip the check the moment we

--- a/pkg/cli/cmd_plugin.go
+++ b/pkg/cli/cmd_plugin.go
@@ -37,7 +37,12 @@ func pluginCommand() *cli.Command {
 					if err != nil {
 						return cli.Exit(fmt.Errorf("failed to parse BPF ELF %s: %w", elfPath, err), 2)
 					}
-					if _, err := bpf.ValidatePluginCollection(spec, programName); err != nil {
+					// CLI is the shift-left path: always enforce the RO-write
+					// check so plugin authors get the same answer they would get
+					// from the server with `validate.ro_enforce: enforce`. The
+					// daemon may still default to warn-only during the staged
+					// rollout (see config.ValidateConfig).
+					if _, err := bpf.ValidatePluginCollection(spec, programName, bpf.SharedReadOnlyMapNamesSet()); err != nil {
 						return cli.Exit(err, 1)
 					}
 					fmt.Printf("OK: %s (program=%s) passes plugin contract\n", elfPath, programName)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,6 +32,18 @@ type SettingConfig struct {
 	StatePath       string         `yaml:"state_path,omitempty"`                      // Path for resource state file (default: /var/lib/vinbero/state.json)
 	FdbAgingSeconds int            `yaml:"fdb_aging_seconds,omitempty" default:"300"` // FDB entry aging timeout (0=disabled)
 	PinMaps         PinMapsConfig  `yaml:"pin_maps,omitempty"`                        // Pin control-state BPF maps under /sys/fs/bpf so they survive a vinberod restart.
+	Validate        ValidateConfig `yaml:"validate,omitempty"`                        // Plugin validator policy knobs.
+}
+
+// ValidateConfig knobs the plugin validator enforces on the server side.
+// CLI `plugin validate` always runs in shift-left enforce regardless of
+// these values — they only adjust the behaviour of `PluginRegister`.
+type ValidateConfig struct {
+	// RoEnforce selects how plugin writes into vinbero shared read-only
+	// maps are handled at register time. "warn" (default during the Phase 2
+	// rollout) logs the violation but still loads the plugin; "enforce"
+	// hard-rejects the RPC. Empty string is treated as "warn".
+	RoEnforce string `yaml:"ro_enforce,omitempty" default:"warn"`
 }
 
 // PinMapsConfig toggles pinning for the daemon's control-state BPF maps

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,7 +40,7 @@ type SettingConfig struct {
 // these values — they only adjust the behaviour of `PluginRegister`.
 type ValidateConfig struct {
 	// RoEnforce selects how plugin writes into vinbero shared read-only
-	// maps are handled at register time. "warn" (default during the Phase 2
+	// maps are handled at register time. "warn" (default during initial
 	// rollout) logs the violation but still loads the plugin; "enforce"
 	// hard-rejects the RPC. Empty string is treated as "warn".
 	RoEnforce string `yaml:"ro_enforce,omitempty" default:"warn"`

--- a/pkg/server/plugin.go
+++ b/pkg/server/plugin.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -66,16 +67,18 @@ type PluginEntryInfo struct {
 type PluginServer struct {
 	mapOps       *bpf.MapOperations
 	bpfConstants map[string]any
+	roEnforce    bpf.ROEnforceMode
 	logger       *zap.Logger
 
 	mu       sync.RWMutex
 	registry map[pluginSlotKey]*pluginEntry
 }
 
-func NewPluginServer(mapOps *bpf.MapOperations, bpfConstants map[string]any, logger *zap.Logger) *PluginServer {
+func NewPluginServer(mapOps *bpf.MapOperations, bpfConstants map[string]any, roEnforce bpf.ROEnforceMode, logger *zap.Logger) *PluginServer {
 	return &PluginServer{
 		mapOps:       mapOps,
 		bpfConstants: bpfConstants,
+		roEnforce:    roEnforce,
 		logger:       logger,
 		registry:     make(map[pluginSlotKey]*pluginEntry),
 	}
@@ -171,8 +174,26 @@ func (s *PluginServer) PluginRegister(
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("failed to parse BPF ELF: %w", err))
 	}
 
-	if _, err := bpf.ValidatePluginCollection(spec, msg.Program); err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	// The shared-RO set is rebuilt per call so a future runtime
+	// reconfiguration can change it without rebooting; the helper is
+	// O(1) per name so the cost is in the noise compared to ELF parsing.
+	roSet := bpf.SharedReadOnlyMapNamesSet()
+	if _, err := bpf.ValidatePluginCollection(spec, msg.Program, roSet); err != nil {
+		// Phase 2 staged rollout: in warn mode we keep loading the
+		// plugin but surface every detected violation to the audit log
+		// so ops can see who would be rejected once we flip to enforce.
+		// Other validator failures (forbidden helper, missing epilogue,
+		// BTF mismatch, ...) are not warn-eligible and always reject.
+		if s.roEnforce == bpf.ROEnforceWarn && errors.Is(err, bpf.ErrPluginROWrite) {
+			s.logger.Warn("plugin RO write violation (warn-only)",
+				zap.String("program", msg.Program),
+				zap.String("map_type", msg.MapType),
+				zap.Uint32("slot", msg.Index),
+				zap.Error(err),
+			)
+		} else {
+			return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		}
 	}
 
 	// The plugin ELF ships its own copy of shared `const volatile` vars

--- a/pkg/server/plugin.go
+++ b/pkg/server/plugin.go
@@ -179,11 +179,11 @@ func (s *PluginServer) PluginRegister(
 	// O(1) per name so the cost is in the noise compared to ELF parsing.
 	roSet := bpf.SharedReadOnlyMapNamesSet()
 	if _, err := bpf.ValidatePluginCollection(spec, msg.Program, roSet); err != nil {
-		// Phase 2 staged rollout: in warn mode we keep loading the
-		// plugin but surface every detected violation to the audit log
-		// so ops can see who would be rejected once we flip to enforce.
-		// Other validator failures (forbidden helper, missing epilogue,
-		// BTF mismatch, ...) are not warn-eligible and always reject.
+		// In warn mode we keep loading the plugin but surface every
+		// detected violation to the audit log so ops can see who would
+		// be rejected once enforce is flipped on. Other validator
+		// failures (forbidden helper, missing epilogue, BTF mismatch,
+		// ...) are not warn-eligible and always reject.
 		if s.roEnforce == bpf.ROEnforceWarn && errors.Is(err, bpf.ErrPluginROWrite) {
 			s.logger.Warn("plugin RO write violation (warn-only)",
 				zap.String("program", msg.Program),

--- a/pkg/server/plugin_aux.go
+++ b/pkg/server/plugin_aux.go
@@ -13,14 +13,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// validatePluginSlot is a thin server-side alias for bpf.ValidatePluginSlot;
-// kept under this name because every PluginAux RPC handler reads cleaner with
-// the unprefixed call site, and to make any future server-only relaxation
-// (e.g. allowing reserved slots in a debug mode) a one-liner.
-func validatePluginSlot(mapType string, slot uint32) error {
-	return bpf.ValidatePluginSlot(mapType, slot)
-}
-
 // encodePluginAuxPayload normalizes a PluginAux payload to its on-wire byte
 // form. Exactly one of rawIn / jsonIn must be non-empty; json is encoded via
 // the plugin's BTF-declared <program>_aux struct.
@@ -56,7 +48,7 @@ func (s *PluginServer) encodePluginAuxPayload(mapType string, slot uint32, rawIn
 // index, then returns the owner tag used by every PluginAux op on that slot.
 // requireIdx=false is used by Alloc where no index exists yet.
 func ownerFor(mapType string, slot, idx uint32, requireIdx bool) (string, error) {
-	if err := validatePluginSlot(mapType, slot); err != nil {
+	if err := bpf.ValidatePluginSlot(mapType, slot); err != nil {
 		return "", err
 	}
 	if requireIdx && idx == 0 {

--- a/pkg/server/plugin_aux_test.go
+++ b/pkg/server/plugin_aux_test.go
@@ -33,7 +33,7 @@ func TestValidatePluginSlot(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			err := validatePluginSlot(c.mapType, c.slot)
+			err := bpf.ValidatePluginSlot(c.mapType, c.slot)
 			if c.wantErr && err == nil {
 				t.Errorf("expected error, got nil")
 			}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -44,7 +44,23 @@ func (s *Server) Setup() {
 	// Plugin service is constructed first so SidFunctionServer can resolve
 	// per-slot aux BTF types when callers use plugin_aux_json. The actual
 	// handler registration happens further down with the other services.
-	pluginServer := NewPluginServer(s.mapOps, s.cfg.BpfConstants(), s.logger)
+	//
+	// roEnforce gates the Phase 2 asm-level RO-write check. An invalid
+	// config string falls back to warn-only so a typo in vinbero.yaml
+	// can't accidentally lock out previously-working plugins; the parse
+	// failure is surfaced via the audit log instead.
+	roEnforce, err := bpf.ParseROEnforceMode(s.cfg.Setting.Validate.RoEnforce)
+	if err != nil {
+		s.logger.Warn("invalid settings.validate.ro_enforce; defaulting to warn",
+			zap.String("value", s.cfg.Setting.Validate.RoEnforce),
+			zap.Error(err),
+		)
+		roEnforce = bpf.ROEnforceWarn
+	}
+	s.logger.Info("plugin RO-write enforcement",
+		zap.String("mode", roEnforce.String()),
+	)
+	pluginServer := NewPluginServer(s.mapOps, s.cfg.BpfConstants(), roEnforce, s.logger)
 
 	// SidFunction service
 	sidFunctionServer := NewSidFunctionServer(s.mapOps, pluginServer)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -45,7 +45,7 @@ func (s *Server) Setup() {
 	// per-slot aux BTF types when callers use plugin_aux_json. The actual
 	// handler registration happens further down with the other services.
 	//
-	// roEnforce gates the Phase 2 asm-level RO-write check. An invalid
+	// roEnforce gates the asm-level RO-write check. An invalid
 	// config string falls back to warn-only so a typo in vinbero.yaml
 	// can't accidentally lock out previously-working plugins; the parse
 	// failure is surfaced via the audit log instead.

--- a/sdk/examples/plugin-counter-evil/Makefile
+++ b/sdk/examples/plugin-counter-evil/Makefile
@@ -1,0 +1,8 @@
+VINBERO_SDK_ROOT  ?= ../../c/include
+VINBERO_CORE_ROOT ?= ../../../src
+# Allow overriding the include path so the same Makefile works both
+# in-tree (default, ../../c/Makefile.plugin) and from an extracted SDK
+# tarball (override to <prefix>/include/vinbero/Makefile.plugin).
+MAKEFILE_PLUGIN   ?= ../../c/Makefile.plugin
+
+include $(MAKEFILE_PLUGIN)

--- a/sdk/examples/plugin-counter-evil/README.md
+++ b/sdk/examples/plugin-counter-evil/README.md
@@ -1,0 +1,44 @@
+# Plugin Example (Negative): Read-Only Map Write Violation
+
+このディレクトリは Vinbero Plugin SDK Phase 2 (asm-level RO write enforce) の
+**負の例 (negative example)** です。意図的に契約違反となるプラグインを
+コンパイルし、`vbctl plugin validate` が確実に reject することを確認するため
+だけに存在します。
+
+## 何が違反か
+
+`plugin.c` は vinbero の共有 read-only マップ `sid_function_map` の値を
+`bpf_map_lookup_elem()` で取得した後、その `action` フィールドを書き換えます。
+プラグインからは `sid_function_map` は **読み取り専用**: コントロールプレーン
+の状態をプラグインが上書きすると、vinbero 全体の動作が壊れる可能性があります。
+
+`pkg/bpf/plugin_validate.go::checkROWrites` がこの書き込みを load 前に検出して
+reject します。
+
+## ビルドと検証
+
+通常の SDK 例と同じ手順でビルドできます (clang は kernel verifier を呼ばない
+ので `.o` 自体は生成されます):
+
+```bash
+make -C sdk/examples/plugin-counter-evil
+```
+
+その上で `vbctl plugin validate` で reject されることを確認します:
+
+```bash
+./out/bin/vinbero plugin validate \
+    --prog sdk/examples/plugin-counter-evil/plugin.o \
+    --program plugin_counter_evil
+# expected: exit code 1, stderr に
+#   "plugin program ... has N disallowed map write(s); ..."
+```
+
+CI ではルートの `make sdk-test-negative` ターゲットがこの reject を自動検証
+します。`make sdk-test` (正の例向け) には含まれません — 含めると CI が
+"validate が pass する" を期待して失敗するためです。
+
+## 使ってはいけない
+
+これはあくまで validator のリグレッションテスト用サンプルです。実プラグインの
+ひな型としては `sdk/examples/plugin-counter/` を参照してください。

--- a/sdk/examples/plugin-counter-evil/README.md
+++ b/sdk/examples/plugin-counter-evil/README.md
@@ -1,6 +1,6 @@
 # Plugin Example (Negative): Read-Only Map Write Violation
 
-このディレクトリは Vinbero Plugin SDK Phase 2 (asm-level RO write enforce) の
+このディレクトリは Vinbero Plugin SDK の asm-level RO-write enforcer に対する
 **負の例 (negative example)** です。意図的に契約違反となるプラグインを
 コンパイルし、`vbctl plugin validate` が確実に reject することを確認するため
 だけに存在します。

--- a/sdk/examples/plugin-counter-evil/plugin.c
+++ b/sdk/examples/plugin-counter-evil/plugin.c
@@ -1,10 +1,10 @@
 // plugin_counter_evil.c — Negative example for the Vinbero plugin SDK.
 //
-// This plugin is intentionally written to violate the Phase 2 RO-write
-// contract: it looks up an entry in `sid_function_map` (a vinbero
-// shared READ-ONLY map) and rewrites its `action` field. The asm-level
-// validator in `pkg/bpf/plugin_validate.go` must reject this plugin at
-// load time. `make sdk-test-negative` confirms the rejection in CI.
+// This plugin intentionally violates the RO-write contract: it looks
+// up an entry in `sid_function_map` (a vinbero shared READ-ONLY map)
+// and rewrites its `action` field. The asm-level validator in
+// `pkg/bpf/plugin_validate.go` must reject this plugin at load time.
+// `make sdk-test-negative` confirms the rejection in CI.
 //
 // Do not copy this as a starting point for real plugins; use the
 // `plugin-counter` sample instead.
@@ -19,10 +19,11 @@
 
 VINBERO_PLUGIN(plugin_counter_evil)
 {
-    // Forbidden by Phase 2 RO enforcement: writing to sid_function_map
-    // would let a plugin rewrite vinbero's control plane. The validator
-    // sees the store target (whether resolved as the static map or as
-    // a "(dynamic)" lookup-return-value pointer) and rejects load.
+    // Forbidden by the validator's RO enforcement: writing to
+    // sid_function_map would let a plugin rewrite vinbero's control
+    // plane. The validator sees the store target (whether resolved as
+    // the static map or as a lookup-return-value pointer it cannot
+    // statically trace) and rejects load.
     __u32 key = 0;
     struct sid_function_entry *e =
         bpf_map_lookup_elem(&sid_function_map, &key);

--- a/sdk/examples/plugin-counter-evil/plugin.c
+++ b/sdk/examples/plugin-counter-evil/plugin.c
@@ -1,0 +1,35 @@
+// plugin_counter_evil.c — Negative example for the Vinbero plugin SDK.
+//
+// This plugin is intentionally written to violate the Phase 2 RO-write
+// contract: it looks up an entry in `sid_function_map` (a vinbero
+// shared READ-ONLY map) and rewrites its `action` field. The asm-level
+// validator in `pkg/bpf/plugin_validate.go` must reject this plugin at
+// load time. `make sdk-test-negative` confirms the rejection in CI.
+//
+// Do not copy this as a starting point for real plugins; use the
+// `plugin-counter` sample instead.
+
+#include <linux/types.h>
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+#include <vinbero/plugin.h>
+#include <vinbero/types.h>
+#include <vinbero/maps.h>
+
+VINBERO_PLUGIN(plugin_counter_evil)
+{
+    // Forbidden by Phase 2 RO enforcement: writing to sid_function_map
+    // would let a plugin rewrite vinbero's control plane. The validator
+    // sees the store target (whether resolved as the static map or as
+    // a "(dynamic)" lookup-return-value pointer) and rejects load.
+    __u32 key = 0;
+    struct sid_function_entry *e =
+        bpf_map_lookup_elem(&sid_function_map, &key);
+    if (e)
+        e->action = 99;
+
+    return XDP_PASS;
+}
+
+char _license[] SEC("license") = "GPL";


### PR DESCRIPTION
## Summary

Phase 1c の RO/RW map 分類は audit ログ止まりだったので、Phase 2 で **load 前 reject** に格上げする CFG analyzer を validator に追加する。クラサバ間の信頼境界を「audit 後検出」から「load 前検出」に強化。

### 追加した検査

- `pkg/bpf/plugin_validate.go::checkROWrites`:
  - `spec.Instructions` をメインプログラムのみ線形走査 (subprogram 以降は除外、`tailcall_epilogue` の合法書込を踏まないため)
  - `BPF_ST*` / `BPF_STX*` / `BPF_ATOMIC` を書込命令として検出
  - 書込先レジスタの直近 LoadMapPtr を逆向き解析で特定 → vinbero shared RO map なら reject、追跡不能 (`BPF_CALL` 戻り値経由 / 別 register コピー) なら保守的に reject
  - スタックストア (R10/RFP) は除外: clang のローカル変数 spill を false positive で弾かないため (実 `simple-acl` で 7 件の誤検出を観測してから追加)
- `pkg/bpf/maps.go::SharedReadOnlyMapNames` / `SharedReadWriteMapNames` / `SharedReadOnlyMapNamesSet`: CLI shift-left (`vbctl plugin validate`) が `MapOperations` 不要で RO 集合を引けるよう、静的 helper を追加。`TestSharedMapNamesStatic` で `GetSharedReadOnlyMaps()` キーと一致を assert (drift 検出)。

### 段階的展開 (Stage 1: warn-only default)

`settings.validate.ro_enforce` 設定を導入:
- `warn` (default): 違反検出時に `slog.Warn` audit ログ、register/load は続行
- `enforce`: hard-reject (CLI `vbctl plugin validate` は **常に enforce**)

これにより既存プラグインの突然の reject を避けつつ、運用で reject 候補を観測できる。

### Simplify pass

実装後に reuse / quality / efficiency の 3 視点でレビューし、以下を一括適用 (3 commit 目):

1. `listByOwner` の bubble sort → `sort.Slice` (stdlib)
2. `findStoreTargetMapName` と `findTailCallMapName` を `findStaticMapPtrSource` 1 関数に統合
3. `MapOperations.FreeAllByOwner` を `FreePluginAux` 反復に置換 (TOCTOU race も解消)
4. owner tag dual representation 解消: `AuxOwnerBuiltin = "builtin:v1"` 単一化、`persistedOwnerTag` 削除
5. `validatePluginSlot` server-side wrapper 削除 (使われ方が不一致だった)
6. `checkROWrites` を per-write reverse scan から forward 1-pass `lastMap[reg]` 表に (O(N×W) → O(N)、adversarial input への DoS 防御)
7. error message から内部 jargon (LoadMapPtr) 除去、操作ガイドへ書き換え
8. "Phase 2"/"Phase 1d" の task vocabulary をコメントから除去

正味 -28 LOC、機能は同等。

### Stacked PR base

本ブランチは A2 pinning (PR #25) の上に積んでいます。PR #25 → PR #24 → PR #23 の順でマージされる前提です。

## Test plan

- [x] `go test -race ./pkg/bpf/... ./pkg/server/...`: `TestValidatePluginROWrites_*` (8 ケース) + `TestParseROEnforceMode` + 既存テスト全 pass
- [x] `make test` (sudo + race + BPF) PASS
- [x] `make build` + `make sdk-archive-verify` PASS (positive examples)
- [x] `go build ./...` / `go vet ./...` clean、`golangci-lint` (lefthook) 0 issues
- [ ] Reviewer: `make sdk-test-negative` (clang 環境で `plugin-counter-evil` がビルドされ、`vinbero plugin validate` で reject されること)
- [ ] 設計書: `docs/plan/plugin-sdk-2-asm-ro-enforce.md` (gitignore 配下、未コミット)

## 設計書からの逸脱

1. `isStackStore` (R10/RFP 除外) を追加 — clang の stack-build key パターンで false positive 多発、`simple-acl` で実証してから対応 (R10 は read-only frame pointer なので map base に成り得ず安全)。
2. `ErrPluginROWrite` sentinel 追加 — エラー文字列マッチは脆いため `errors.Is` パターンに揃える (Phase 1d の `ErrAuxPayloadTooLarge` と同形)。
3. config parse 失敗時は warn フォールバック (typo で daemon 起動を止めない方針)。