### PR TITLE
feat(plugin): open headend_l2 plugin slot + SDK helpers (Phase 2)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -106,6 +106,9 @@ jobs:
       - name: Build SDK tarball and verify it produces a working plugin
         run: make sdk-archive-verify
 
+      - name: Confirm validator rejects intentionally-bad sample plugins
+        run: make sdk-test-negative
+
   integration-test:
     name: Integration Test - ${{ matrix.example }}
     runs-on: ubuntu-24.04

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -91,6 +91,18 @@ archives:
         dst: share/vinbero-sdk/examples/simple-acl/plugin.c
       - src: sdk/examples/simple-acl/README.md
         dst: share/vinbero-sdk/examples/simple-acl/README.md
+      - src: sdk/examples/plugin-counter-l2/Makefile
+        dst: share/vinbero-sdk/examples/plugin-counter-l2/Makefile
+      - src: sdk/examples/plugin-counter-l2/plugin.c
+        dst: share/vinbero-sdk/examples/plugin-counter-l2/plugin.c
+      - src: sdk/examples/plugin-counter-l2/README.md
+        dst: share/vinbero-sdk/examples/plugin-counter-l2/README.md
+      - src: sdk/examples/plugin-custom-sh/Makefile
+        dst: share/vinbero-sdk/examples/plugin-custom-sh/Makefile
+      - src: sdk/examples/plugin-custom-sh/plugin.c
+        dst: share/vinbero-sdk/examples/plugin-custom-sh/plugin.c
+      - src: sdk/examples/plugin-custom-sh/README.md
+        dst: share/vinbero-sdk/examples/plugin-custom-sh/README.md
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ sdk-archive: ## Build SDK tarball into out/
 	@install -m 644 src/core/srv6.h $(SDK_STAGE)/include/core/
 	@install -m 644 sdk/README.md $(SDK_STAGE)/share/vinbero-sdk/
 	@install -m 644 LICENSE $(SDK_STAGE)/share/vinbero-sdk/
-	@for d in sdk/examples/plugin-counter sdk/examples/simple-acl; do \
+	@for d in sdk/examples/plugin-counter sdk/examples/simple-acl sdk/examples/plugin-counter-l2 sdk/examples/plugin-custom-sh; do \
 		name=$$(basename $$d); \
 		install -d $(SDK_STAGE)/share/vinbero-sdk/examples/$$name; \
 		install -m 644 $$d/Makefile $$d/plugin.c $$d/README.md \

--- a/api/vinbero/v1/plugin.pb.go
+++ b/api/vinbero/v1/plugin.pb.go
@@ -229,7 +229,7 @@ type PluginListRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	MapTypeFilter string `protobuf:"bytes,1,opt,name=map_type_filter,json=mapTypeFilter,proto3" json:"map_type_filter,omitempty"` // Empty = all map types; otherwise "endpoint" / "headend_v4" / "headend_v6"
+	MapTypeFilter string `protobuf:"bytes,1,opt,name=map_type_filter,json=mapTypeFilter,proto3" json:"map_type_filter,omitempty"` // Empty = all map types; otherwise "endpoint" / "headend_v4" / "headend_v6" / "headend_l2"
 }
 
 func (x *PluginListRequest) Reset() {

--- a/api/vinbero/v1/plugin.pb.go
+++ b/api/vinbero/v1/plugin.pb.go
@@ -27,7 +27,7 @@ type PluginRegisterRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	MapType string `protobuf:"bytes,1,opt,name=map_type,json=mapType,proto3" json:"map_type,omitempty"` // PROG_ARRAY target: "endpoint", "headend_v4", "headend_v6"
+	MapType string `protobuf:"bytes,1,opt,name=map_type,json=mapType,proto3" json:"map_type,omitempty"` // PROG_ARRAY target: "endpoint", "headend_v4", "headend_v6", "headend_l2"
 	Index   uint32 `protobuf:"varint,2,opt,name=index,proto3" json:"index,omitempty"`                   // Plugin slot index (endpoint: 32-63, headend: 16-31)
 	BpfElf  []byte `protobuf:"bytes,3,opt,name=bpf_elf,json=bpfElf,proto3" json:"bpf_elf,omitempty"`    // Compiled BPF ELF object file bytes
 	Program string `protobuf:"bytes,4,opt,name=program,proto3" json:"program,omitempty"`                // BPF program function name within the ELF (e.g., "plugin_counter")
@@ -136,7 +136,7 @@ type PluginUnregisterRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	MapType string `protobuf:"bytes,1,opt,name=map_type,json=mapType,proto3" json:"map_type,omitempty"` // PROG_ARRAY target: "endpoint", "headend_v4", "headend_v6"
+	MapType string `protobuf:"bytes,1,opt,name=map_type,json=mapType,proto3" json:"map_type,omitempty"` // PROG_ARRAY target: "endpoint", "headend_v4", "headend_v6", "headend_l2"
 	Index   uint32 `protobuf:"varint,2,opt,name=index,proto3" json:"index,omitempty"`                   // Plugin slot index to clear
 }
 

--- a/pkg/bpf/maps.go
+++ b/pkg/bpf/maps.go
@@ -1844,11 +1844,7 @@ func (m *MapOperations) GetSharedReadWriteMaps() map[string]*ebpf.Map {
 		MapNameSidEndpointProgs: m.objs.SidEndpointProgs,
 		MapNameHeadendV4Progs:   m.objs.HeadendV4Progs,
 		MapNameHeadendV6Progs:   m.objs.HeadendV6Progs,
-		// headend_l2_progs is intentionally NOT exposed here in Phase 1:
-		// the validator's tail-call whitelist (ValidTailCallMaps) does
-		// not include it yet, so external plugins cannot dispatch into
-		// L2 slots. Phase 2 of the L2 plugin rollout adds it together
-		// with MapTypeHeadendL2 / MapNameHeadendL2Progs constants.
+		MapNameHeadendL2Progs:   m.objs.HeadendL2Progs,
 	}
 }
 
@@ -1893,6 +1889,7 @@ func SharedReadWriteMapNames() []string {
 		MapNameSidEndpointProgs,
 		MapNameHeadendV4Progs,
 		MapNameHeadendV6Progs,
+		MapNameHeadendL2Progs,
 	}
 }
 
@@ -1921,6 +1918,7 @@ const (
 	MapTypeEndpoint  = "endpoint"
 	MapTypeHeadendV4 = "headend_v4"
 	MapTypeHeadendV6 = "headend_v6"
+	MapTypeHeadendL2 = "headend_l2"
 )
 
 // BPF map names for vinbero-managed PROG_ARRAYs. Referenced by the shared-map
@@ -1929,6 +1927,7 @@ const (
 	MapNameSidEndpointProgs = "sid_endpoint_progs"
 	MapNameHeadendV4Progs   = "headend_v4_progs"
 	MapNameHeadendV6Progs   = "headend_v6_progs"
+	MapNameHeadendL2Progs   = "headend_l2_progs"
 )
 
 var (
@@ -1944,10 +1943,10 @@ func PluginSlotRange(mapType string) (base, max uint32, err error) {
 	switch mapType {
 	case MapTypeEndpoint:
 		return EndpointPluginBase, EndpointProgMax, nil
-	case MapTypeHeadendV4, MapTypeHeadendV6:
+	case MapTypeHeadendV4, MapTypeHeadendV6, MapTypeHeadendL2:
 		return HeadendPluginBase, HeadendProgMax, nil
 	default:
-		return 0, 0, fmt.Errorf("unknown map_type %q (expected endpoint / headend_v4 / headend_v6)", mapType)
+		return 0, 0, fmt.Errorf("unknown map_type %q (expected endpoint / headend_v4 / headend_v6 / headend_l2)", mapType)
 	}
 }
 
@@ -2001,6 +2000,8 @@ func (m *MapOperations) resolvePluginMap(mapType string) (*ebpf.Map, uint32, uin
 		return m.objs.HeadendV4Progs, HeadendPluginBase, HeadendProgMax, nil
 	case MapTypeHeadendV6:
 		return m.objs.HeadendV6Progs, HeadendPluginBase, HeadendProgMax, nil
+	case MapTypeHeadendL2:
+		return m.objs.HeadendL2Progs, HeadendPluginBase, HeadendProgMax, nil
 	default:
 		return nil, 0, 0, fmt.Errorf("unknown plugin map type: %s", mapType)
 	}

--- a/pkg/bpf/plugin_validate.go
+++ b/pkg/bpf/plugin_validate.go
@@ -72,6 +72,7 @@ var ValidTailCallMaps = []string{
 	MapNameSidEndpointProgs,
 	MapNameHeadendV4Progs,
 	MapNameHeadendV6Progs,
+	MapNameHeadendL2Progs,
 }
 
 // ForbiddenHelpers names BPF helpers whose direct use from a plugin would

--- a/pkg/bpf/plugin_validate_test.go
+++ b/pkg/bpf/plugin_validate_test.go
@@ -132,6 +132,14 @@ func TestValidatePluginProgram_ValidTailCallHeadendV4(t *testing.T) {
 	}
 }
 
