### PR TITLE
fix(bpf): make src/core/srv6.h self-sufficient by including linux/in6.h

### DIFF
--- a/src/core/srv6.h
+++ b/src/core/srv6.h
@@ -5,6 +5,7 @@
 #include <bpf/bpf_helpers.h>
 #include <linux/bpf.h>
 #include <linux/in.h>
+#include <linux/in6.h>
 
 // ========== SRv6 Local Action (Endpoint functions) ==========
 // Maps to Srv6LocalAction enum in protobuf


### PR DESCRIPTION
## Summary
- `struct in6_addr` で宣言される SRH の `segments[]` フレキシブル配列が `<linux/in.h>` だけでは前方宣言止まりになる潜在バグの修正。
- メイン BPF ビルドは `xdp_prog.c` が `<linux/ipv6.h>` を先に読むので偶然通っていたが、プラグイン SDK のビルド (`<vinbero/plugin.h>` → `xdp_map.h` → `srv6.h`) は `in6.h` を踏まず以下で失敗する:

```
src/core/srv6.h:88:29: error: array has incomplete element type 'struct in6_addr'
    struct in6_addr segments[0]; // Segment list (variable length)
```

- `srv6.h` に `#include <linux/in6.h>` を 1 行追加してヘッダ衛生を整える。

## Test plan
- [x] `make bpf-gen` がメイン BPF ビルドで通ること (回帰なし確認)
- [x] `cd sdk/examples/plugin-counter && make` がプラグインビルドで通ること (これが壊れていた)