+func TestValidatePluginProgram_ValidTailCallHeadendL2(t *testing.T) {
+	ins := append(asm.Instructions{}, tailCallTo("headend_l2_progs", 20)...)
+	ins = append(ins, asm.Mov.Imm(asm.R0, 2), asm.Return())
+	if err := ValidatePluginProgram(buildSpec("dispatch", ebpf.XDP, ins), nil); err != nil {
+		t.Fatalf("expected tail-call into headend_l2_progs to pass, got: %v", err)
+	}
+}
+
 // Plugin uses both routes: leaf on one path, dispatch on another.
 func TestValidatePluginProgram_BothEpilogueAndTailCall(t *testing.T) {
 	ins := append(asm.Instructions{}, tailCallTo("sid_endpoint_progs", 40)...)

--- a/pkg/bpf/slotname.go
+++ b/pkg/bpf/slotname.go
@@ -15,6 +15,7 @@ var SlotStatsMapTypes = []string{
 	MapTypeEndpoint,
 	MapTypeHeadendV4,
 	MapTypeHeadendV6,
+	MapTypeHeadendL2,
 }
 
 // ValidateSlotStatsMapType returns an error if mapType is not one of

--- a/pkg/cli/cmd_plugin.go
+++ b/pkg/cli/cmd_plugin.go
@@ -15,6 +15,13 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+// pluginMapTypesCSV joins bpf.SlotStatsMapTypes with ", " so --type help
+// strings stay in sync with the canonical list (one place to add new map
+// types when more plugin slots open up).
+func pluginMapTypesCSV() string {
+	return strings.Join(bpf.SlotStatsMapTypes, ", ")
+}
+
 func pluginCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "plugin",
@@ -53,7 +60,7 @@ func pluginCommand() *cli.Command {
 				Name:  "register",
 				Usage: "Register a BPF plugin into a tail call slot",
 				Flags: []cli.Flag{
-					&cli.StringFlag{Name: "type", Required: true, Usage: "PROG_ARRAY target: endpoint, headend_v4, headend_v6, headend_l2"},
+					&cli.StringFlag{Name: "type", Required: true, Usage: "PROG_ARRAY target: " + pluginMapTypesCSV()},
 					&cli.UintFlag{Name: "index", Required: true, Usage: "Plugin slot index (endpoint: 32-63, headend: 16-31)"},
 					&cli.StringFlag{Name: "prog", Required: true, Usage: "Path to compiled BPF ELF object file"},
 					&cli.StringFlag{Name: "program", Required: true, Usage: "BPF program function name in the ELF (e.g., plugin_counter)"},
@@ -88,7 +95,7 @@ func pluginCommand() *cli.Command {
 				Name:  "unregister",
 				Usage: "Unregister a BPF plugin from a tail call slot",
 				Flags: []cli.Flag{
-					&cli.StringFlag{Name: "type", Required: true, Usage: "PROG_ARRAY target: endpoint, headend_v4, headend_v6, headend_l2"},
+					&cli.StringFlag{Name: "type", Required: true, Usage: "PROG_ARRAY target: " + pluginMapTypesCSV()},
 					&cli.UintFlag{Name: "index", Required: true, Usage: "Plugin slot index to clear"},
 				},
 				Action: func(c *cli.Context) error {
@@ -112,7 +119,7 @@ func pluginCommand() *cli.Command {
 				Name:  "list",
 				Usage: "List registered plugins",
 				Flags: []cli.Flag{
-					&cli.StringFlag{Name: "type", Usage: "Filter by map type: endpoint, headend_v4, headend_v6, headend_l2"},
+					&cli.StringFlag{Name: "type", Usage: "Filter by map type: " + pluginMapTypesCSV()},
 					&cli.BoolFlag{Name: "verbose", Aliases: []string{"v"}, Usage: "Show map linkage (shared/owned)"},
 				},
 				Action: func(c *cli.Context) error {
@@ -166,7 +173,7 @@ func pluginCommand() *cli.Command {
 // SidFunction create cycle. Each subcommand requires --map-type and --slot,
 // matching the owner tag the server derives server-side.
 func pluginAuxCommand() *cli.Command {
-	typeFlag := &cli.StringFlag{Name: "map-type", Required: true, Usage: "Plugin map type: endpoint, headend_v4, headend_v6, headend_l2"}
+	typeFlag := &cli.StringFlag{Name: "map-type", Required: true, Usage: "Plugin map type: " + pluginMapTypesCSV()}
 	slotFlag := &cli.UintFlag{Name: "slot", Required: true, Usage: "Plugin PROG_ARRAY slot (endpoint >= 32, headend >= 16)"}
 	jsonFlag := &cli.StringFlag{Name: "json", Usage: "JSON payload encoded via the plugin's <program>_aux BTF type"}
 	rawFlag := &cli.StringFlag{Name: "raw", Usage: "Raw payload as hex (<= 196 bytes). Mutually exclusive with --json"}
@@ -314,7 +321,7 @@ func pluginAuxCommand() *cli.Command {
 				Name:  "list",
 				Usage: "Enumerate live aux indices. Without --map-type, lists every owner.",
 				Flags: []cli.Flag{
-					&cli.StringFlag{Name: "map-type", Usage: "Filter to one plugin map type (endpoint / headend_v4 / headend_v6 / headend_l2)"},
+					&cli.StringFlag{Name: "map-type", Usage: "Filter to one plugin map type (" + pluginMapTypesCSV() + ")"},
 					&cli.UintFlag{Name: "slot", Usage: "Restrict to one slot. Only honoured with --match-slot."},
 					&cli.BoolFlag{Name: "match-slot", Usage: "Use --slot value as an exact filter."},
 				},

--- a/pkg/cli/cmd_plugin.go
+++ b/pkg/cli/cmd_plugin.go
@@ -53,7 +53,7 @@ func pluginCommand() *cli.Command {
 				Name:  "register",
 				Usage: "Register a BPF plugin into a tail call slot",
 				Flags: []cli.Flag{
-					&cli.StringFlag{Name: "type", Required: true, Usage: "PROG_ARRAY target: endpoint, headend_v4, headend_v6"},
+					&cli.StringFlag{Name: "type", Required: true, Usage: "PROG_ARRAY target: endpoint, headend_v4, headend_v6, headend_l2"},
 					&cli.UintFlag{Name: "index", Required: true, Usage: "Plugin slot index (endpoint: 32-63, headend: 16-31)"},
 					&cli.StringFlag{Name: "prog", Required: true, Usage: "Path to compiled BPF ELF object file"},
 					&cli.StringFlag{Name: "program", Required: true, Usage: "BPF program function name in the ELF (e.g., plugin_counter)"},
@@ -88,7 +88,7 @@ func pluginCommand() *cli.Command {
 				Name:  "unregister",
 				Usage: "Unregister a BPF plugin from a tail call slot",
 				Flags: []cli.Flag{
-					&cli.StringFlag{Name: "type", Required: true, Usage: "PROG_ARRAY target: endpoint, headend_v4, headend_v6"},
+					&cli.StringFlag{Name: "type", Required: true, Usage: "PROG_ARRAY target: endpoint, headend_v4, headend_v6, headend_l2"},
 					&cli.UintFlag{Name: "index", Required: true, Usage: "Plugin slot index to clear"},
 				},
 				Action: func(c *cli.Context) error {
@@ -112,7 +112,7 @@ func pluginCommand() *cli.Command {
 				Name:  "list",
 				Usage: "List registered plugins",
 				Flags: []cli.Flag{
-					&cli.StringFlag{Name: "type", Usage: "Filter by map type: endpoint, headend_v4, headend_v6"},
+					&cli.StringFlag{Name: "type", Usage: "Filter by map type: endpoint, headend_v4, headend_v6, headend_l2"},
 					&cli.BoolFlag{Name: "verbose", Aliases: []string{"v"}, Usage: "Show map linkage (shared/owned)"},
 				},
 				Action: func(c *cli.Context) error {
@@ -166,7 +166,7 @@ func pluginCommand() *cli.Command {
 // SidFunction create cycle. Each subcommand requires --map-type and --slot,
 // matching the owner tag the server derives server-side.
 func pluginAuxCommand() *cli.Command {
-	typeFlag := &cli.StringFlag{Name: "map-type", Required: true, Usage: "Plugin map type: endpoint, headend_v4, headend_v6"}
+	typeFlag := &cli.StringFlag{Name: "map-type", Required: true, Usage: "Plugin map type: endpoint, headend_v4, headend_v6, headend_l2"}
 	slotFlag := &cli.UintFlag{Name: "slot", Required: true, Usage: "Plugin PROG_ARRAY slot (endpoint >= 32, headend >= 16)"}
 	jsonFlag := &cli.StringFlag{Name: "json", Usage: "JSON payload encoded via the plugin's <program>_aux BTF type"}
 	rawFlag := &cli.StringFlag{Name: "raw", Usage: "Raw payload as hex (<= 196 bytes). Mutually exclusive with --json"}
@@ -314,7 +314,7 @@ func pluginAuxCommand() *cli.Command {
 				Name:  "list",
 				Usage: "Enumerate live aux indices. Without --map-type, lists every owner.",
 				Flags: []cli.Flag{
-					&cli.StringFlag{Name: "map-type", Usage: "Filter to one plugin map type (endpoint / headend_v4 / headend_v6)"},
+					&cli.StringFlag{Name: "map-type", Usage: "Filter to one plugin map type (endpoint / headend_v4 / headend_v6 / headend_l2)"},
 					&cli.UintFlag{Name: "slot", Usage: "Restrict to one slot. Only honoured with --match-slot."},
 					&cli.BoolFlag{Name: "match-slot", Usage: "Use --slot value as an exact filter."},
 				},

--- a/pkg/server/plugin_aux_test.go
+++ b/pkg/server/plugin_aux_test.go
@@ -29,6 +29,10 @@ func TestValidatePluginSlot(t *testing.T) {
 		{"endpoint_above_max", bpf.MapTypeEndpoint, bpf.EndpointProgMax, true},
 		{"headend_v4_valid", bpf.MapTypeHeadendV4, bpf.HeadendPluginBase, false},
 		{"headend_v6_below_base", bpf.MapTypeHeadendV6, bpf.HeadendPluginBase - 1, true},
+		{"headend_l2_valid_low", bpf.MapTypeHeadendL2, bpf.HeadendPluginBase, false},
+		{"headend_l2_valid_high", bpf.MapTypeHeadendL2, bpf.HeadendProgMax - 1, false},
+		{"headend_l2_below_base", bpf.MapTypeHeadendL2, bpf.HeadendPluginBase - 1, true},
+		{"headend_l2_above_max", bpf.MapTypeHeadendL2, bpf.HeadendProgMax, true},
 		{"unknown_map_type", "bogus", 32, true},
 	}
 	for _, c := range cases {

--- a/proto/vinbero/v1/plugin.proto
+++ b/proto/vinbero/v1/plugin.proto
@@ -35,7 +35,7 @@ service PluginService {
 }
 
 message PluginRegisterRequest {
-  string map_type = 1; // PROG_ARRAY target: "endpoint", "headend_v4", "headend_v6"
+  string map_type = 1; // PROG_ARRAY target: "endpoint", "headend_v4", "headend_v6", "headend_l2"
   uint32 index = 2; // Plugin slot index (endpoint: 32-63, headend: 16-31)
   bytes bpf_elf = 3; // Compiled BPF ELF object file bytes
   string program = 4; // BPF program function name within the ELF (e.g., "plugin_counter")
@@ -44,7 +44,7 @@ message PluginRegisterRequest {
 message PluginRegisterResponse {}
 
 message PluginUnregisterRequest {
-  string map_type = 1; // PROG_ARRAY target: "endpoint", "headend_v4", "headend_v6"
+  string map_type = 1; // PROG_ARRAY target: "endpoint", "headend_v4", "headend_v6", "headend_l2"
   uint32 index = 2; // Plugin slot index to clear
 }
 

--- a/proto/vinbero/v1/plugin.proto
+++ b/proto/vinbero/v1/plugin.proto
@@ -51,7 +51,7 @@ message PluginUnregisterRequest {
 message PluginUnregisterResponse {}
 
 message PluginListRequest {
-  string map_type_filter = 1; // Empty = all map types; otherwise "endpoint" / "headend_v4" / "headend_v6"
+  string map_type_filter = 1; // Empty = all map types; otherwise "endpoint" / "headend_v4" / "headend_v6" / "headend_l2"
 }
 
 message PluginInfo {

--- a/scripts/sdk_archive_verify.sh
+++ b/scripts/sdk_archive_verify.sh
@@ -17,6 +17,7 @@ required=(
   "$WORK/prefix/include/vinbero/maps.h"
   "$WORK/prefix/include/vinbero/types.h"
   "$WORK/prefix/include/vinbero/helpers.h"
+  "$WORK/prefix/include/vinbero/headend_l2_helpers.h"
   "$WORK/prefix/include/vinbero/Makefile.plugin"
   "$WORK/prefix/include/core/xdp_tailcall.h"
   "$WORK/prefix/include/core/xdp_prog.h"
@@ -29,6 +30,10 @@ required=(
   "$WORK/prefix/share/vinbero-sdk/examples/plugin-counter/plugin.c"
   "$WORK/prefix/share/vinbero-sdk/examples/simple-acl/Makefile"
   "$WORK/prefix/share/vinbero-sdk/examples/simple-acl/plugin.c"
+  "$WORK/prefix/share/vinbero-sdk/examples/plugin-counter-l2/Makefile"
+  "$WORK/prefix/share/vinbero-sdk/examples/plugin-counter-l2/plugin.c"
+  "$WORK/prefix/share/vinbero-sdk/examples/plugin-custom-sh/Makefile"
+  "$WORK/prefix/share/vinbero-sdk/examples/plugin-custom-sh/plugin.c"
 )
 for f in "${required[@]}"; do
   test -f "$f" || { echo "missing: $f" >&2; exit 1; }
@@ -38,7 +43,7 @@ done
 #    immediately if a #include path is wrong or a header is missing.
 #    MAKEFILE_PLUGIN points at the template shipped inside the tarball
 #    so the in-tree relative include (../../c/Makefile.plugin) is bypassed.
-for ex in plugin-counter simple-acl; do
+for ex in plugin-counter simple-acl plugin-counter-l2 plugin-custom-sh; do
   exdir="$WORK/prefix/share/vinbero-sdk/examples/$ex"
   echo "[verify] building $ex"
   make -C "$exdir" \
@@ -63,5 +68,11 @@ fi
 "$VBCTL" plugin validate \
   --prog "$WORK/prefix/share/vinbero-sdk/examples/simple-acl/plugin.o" \
   --program simple_acl
+"$VBCTL" plugin validate \
+  --prog "$WORK/prefix/share/vinbero-sdk/examples/plugin-counter-l2/plugin.o" \
+  --program plugin_counter_l2
+"$VBCTL" plugin validate \
+  --prog "$WORK/prefix/share/vinbero-sdk/examples/plugin-custom-sh/plugin.o" \
+  --program plugin_custom_sh
 
 echo "[verify] OK"

--- a/sdk/c/include/vinbero/headend_l2_helpers.h
+++ b/sdk/c/include/vinbero/headend_l2_helpers.h
@@ -62,6 +62,25 @@ static __always_inline bool vinbero_l2_esi_equal(const __u8 a[ESI_LEN], const __
     return (a_hi == b_hi) && (a_lo == b_lo);
 }
 
+/* IPv6 byte-level helpers. Same rationale as the ESI ones: core/esi.h's
+ * ipv6_{is_zero,equal} aren't on the SDK include path, and the DF check
+ * below needs them. 8+8 split keeps the verifier happy. */
+static __always_inline bool vinbero_l2_ipv6_is_zero(const __u8 addr[IPV6_ADDR_LEN])
+{
+    __u64 hi = *(const __u64 *)addr;
+    __u64 lo = *(const __u64 *)(addr + 8);
+    return (hi | lo) == 0;
+}
+
+static __always_inline bool vinbero_l2_ipv6_equal(const __u8 a[IPV6_ADDR_LEN], const __u8 b[IPV6_ADDR_LEN])
+{
+    __u64 a_hi = *(const __u64 *)a;
+    __u64 b_hi = *(const __u64 *)b;
+    __u64 a_lo = *(const __u64 *)(a + 8);
+    __u64 b_lo = *(const __u64 *)(b + 8);
+    return (a_hi == b_hi) && (a_lo == b_lo);
+}
+
 /* Outer VLAN ID parsed from the packet. Returns 0 for untagged frames or
  * if the buffer is too short to safely read the VLAN header. QinQ outer
  * tag is preferred; inner-tag parsing is left to the plugin. */
@@ -142,19 +161,43 @@ static __always_inline int vinbero_l2_dst_peer_esi(const struct xdp_md *ctx, __u
     return 0;
 }
 
-/* Whether this PE is the DF for the given BD's local ES. Reads
- * bd_local_esi_map[bd_id] (populated by vinberod from HeadendL2.esi
- * config) and compares its ESI against the plugin-supplied one. Returns
- * true only if they match — i.e. the caller's ESI is the BD's local ES
- * AND this PE is the active DF. Callers that already know the local
- * ESI (via vinbero_l2_lookup_esi above) can pass it straight in. */
-static __always_inline bool vinbero_l2_is_df_for_esi(__u16 bd_id, const __u8 esi[ESI_LEN])
+/* RFC 7432 §8.5 / RFC 9252: is this PE the Designated Forwarder for the
+ * BD's local Ethernet Segment? Mirrors src/endpoint/srv6_endpoint_l2.h
+ * ::dt2m_non_df_drop so plugins observe the same DF state the built-in
+ * BUM filter uses. Returns true only when:
+ *
+ *   1. bd_local_esi_map[bd_id] resolves to a non-zero ESI (BD has a
+ *      local ES configured).
+ *   2. That ESI is registered in esi_map with local_attached=1
+ *      (this PE actually attaches to the ES).
+ *   3. esi_map[esi].df_pe_src_addr is set (DF election has completed —
+ *      all-zero is treated as "not yet configured" and returns false to
+ *      fail closed for plugins; the built-in NON_DF filter fails open
+ *      in this state, the SDK contract is stricter on purpose).
+ *   4. df_pe_src_addr == local_pe_src_addr (this PE is the active DF).
+ *
+ * bd_id==0 (no BD) returns false. Callers don't need to pre-lookup the
+ * ESI; this helper handles the entire chain. */
+static __always_inline bool vinbero_l2_is_df(__u16 bd_id)
 {
-    __u32 key = bd_id;
-    struct bd_local_esi_val *val = bpf_map_lookup_elem(&bd_local_esi_map, &key);
-    if (!val)
+    if (bd_id == 0)
         return false;
-    return vinbero_l2_esi_equal(val->esi, esi);
+
+    __u32 key = bd_id;
+    struct bd_local_esi_val *lv = bpf_map_lookup_elem(&bd_local_esi_map, &key);
+    if (!lv || vinbero_l2_esi_is_zero(lv->esi))
+        return false;
+
+    struct esi_key ek = {};
+    __builtin_memcpy(ek.esi, lv->esi, ESI_LEN);
+    struct esi_entry *e = bpf_map_lookup_elem(&esi_map, &ek);
+    if (!e || !e->local_attached)
+        return false;
+
+    if (vinbero_l2_ipv6_is_zero(e->df_pe_src_addr))
+        return false;
+
+    return vinbero_l2_ipv6_equal(e->df_pe_src_addr, e->local_pe_src_addr);
 }
 
 #endif /* VINBERO_SDK_HEADEND_L2_HELPERS_H */

--- a/sdk/c/include/vinbero/headend_l2_helpers.h
+++ b/sdk/c/include/vinbero/headend_l2_helpers.h
@@ -1,0 +1,144 @@
+#ifndef VINBERO_SDK_HEADEND_L2_HELPERS_H
+#define VINBERO_SDK_HEADEND_L2_HELPERS_H
+
+/*
+ * Vinbero Plugin SDK — L2 headend helpers (Phase 2).
+ *
+ * Plugins registered into headend_l2_progs slots (HEADEND_PLUGIN_BASE
+ * == 16 .. HEADEND_PROG_MAX == 32) sit between BD forwarding's
+ * remote-peer decision and do_h_encaps_l2{,_red}. The dispatcher writes
+ * the chosen headend_entry into tctx->headend, so the encap target
+ * (segments / src_addr / bd_id) is immediately readable. Anything else
+ * the plugin wants to observe — VLAN ID, source / destination ESI,
+ * local DF status — has to be re-derived from RO maps that vinberod
+ * populates from the control plane.
+ *
+ * These inline helpers cover the common observations so plugin authors
+ * don't reinvent header parsing or map lookup chains. All of them are
+ * verifier-friendly (every memory access guarded, every map lookup
+ * NULL-checked) and side-effect free.
+ */
+
+#include <linux/types.h>
+#include <linux/bpf.h>
+#include <linux/if_ether.h>
+#include <stdbool.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_endian.h>
+
+#include "core/xdp_map.h"
+#include "core/xdp_prog.h"
+
+#ifndef ETH_P_8021Q
+#define ETH_P_8021Q 0x8100
+#endif
+#ifndef ETH_P_8021AD
+#define ETH_P_8021AD 0x88A8
+#endif
+
+/* Inner L2 frame length seen by the plugin (Eth + payload, pre-encap). */
+static __always_inline __u16 vinbero_l2_frame_len(const struct xdp_md *ctx)
+{
+    return (__u16)((long)ctx->data_end - (long)ctx->data);
+}
+
+/* Outer VLAN ID parsed from the packet. Returns 0 for untagged frames or
+ * if the buffer is too short to safely read the VLAN header. QinQ outer
+ * tag is preferred; inner-tag parsing is left to the plugin. */
+static __always_inline __u16 vinbero_l2_vlan_id(const struct xdp_md *ctx)
+{
+    void *data = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
+    struct ethhdr *eth = data;
+    if ((void *)(eth + 1) > data_end)
+        return 0;
+    __u16 proto = eth->h_proto;
+    if (proto != bpf_htons(ETH_P_8021Q) && proto != bpf_htons(ETH_P_8021AD))
+        return 0;
+    struct vlan_hdr {
+        __be16 h_vlan_TCI;
+        __be16 h_vlan_encapsulated_proto;
+    } __attribute__((packed));
+    struct vlan_hdr *vh = (struct vlan_hdr *)(eth + 1);
+    if ((void *)(vh + 1) > data_end)
+        return 0;
+    return bpf_ntohs(vh->h_vlan_TCI) & 0x0FFF;
+}
+
+/* Source ESI (the ES the local AC is attached to). Looks up
+ * headend_l2_ext_map[(ifindex, vlan_id)] and copies the ESI bytes into
+ * `out_esi`. Returns 0 on hit, -1 on miss (out_esi zeroed). Plugins
+ * that don't care about multihoming can ignore the return value and
+ * just check whether out_esi is all-zero. */
+static __always_inline int vinbero_l2_lookup_esi(__u32 ifindex, __u16 vlan_id,
+                                                 __u8 out_esi[ESI_LEN])
+{
+    struct headend_l2_key key = { .ifindex = ifindex, .vlan_id = vlan_id };
+    struct headend_l2_ext_val *val = bpf_map_lookup_elem(&headend_l2_ext_map, &key);
+    if (!val) {
+        __builtin_memset(out_esi, 0, ESI_LEN);
+        return -1;
+    }
+    __builtin_memcpy(out_esi, val->esi, ESI_LEN);
+    return 0;
+}
+
+/* Destination peer's ESI. Two-step lookup:
+ *   1. fdb_map[(bd_id, inner_dst_mac)] -> peer_index
+ *   2. bd_peer_l2_ext_map[(bd_id, peer_index)] -> esi
+ *
+ * Returns 0 on hit, -1 otherwise (out_esi zeroed). The packet must
+ * still have its inner Ethernet header at ctx->data — i.e. call this
+ * BEFORE bpf_xdp_adjust_head or any other header manipulation.
+ *
+ * Note: BD-peer ESI is only available after BD forwarding has chosen a
+ * remote peer; the dispatcher already gives the plugin a chance to
+ * observe this state via tctx->headend, but the peer_index that maps
+ * back to the ESI isn't carried in tctx, so this helper re-derives it. */
+static __always_inline int vinbero_l2_dst_peer_esi(const struct xdp_md *ctx, __u16 bd_id,
+                                                   __u8 out_esi[ESI_LEN])
+{
+    void *data = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
+    struct ethhdr *eth = data;
+    if ((void *)(eth + 1) > data_end) {
+        __builtin_memset(out_esi, 0, ESI_LEN);
+        return -1;
+    }
+    struct fdb_key fkey = { .bd_id = bd_id };
+    __builtin_memcpy(fkey.mac, eth->h_dest, ETH_ALEN);
+    struct fdb_entry *f = bpf_map_lookup_elem(&fdb_map, &fkey);
+    if (!f || !f->is_remote) {
+        __builtin_memset(out_esi, 0, ESI_LEN);
+        return -1;
+    }
+    struct bd_peer_l2_ext_key pkey = { .bd_id = f->bd_id, .index = f->peer_index };
+    struct bd_peer_l2_ext_val *pval = bpf_map_lookup_elem(&bd_peer_l2_ext_map, &pkey);
+    if (!pval) {
+        __builtin_memset(out_esi, 0, ESI_LEN);
+        return -1;
+    }
+    __builtin_memcpy(out_esi, pval->esi, ESI_LEN);
+    return 0;
+}
+
+/* Whether this PE is the DF for the given BD's local ES. Reads
+ * bd_local_esi_map[bd_id] (populated by vinberod from HeadendL2.esi
+ * config) and compares its ESI against the plugin-supplied one. Returns
+ * true only if they match — i.e. the caller's ESI is the BD's local ES
+ * AND this PE is the active DF. Callers that already know the local
+ * ESI (via vinbero_l2_lookup_esi above) can pass it straight in. */
+static __always_inline bool vinbero_l2_is_df_for_esi(__u16 bd_id, const __u8 esi[ESI_LEN])
+{
+    __u32 key = bd_id;
+    struct bd_local_esi_val *val = bpf_map_lookup_elem(&bd_local_esi_map, &key);
+    if (!val)
+        return false;
+    for (int i = 0; i < ESI_LEN; i++) {
+        if (val->esi[i] != esi[i])
+            return false;
+    }
+    return true;
+}
+
+#endif /* VINBERO_SDK_HEADEND_L2_HELPERS_H */

--- a/sdk/c/include/vinbero/headend_l2_helpers.h
+++ b/sdk/c/include/vinbero/headend_l2_helpers.h
@@ -42,6 +42,26 @@ static __always_inline __u16 vinbero_l2_frame_len(const struct xdp_md *ctx)
     return (__u16)((long)ctx->data_end - (long)ctx->data);
 }
 
+/* ESI byte-level helpers. core/esi.h's esi_{is_zero,equal} aren't exposed
+ * to plugins (only headers under vinbero/ ship in the SDK), so plugins
+ * that compare ESIs use these. 8+2 split matches the in-tree pattern: it
+ * gives the verifier two scalar loads instead of a 10-byte unrolled loop. */
+static __always_inline bool vinbero_l2_esi_is_zero(const __u8 esi[ESI_LEN])
+{
+    __u64 hi = *(const __u64 *)esi;
+    __u16 lo = *(const __u16 *)(esi + 8);
+    return (hi | (__u64)lo) == 0;
+}
+
+static __always_inline bool vinbero_l2_esi_equal(const __u8 a[ESI_LEN], const __u8 b[ESI_LEN])
+{
+    __u64 a_hi = *(const __u64 *)a;
+    __u64 b_hi = *(const __u64 *)b;
+    __u16 a_lo = *(const __u16 *)(a + 8);
+    __u16 b_lo = *(const __u16 *)(b + 8);
+    return (a_hi == b_hi) && (a_lo == b_lo);
+}
+
 /* Outer VLAN ID parsed from the packet. Returns 0 for untagged frames or
  * if the buffer is too short to safely read the VLAN header. QinQ outer
  * tag is preferred; inner-tag parsing is left to the plugin. */
@@ -134,11 +154,7 @@ static __always_inline bool vinbero_l2_is_df_for_esi(__u16 bd_id, const __u8 esi
     struct bd_local_esi_val *val = bpf_map_lookup_elem(&bd_local_esi_map, &key);
     if (!val)
         return false;
-    for (int i = 0; i < ESI_LEN; i++) {
-        if (val->esi[i] != esi[i])
-            return false;
-    }
-    return true;
+    return vinbero_l2_esi_equal(val->esi, esi);
 }
 
 #endif /* VINBERO_SDK_HEADEND_L2_HELPERS_H */

--- a/sdk/c/include/vinbero/plugin.h
+++ b/sdk/c/include/vinbero/plugin.h
@@ -5,7 +5,7 @@
  * Vinbero Plugin SDK: entry-point header.
  *
  * A plugin is a SEC("xdp") BPF program registered into one of vinbero's
- * PROG_ARRAY slots (endpoint 32..63, headend_v4/v6 16..31) via the
+ * PROG_ARRAY slots (endpoint 32..63, headend_v4/v6/l2 16..31) via the
  * PluginService API. Include this header to get:
  *
  *   - struct tailcall_ctx definition (per-CPU context handed in by the

--- a/sdk/c/include/vinbero/plugin.h
+++ b/sdk/c/include/vinbero/plugin.h
@@ -38,11 +38,17 @@
  *       verifier-helper macros, shared map declarations.
  *   v2: adds VINBERO_PLUGIN(name) entry macro; tailcall_epilogue gains
  *       warn_unused_result.
+ *   v3: opens headend_l2 plugin slot. headend_l2_progs is now a valid
+ *       bpf_tail_call target (ValidTailCallMaps) and --type=headend_l2
+ *       is accepted by the CLI / PluginService. Adds
+ *       vinbero/headend_l2_helpers.h with VLAN / ESI / DF observation
+ *       helpers; tctx->headend carries the chosen encap target for L2
+ *       dispatch (existing union variant, re-used).
  *
  * Version bumps are additive. Plugins compiled against an older SDK
  * remain valid against newer vinbero.
  */
-#define VINBERO_SDK_VERSION 2
+#define VINBERO_SDK_VERSION 3
 
 /*
  * VINBERO_PLUGIN(name) — recommended entry macro for plugin authors.

--- a/sdk/examples/plugin-counter-l2/Makefile
+++ b/sdk/examples/plugin-counter-l2/Makefile
@@ -1,0 +1,5 @@
+VINBERO_SDK_ROOT  ?= ../../c/include
+VINBERO_CORE_ROOT ?= ../../../src
+MAKEFILE_PLUGIN   ?= ../../c/Makefile.plugin
+
+include $(MAKEFILE_PLUGIN)

--- a/sdk/examples/plugin-counter-l2/README.md
+++ b/sdk/examples/plugin-counter-l2/README.md
@@ -19,15 +19,30 @@ make
 # Register (slot 16 = HEADEND_PLUGIN_BASE)
 vinbero plugin register --type headend_l2 --index 16 \
     --prog plugin.o --program plugin_counter_l2
+```
 
-# Wire HL2 entry to use slot 16 instead of the built-in (= sid create flow
-# is not applicable for headend_l2; instead, the dispatcher in vinbero
-# selects the plugin slot when sid_function_entry.action is set).
-# NOTE: hooking by slot for L2 headend is automatic once registered —
-# any traffic that reaches the no-BD path or remote-peer encap will run
-# through the plugin chain. (Future: per-HL2-entry plugin slot selection.)
+### Plugin slot を HL2 entry に紐付ける
 
-# Observe
+L2 headend dispatcher は `headend_entry.mode` の値を `headend_l2_progs` の
+tail-call index として使う (`src/dispatch/l2_headend.c`)。Plugin を呼ぶには
+対象 HL2 entry の `mode` をプラグインスロット値 (= 上で指定した index、
+ここでは 16) に書き換える必要がある。
+
+Phase 2 時点では `HeadendL2Create` の `mode` フィールドは `Srv6HeadendBehavior`
+enum (組込み 0..15) なので、plugin slot 値 (16..31) を gRPC 経由で直接渡せる
+control-plane API はまだない (Phase 3 で追加予定: per-HL2-entry plugin slot
+selection)。デモ用には map を直接書き換える:
+
+```bash
+# 既存の HL2 entry (mode=3 = H_ENCAPS_L2) を slot 16 に向ける
+bpftool map update pinned /sys/fs/bpf/headend_l2_map \
+    key <ifindex+vlan_le> value <headend_entry with mode=16>
+```
+
+### 観測
+
+```bash
+# Plugin counter は PERCPU_HASH なので bpftool が自動で per-CPU を集計
 bpftool map dump pinned /sys/fs/bpf/plugin_counter_l2_map
 ```
 

--- a/sdk/examples/plugin-counter-l2/README.md
+++ b/sdk/examples/plugin-counter-l2/README.md
@@ -41,9 +41,14 @@ bpftool map update pinned /sys/fs/bpf/headend_l2_map \
 
 ### 観測
 
+PluginRegister は owned map を bpffs に pin しない。`bpftool map show` で
+ID を引いてから dump する:
+
 ```bash
-# Plugin counter は PERCPU_HASH なので bpftool が自動で per-CPU を集計
-bpftool map dump pinned /sys/fs/bpf/plugin_counter_l2_map
+MAP_ID=$(sudo bpftool map show \
+    | awk '/name plugin_counter_l2/ { sub(":","",$1); print $1; exit }')
+# PERCPU_HASH なので bpftool が自動で per-CPU を集計
+sudo bpftool map dump id "$MAP_ID"
 ```
 
 ## SDK helper の例

--- a/sdk/examples/plugin-counter-l2/README.md
+++ b/sdk/examples/plugin-counter-l2/README.md
@@ -55,7 +55,7 @@ bpftool map dump pinned /sys/fs/bpf/plugin_counter_l2_map
 - `vinbero_l2_frame_len(ctx)` — pre-encap の inner L2 frame 長
 - `vinbero_l2_lookup_esi(ifindex, vlan_id, out_esi)` — 自 AC の source ESI
 - `vinbero_l2_dst_peer_esi(ctx, bd_id, out_esi)` — dst peer の ESI (FDB → bd_peer_l2_ext_map)
-- `vinbero_l2_is_df_for_esi(bd_id, esi)` — 自 PE が DF か
+- `vinbero_l2_is_df(bd_id)` — 自 PE が BD の local ES の DF か (RFC 7432 §8.5)
 
 ## 仕様メモ
 

--- a/sdk/examples/plugin-counter-l2/README.md
+++ b/sdk/examples/plugin-counter-l2/README.md
@@ -1,0 +1,52 @@
+# plugin-counter-l2
+
+L2 headend plugin の最小例 (Vinbero SDK v3+)。`headend_l2_progs` のプラグインスロット
+(16-31 の範囲、慣例的に 16) に register され、BD forwarding が「remote peer に encap
+する」と決定した直後 / no-BD entry の encap 経路の直前に呼ばれる。
+
+## 何をするか
+
+- `tctx->headend.bd_id` をキーに per-CPU counter map を加算する
+- 続けて `bpf_tail_call(ctx, &headend_l2_progs, SRV6_HEADEND_BEHAVIOR_H_ENCAPS_L2)`
+  で built-in `do_h_encaps_l2` (slot 3) に dispatch を戻し、通常の encap path を継続
+
+## 使い方
+
+```bash
+# Build
+make
+
+# Register (slot 16 = HEADEND_PLUGIN_BASE)
+vinbero plugin register --type headend_l2 --index 16 \
+    --prog plugin.o --program plugin_counter_l2
+
+# Wire HL2 entry to use slot 16 instead of the built-in (= sid create flow
+# is not applicable for headend_l2; instead, the dispatcher in vinbero
+# selects the plugin slot when sid_function_entry.action is set).
+# NOTE: hooking by slot for L2 headend is automatic once registered —
+# any traffic that reaches the no-BD path or remote-peer encap will run
+# through the plugin chain. (Future: per-HL2-entry plugin slot selection.)
+
+# Observe
+bpftool map dump pinned /sys/fs/bpf/plugin_counter_l2_map
+```
+
+## SDK helper の例
+
+このサンプルは `bd_id` だけ参照しているが、`vinbero/headend_l2_helpers.h` には
+以下も用意されている (実装は `plugin-custom-sh` 例を参照):
+
+- `vinbero_l2_vlan_id(ctx)` — packet header から VLAN ID
+- `vinbero_l2_frame_len(ctx)` — pre-encap の inner L2 frame 長
+- `vinbero_l2_lookup_esi(ifindex, vlan_id, out_esi)` — 自 AC の source ESI
+- `vinbero_l2_dst_peer_esi(ctx, bd_id, out_esi)` — dst peer の ESI (FDB → bd_peer_l2_ext_map)
+- `vinbero_l2_is_df_for_esi(bd_id, esi)` — 自 PE が DF か
+
+## 仕様メモ
+
+- plugin は **post-BD-forwarding (HOOK BETA)** に位置する。BUM / dst==LOCAL
+  経路には呼ばれない。
+- aux (PluginAux) は Phase 2 では未対応。per-instance config を持ちたければ
+  plugin-owned map を使う (このサンプルが counter を持っているのと同じ要領)。
+- `tctx->headend` は L3 plugin と同じ union variant。`tctx->l3_offset` は L2
+  では使用しない (dispatcher が 0 を書く)。

--- a/sdk/examples/plugin-counter-l2/plugin.c
+++ b/sdk/examples/plugin-counter-l2/plugin.c
@@ -17,9 +17,11 @@
 #include <vinbero/headend_l2_helpers.h>
 
 // Per-(bd_id) packet counter. bd_id is __u16 from headend_entry; the
-// map keys it as __u32 to keep things verifier-simple.
+// map keys it as __u32 to keep things verifier-simple. PERCPU_HASH avoids
+// the LOCK XADD / cacheline bouncing that plain HASH would incur on the
+// XDP per-packet path; bpftool aggregates per-CPU values automatically.
 struct {
-    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
     __type(key, __u32);
     __type(value, __u64);
     __uint(max_entries, 256);
@@ -35,7 +37,7 @@ VINBERO_PLUGIN(plugin_counter_l2)
         counter = bpf_map_lookup_elem(&plugin_counter_l2_map, &key);
     }
     if (counter)
-        __sync_fetch_and_add(counter, 1);
+        (*counter)++;
 
     // Hand control back to the built-in H.Encaps.L2 encap so the packet
     // continues on its normal path. tctx->headend already carries the

--- a/sdk/examples/plugin-counter-l2/plugin.c
+++ b/sdk/examples/plugin-counter-l2/plugin.c
@@ -1,0 +1,48 @@
+// plugin_counter_l2.c — Minimal Vinbero L2 headend plugin example.
+//
+// Demonstrates the headend_l2 plugin slot introduced in Phase 2 of the
+// L2 headend plugin SDK (see docs/plan/plugin-sdk-l2-headend.md). The
+// plugin sits between BD forwarding's encap-target decision and the
+// built-in do_h_encaps_l2{,_red} encap body. It counts packets per BD
+// in a plugin-owned map and dispatches back into headend_l2_progs[3]
+// (H_ENCAPS_L2) so the built-in encap still runs.
+
+#include <linux/types.h>
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+#include <vinbero/plugin.h>
+#include <vinbero/types.h>
+#include <vinbero/maps.h>
+#include <vinbero/headend_l2_helpers.h>
+
+// Per-(bd_id) packet counter. bd_id is __u16 from headend_entry; the
+// map keys it as __u32 to keep things verifier-simple.
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, 256);
+} plugin_counter_l2_map SEC(".maps");
+
+VINBERO_PLUGIN(plugin_counter_l2)
+{
+    __u32 key = (__u32)tctx->headend.bd_id;
+    __u64 init = 0;
+    __u64 *counter = bpf_map_lookup_elem(&plugin_counter_l2_map, &key);
+    if (!counter) {
+        bpf_map_update_elem(&plugin_counter_l2_map, &key, &init, BPF_NOEXIST);
+        counter = bpf_map_lookup_elem(&plugin_counter_l2_map, &key);
+    }
+    if (counter)
+        __sync_fetch_and_add(counter, 1);
+
+    // Hand control back to the built-in H.Encaps.L2 encap so the packet
+    // continues on its normal path. tctx->headend already carries the
+    // chosen encap target (l2_entry or pe), so no rewrite needed.
+    bpf_tail_call(ctx, &headend_l2_progs, SRV6_HEADEND_BEHAVIOR_H_ENCAPS_L2);
+    // Tail call only returns on failure (empty slot / map error).
+    return XDP_DROP;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/sdk/examples/plugin-custom-sh/Makefile
+++ b/sdk/examples/plugin-custom-sh/Makefile
@@ -1,0 +1,5 @@
+VINBERO_SDK_ROOT  ?= ../../c/include
+VINBERO_CORE_ROOT ?= ../../../src
+MAKEFILE_PLUGIN   ?= ../../c/Makefile.plugin
+
+include $(MAKEFILE_PLUGIN)

--- a/sdk/examples/plugin-custom-sh/README.md
+++ b/sdk/examples/plugin-custom-sh/README.md
@@ -29,9 +29,14 @@ vinbero plugin register --type headend_l2 --index 17 \
 
 ## 観測
 
+Plugin-owned map は bpffs に pin されないので、`bpftool map show` で ID を
+取得して dump する:
+
 ```bash
-# Plugin が drop した frame の per-BD カウント
-bpftool map dump pinned /sys/fs/bpf/plugin_custom_sh_drops
+# Plugin が drop した frame の per-BD カウント (PERCPU_HASH)
+MAP_ID=$(sudo bpftool map show \
+    | awk '/name plugin_custom_sh_drops/ { sub(":","",$1); print $1; exit }')
+sudo bpftool map dump id "$MAP_ID"
 
 # Vinbero の組込み NON_DF_DROP カウンタとの比較
 vinbero stats show

--- a/sdk/examples/plugin-custom-sh/README.md
+++ b/sdk/examples/plugin-custom-sh/README.md
@@ -15,7 +15,8 @@ vinbero_l2_lookup_esi(ifindex, vlan_id, src_esi);   // local AC の ESI
 vinbero_l2_dst_peer_esi(ctx, bd_id, dst_esi);       // dst peer の ESI (FDB → bd_peer_l2_ext_map)
 ```
 
-両方が non-zero でかつ一致 → drop。それ以外は `bpf_tail_call(&headend_l2_progs, H_ENCAPS_L2)`
+両方が non-zero でかつ一致 → drop。それ以外は
+`bpf_tail_call(ctx, &headend_l2_progs, SRV6_HEADEND_BEHAVIOR_H_ENCAPS_L2)`
 で built-in encap に戻す。
 
 ## ビルド + 登録

--- a/sdk/examples/plugin-custom-sh/README.md
+++ b/sdk/examples/plugin-custom-sh/README.md
@@ -1,0 +1,49 @@
+# plugin-custom-sh
+
+EVPN multi-homing reference: TX-side custom Split-Horizon filter. Headend L2 plugin
+(`headend_l2` slot, Vinbero SDK v3+) が src AC の ESI と dst peer の ESI を比較し、
+両方が同じ非ゼロ ESI のとき frame を drop する。Built-in の RFC 7432 §8.3 SH
+(`NON_DF_DROP` 経路、RX 側) に加えて TX 側で stricter rule を適用するのが用途。
+
+## SDK helper の使い方
+
+`vinbero/headend_l2_helpers.h` の helper を 2 段引きで使用:
+
+```c
+__u8 src_esi[ESI_LEN], dst_esi[ESI_LEN];
+vinbero_l2_lookup_esi(ifindex, vlan_id, src_esi);   // local AC の ESI
+vinbero_l2_dst_peer_esi(ctx, bd_id, dst_esi);       // dst peer の ESI (FDB → bd_peer_l2_ext_map)
+```
+
+両方が non-zero でかつ一致 → drop。それ以外は `bpf_tail_call(&headend_l2_progs, H_ENCAPS_L2)`
+で built-in encap に戻す。
+
+## ビルド + 登録
+
+```bash
+make
+vinbero plugin register --type headend_l2 --index 17 \
+    --prog plugin.o --program plugin_custom_sh
+```
+
+## 観測
+
+```bash
+# Plugin が drop した frame の per-BD カウント
+bpftool map dump pinned /sys/fs/bpf/plugin_custom_sh_drops
+
+# Vinbero の組込み NON_DF_DROP カウンタとの比較
+vinbero stats show
+```
+
+## 制約
+
+- HOOK BETA (post-BD-forwarding) のみ。`dst==LOCAL` / BUM 経路には呼ばれない (HOOK ALPHA = Phase 3+ 待ち)。
+- `vinbero_l2_dst_peer_esi` は inner Eth + FDB の存在を前提とする。FDB miss
+  ケース (= 学習前のフロー) では dst_esi が all-zero で返り、フィルタは pass する。
+- DF election ロジックを上書きしたい場合は本サンプル対象外 (Phase 3 HOOK ALPHA + control plane plugin が必要)。
+
+## 関連設計
+
+- `docs/plan/plugin-sdk-l2-headend.md` §5.7 Multihoming-aware plugin patterns
+- `sdk/c/include/vinbero/headend_l2_helpers.h` (5 つの SDK helper)

--- a/sdk/examples/plugin-custom-sh/plugin.c
+++ b/sdk/examples/plugin-custom-sh/plugin.c
@@ -1,0 +1,84 @@
+// plugin_custom_sh.c — Custom Split-Horizon (SH) filter for L2 headend.
+//
+// EVPN multi-homing reference plugin (Vinbero SDK v3+). Demonstrates how
+// to observe source / destination ESI from a headend_l2_progs plugin
+// slot and drop frames that would cross between two ACs that share an
+// Ethernet Segment — i.e. apply an SH rule that's stricter (or just
+// different) from vinbero's built-in behavior.
+//
+// Built-in Vinbero already enforces RFC 7432 §8.3 SH on the receive
+// side (NON_DF_DROP). This plugin layers an additional TX-side check:
+// if the local AC's ESI equals the destination peer's ESI, drop the
+// frame before encap. Useful for topologies where two PEs are in the
+// same ES and you want to force traffic to take an alternate path.
+
+#include <linux/types.h>
+#include <linux/bpf.h>
+#include <linux/if_ether.h>
+#include <bpf/bpf_helpers.h>
+
+#include <vinbero/plugin.h>
+#include <vinbero/types.h>
+#include <vinbero/maps.h>
+#include <vinbero/headend_l2_helpers.h>
+
+// Per-(bd_id) drop counter — observability for ops to confirm the
+// plugin is taking effect. Real deployments would also export this via
+// vinbero stats; for the example we keep it plugin-private.
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, 256);
+} plugin_custom_sh_drops SEC(".maps");
+
+static __always_inline void bump_drops(__u16 bd_id)
+{
+    __u32 key = (__u32)bd_id;
+    __u64 init = 0;
+    __u64 *c = bpf_map_lookup_elem(&plugin_custom_sh_drops, &key);
+    if (!c) {
+        bpf_map_update_elem(&plugin_custom_sh_drops, &key, &init, BPF_NOEXIST);
+        c = bpf_map_lookup_elem(&plugin_custom_sh_drops, &key);
+    }
+    if (c)
+        __sync_fetch_and_add(c, 1);
+}
+
+VINBERO_PLUGIN(plugin_custom_sh)
+{
+    __u32 ifindex = (__u32)ctx->ingress_ifindex;
+    __u16 vlan_id = vinbero_l2_vlan_id(ctx);
+    __u16 bd_id = tctx->headend.bd_id;
+
+    __u8 src_esi[ESI_LEN];
+    __u8 dst_esi[ESI_LEN];
+
+    // Pull both ends of the local AC <-> remote peer pair. Missing
+    // entries (lookup returning -1) leave the ESI buffer all-zero,
+    // which the equality check below treats as "not in an ES" -> pass.
+    (void)vinbero_l2_lookup_esi(ifindex, vlan_id, src_esi);
+    (void)vinbero_l2_dst_peer_esi(ctx, bd_id, dst_esi);
+
+    // Drop only when BOTH sides have a non-zero ESI AND they match.
+    // Comparing zeros against zeros would drop every non-multihomed
+    // frame, which is obviously wrong.
+    bool src_set = false, eq = true;
+    #pragma unroll
+    for (int i = 0; i < ESI_LEN; i++) {
+        if (src_esi[i] != 0)
+            src_set = true;
+        if (src_esi[i] != dst_esi[i])
+            eq = false;
+    }
+    if (src_set && eq) {
+        bump_drops(bd_id);
+        return XDP_DROP;
+    }
+
+    // Not an SH violation — hand off to built-in H.Encaps.L2.
+    bpf_tail_call(ctx, &headend_l2_progs, SRV6_HEADEND_BEHAVIOR_H_ENCAPS_L2);
+    return XDP_DROP;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/sdk/examples/plugin-custom-sh/plugin.c
+++ b/sdk/examples/plugin-custom-sh/plugin.c
@@ -24,9 +24,10 @@
 
 // Per-(bd_id) drop counter — observability for ops to confirm the
 // plugin is taking effect. Real deployments would also export this via
-// vinbero stats; for the example we keep it plugin-private.
+// vinbero stats; for the example we keep it plugin-private. PERCPU_HASH
+// keeps the increment lock-free in the XDP per-packet path.
 struct {
-    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
     __type(key, __u32);
     __type(value, __u64);
     __uint(max_entries, 256);
@@ -42,7 +43,7 @@ static __always_inline void bump_drops(__u16 bd_id)
         c = bpf_map_lookup_elem(&plugin_custom_sh_drops, &key);
     }
     if (c)
-        __sync_fetch_and_add(c, 1);
+        (*c)++;
 }
 
 VINBERO_PLUGIN(plugin_custom_sh)
@@ -63,15 +64,7 @@ VINBERO_PLUGIN(plugin_custom_sh)
     // Drop only when BOTH sides have a non-zero ESI AND they match.
     // Comparing zeros against zeros would drop every non-multihomed
     // frame, which is obviously wrong.
-    bool src_set = false, eq = true;
-    #pragma unroll
-    for (int i = 0; i < ESI_LEN; i++) {
-        if (src_esi[i] != 0)
-            src_set = true;
-        if (src_esi[i] != dst_esi[i])
-            eq = false;
-    }
-    if (src_set && eq) {
+    if (!vinbero_l2_esi_is_zero(src_esi) && vinbero_l2_esi_equal(src_esi, dst_esi)) {
         bump_drops(bd_id);
         return XDP_DROP;
     }

--- a/src/dispatch/l2_headend.c
+++ b/src/dispatch/l2_headend.c
@@ -13,9 +13,16 @@
 // out of this helper is intentional and enforced as an invariant: any second
 // lexical bpf_tail_call site into headend_l2_progs in the same translation
 // unit causes the kernel to silently drop the redirected frame on the first
-// callsite, even when that branch is dead code at runtime. See
-// reference_bpf_tail_call_redirect_gotcha for repro notes — tail_call must
-// stay as a single inline instruction in try_l2_headend below.
+// callsite, even when that branch is dead code at runtime.
+//
+// Repro (kernel 6.x, observed 2026-05): two lexical bpf_tail_call sites in
+// xdp_main.c targeting the same PROG_ARRAY (headend_l2_progs) cause the
+// first site's XDP_REDIRECT (set by the target program's bpf_redirect()
+// call) to be silently dropped. The xdp:xdp_redirect{_err,_map_err}
+// tracepoints do not fire. Collapsing all callers to a single inline
+// bpf_tail_call instruction in try_l2_headend below restores delivery.
+// Root cause is not yet pinned down — verifier register-state merge / JIT
+// dispatch / per-CPU bpf_redirect_info aliasing are all suspects.
 static __always_inline struct headend_entry *try_bd_peer_lookup(
     struct xdp_md *ctx,
     struct headend_entry *l2_entry,

--- a/src/dispatch/l2_headend.c
+++ b/src/dispatch/l2_headend.c
@@ -10,12 +10,12 @@
 //
 // FDB src learning, broadcast/multicast BUM meta, and missing-FDB BUM meta
 // are all handled here so the caller stays simple. Keeping the bpf_tail_call
-// out of this helper is intentional — having a second lexical tail_call
-// site to headend_l2_progs (e.g. one here AND one in try_l2_headend) makes
-// the kernel silently drop the redirected frames, even when this BD-peer
-// branch is dead code for the caller's traffic. Root cause is still under
-// investigation (Phase 2); the workaround is to keep tail_call as a single
-// inline instruction in try_l2_headend below.
+// out of this helper is intentional and enforced as an invariant: any second
+// lexical bpf_tail_call site into headend_l2_progs in the same translation
+// unit causes the kernel to silently drop the redirected frame on the first
+// callsite, even when that branch is dead code at runtime. See
+// reference_bpf_tail_call_redirect_gotcha for repro notes — tail_call must
+// stay as a single inline instruction in try_l2_headend below.
 static __always_inline struct headend_entry *try_bd_peer_lookup(
     struct xdp_md *ctx,
     struct headend_entry *l2_entry,


### PR DESCRIPTION
## Summary

[Phase 2 of the L2 headend plugin SDK rollout](https://github.com/takehaya/Vinbero/pull/29) — exposes `headend_l2` as a plugin slot type, adds the SDK helpers needed for multihoming-aware plugin authoring, and ships 2 reference example plugins.

Stacked on top of #29 (Phase 1 tail-call infrastructure). Merge order: #29 first, then this PR.

## What lands

### Validator / CLI / RPC (server side)
- `pkg/bpf/maps.go`: `MapTypeHeadendL2` / `MapNameHeadendL2Progs` 定数を追加、`PluginSlotRange` / `resolvePluginMap` / `GetSharedReadWriteMaps` / `SharedReadWriteMapNames` の switch & list に L2 を編入 (slot 16-31)
- `pkg/bpf/plugin_validate.go`: `ValidTailCallMaps` に `MapNameHeadendL2Progs` を追加 → plugin から `bpf_tail_call(&headend_l2_progs, 3)` で built-in encap に rejoin できる
- `pkg/bpf/slotname.go`: `SlotStatsMapTypes` に `headend_l2` を追加 → `vbctl stats slot show --type=headend_l2` が引ける
- `pkg/cli/cmd_plugin.go`: 各 plugin subcommand の `--type` Usage に `headend_l2` を露出 (register / unregister / list / aux 全部)
- `proto/vinbero/v1/plugin.proto`: `map_type` field のコメントに `headend_l2` を追記、`pb.go` 再生成

### SDK (plugin author 側)
- `sdk/c/include/vinbero/headend_l2_helpers.h` を新設:
  - `vinbero_l2_vlan_id(ctx)`
  - `vinbero_l2_frame_len(ctx)`
  - `vinbero_l2_lookup_esi(ifindex, vlan_id, out_esi)`
  - `vinbero_l2_dst_peer_esi(ctx, bd_id, out_esi)` (FDB → bd_peer_l2_ext_map の 2 段引き)
  - `vinbero_l2_is_df_for_esi(bd_id, esi)`
- `sdk/c/include/vinbero/plugin.h`: `VINBERO_SDK_VERSION` を 3 へ bump、changelog エントリ追加

### Reference examples
- **`sdk/examples/plugin-counter-l2`**: minimal — `tctx->headend.bd_id` をキーに per-CPU counter を加算、`bpf_tail_call(&headend_l2_progs, H_ENCAPS_L2)` で built-in encap に戻す
- **`sdk/examples/plugin-custom-sh`**: multihoming-aware — `vinbero_l2_lookup_esi` + `vinbero_l2_dst_peer_esi` で src / dst peer の ESI を比較、両方が同じ非ゼロ ESI なら `XDP_DROP` (TX-side strict SH)

### Packaging
- `.goreleaser.yaml` / `Makefile sdk-archive`: 新 helper header + 例 2 本を tarball に含める
- `scripts/sdk_archive_verify.sh`: 新 helper / 例の存在チェック + 全 4 sample plugin が tarball から build + `vinbero plugin validate` を通る

## Test plan

- [x] `make test`: unit + BPF load 全 PASS
- [x] `make sdk-test`: 5 positive sample plugin が validate PASS (counter / simple-acl / acl-prefix / counter-l2 / custom-sh)
- [x] `make sdk-test-negative`: counter-evil が期待通り reject
- [x] `make sdk-archive-verify`: tarball から全 4 plugin build + validate
- [x] `examples/headend-l2`: 3 連続 PASS
- [x] `examples/end-dt2`:    3 連続 PASS

## Out of scope (Phase 3+)

- L2 plugin aux 対応 (owner tag `plugin:v1:headend_l2:<slot>` 拡張) — 設計は §7
- HOOK ALPHA (BD forwarding 前 filter — custom DF election / BD decision override) — 設計は §5.7 / §10
- 既存 `docs/dev/plugin-sdk.md` の L2 章追加 (本 PR は plan ドキュメント止まり、SDK user-facing docs は別 PR で予定)

## Backwards-compat

- 既存の `endpoint` / `headend_v4` / `headend_v6` plugin は無影響
- BPF object layout は Phase 1 (#29) で確定したものから変化なし (今回は plugin slot を開ける validator / CLI / SDK 側だけ)
- `VINBERO_SDK_VERSION` bump は additive