### PR TITLE
feat(fib): inject BGP-learned routes into the kernel FIB (Phase 1d-a)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli/v2 v2.27.7
 	github.com/vishvananda/netlink v1.3.1
+	github.com/vishvananda/netns v0.0.5
 	go.uber.org/zap v1.27.1
 	golang.org/x/net v0.48.0
 	golang.org/x/sys v0.39.0
@@ -40,7 +41,6 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/spf13/viper v1.20.1 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/text v0.32.0 // indirect

--- a/pkg/fib/route.go
+++ b/pkg/fib/route.go
@@ -1,0 +1,157 @@
+// Package fib installs and removes routes in the kernel forwarding
+// information base on behalf of BGP-learned prefixes. Vinbero's XDP data
+// plane resolves next hops with bpf_fib_lookup, which reads the kernel
+// FIB -- so an IPv6 unicast route received over BGP must be pushed into
+// the kernel routing table for the data plane to use it.
+//
+// Every route written here is tagged with RTPROT_BGP, so an operator can
+// list exactly Vinbero's BGP-driven entries with `ip route show proto
+// bgp` and List() can filter to them without disturbing routes owned by
+// other daemons.
+package fib
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"syscall"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// routeProtocol marks every FIB entry Vinbero installs as BGP-originated.
+const routeProtocol = netlink.RouteProtocol(unix.RTPROT_BGP)
+
+// Route is a kernel FIB entry Vinbero manages for a BGP-learned prefix.
+type Route struct {
+	Prefix  netip.Prefix
+	NextHop netip.Addr // zero value => no gateway (directly connected)
+	Table   int        // 0 = main table
+	Metric  int        // route priority; 0 = kernel default
+}
+
+// Injector installs and removes routes in the kernel FIB. Implementations
+// must be safe for concurrent use.
+type Injector interface {
+	// Add installs r, replacing any existing Vinbero-owned route for the
+	// same prefix. It is idempotent: re-adding an identical route is a
+	// no-op from the caller's perspective.
+	Add(r Route) error
+	// Delete removes the route for prefix. Deleting a prefix that is not
+	// present is not an error.
+	Delete(prefix netip.Prefix) error
+	// List returns every route currently tagged RTPROT_BGP.
+	List() ([]Route, error)
+}
+
+// KernelInjector is the production Injector backed by netlink.
+type KernelInjector struct{}
+
+var _ Injector = (*KernelInjector)(nil)
+
+// NewKernelInjector returns an Injector that writes to the live kernel
+// routing table.
+func NewKernelInjector() *KernelInjector { return &KernelInjector{} }
+
+func (*KernelInjector) Add(r Route) error {
+	nlRoute, err := toNetlinkRoute(r)
+	if err != nil {
+		return err
+	}
+	// RouteReplace is add-or-update: re-installing the same prefix
+	// refreshes it in place instead of failing with EEXIST.
+	if err := netlink.RouteReplace(nlRoute); err != nil {
+		return fmt.Errorf("fib: add route %s: %w", r.Prefix, err)
+	}
+	return nil
+}
+
+func (*KernelInjector) Delete(prefix netip.Prefix) error {
+	dst, err := prefixToIPNet(prefix)
+	if err != nil {
+		return err
+	}
+	route := &netlink.Route{Dst: dst, Protocol: routeProtocol}
+	if err := netlink.RouteDel(route); err != nil {
+		// ESRCH: the route is already gone. Treat Delete as idempotent
+		// so a double-withdraw or a restart mid-teardown is harmless.
+		if errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		return fmt.Errorf("fib: delete route %s: %w", prefix, err)
+	}
+	return nil
+}
+
+func (*KernelInjector) List() ([]Route, error) {
+	filter := &netlink.Route{Protocol: routeProtocol}
+	nlRoutes, err := netlink.RouteListFiltered(netlink.FAMILY_ALL, filter, netlink.RT_FILTER_PROTOCOL)
+	if err != nil {
+		return nil, fmt.Errorf("fib: list routes: %w", err)
+	}
+	out := make([]Route, 0, len(nlRoutes))
+	for i := range nlRoutes {
+		if r, ok := fromNetlinkRoute(&nlRoutes[i]); ok {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+func toNetlinkRoute(r Route) (*netlink.Route, error) {
+	dst, err := prefixToIPNet(r.Prefix)
+	if err != nil {
+		return nil, err
+	}
+	nl := &netlink.Route{
+		Dst:      dst,
+		Protocol: routeProtocol,
+		Table:    r.Table,
+		Priority: r.Metric,
+	}
+	if r.NextHop.IsValid() {
+		nl.Gw = net.IP(r.NextHop.AsSlice())
+	}
+	return nl, nil
+}
+
+func fromNetlinkRoute(nl *netlink.Route) (Route, bool) {
+	// A nil Dst is the default route (0.0.0.0/0 or ::/0); Vinbero never
+	// installs one, so skip rather than surfacing it.
+	if nl.Dst == nil {
+		return Route{}, false
+	}
+	prefix, ok := ipNetToPrefix(nl.Dst)
+	if !ok {
+		return Route{}, false
+	}
+	r := Route{Prefix: prefix, Table: nl.Table, Metric: nl.Priority}
+	if len(nl.Gw) > 0 {
+		if nh, ok := netip.AddrFromSlice(nl.Gw); ok {
+			r.NextHop = nh.Unmap()
+		}
+	}
+	return r, true
+}
+
+func prefixToIPNet(p netip.Prefix) (*net.IPNet, error) {
+	if !p.IsValid() {
+		return nil, fmt.Errorf("fib: invalid prefix %q", p)
+	}
+	addr := p.Masked().Addr()
+	return &net.IPNet{
+		IP:   net.IP(addr.AsSlice()),
+		Mask: net.CIDRMask(p.Bits(), addr.BitLen()),
+	}, nil
+}
+
+func ipNetToPrefix(n *net.IPNet) (netip.Prefix, bool) {
+	addr, ok := netip.AddrFromSlice(n.IP)
+	if !ok {
+		return netip.Prefix{}, false
+	}
+	ones, _ := n.Mask.Size()
+	return netip.PrefixFrom(addr.Unmap(), ones), true
+}

--- a/pkg/fib/route_test.go
+++ b/pkg/fib/route_test.go
@@ -1,0 +1,150 @@
+package fib
+
+import (
+	"net"
+	"net/netip"
+	"runtime"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
+)
+
+// withTestNetns moves the calling goroutine's OS thread into a fresh
+// network namespace with one up dummy interface, so route mutations
+// never touch the host's real routing table. Requires CAP_NET_ADMIN
+// (run via `go test -exec sudo`).
+func withTestNetns(t *testing.T) {
+	t.Helper()
+	runtime.LockOSThread()
+	orig, err := netns.Get()
+	if err != nil {
+		runtime.UnlockOSThread()
+		t.Fatalf("netns.Get: %v", err)
+	}
+	ns, err := netns.New() // creates the namespace and enters it
+	if err != nil {
+		_ = orig.Close()
+		runtime.UnlockOSThread()
+		t.Fatalf("netns.New (needs root / CAP_NET_ADMIN): %v", err)
+	}
+	t.Cleanup(func() {
+		_ = netns.Set(orig)
+		_ = orig.Close()
+		_ = ns.Close()
+		runtime.UnlockOSThread()
+	})
+
+	// A dummy interface with an address gives routes a valid on-link
+	// nexthop scope.
+	dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "fibtest0"}}
+	if err := netlink.LinkAdd(dummy); err != nil {
+		t.Fatalf("LinkAdd dummy: %v", err)
+	}
+	if err := netlink.LinkSetUp(dummy); err != nil {
+		t.Fatalf("LinkSetUp: %v", err)
+	}
+	addr, err := netlink.ParseAddr("fd00:f1b::1/64")
+	if err != nil {
+		t.Fatalf("ParseAddr: %v", err)
+	}
+	if err := netlink.AddrAdd(dummy, addr); err != nil {
+		t.Fatalf("AddrAdd: %v", err)
+	}
+}
+
+func TestKernelInjector_AddListDelete(t *testing.T) {
+	withTestNetns(t)
+	inj := NewKernelInjector()
+	r := Route{
+		Prefix:  netip.MustParsePrefix("fd00:dead::/64"),
+		NextHop: netip.MustParseAddr("fd00:f1b::2"),
+	}
+	if err := inj.Add(r); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	routes, err := inj.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("List = %d routes, want 1", len(routes))
+	}
+	if routes[0].Prefix != r.Prefix {
+		t.Errorf("listed prefix = %s, want %s", routes[0].Prefix, r.Prefix)
+	}
+	if routes[0].NextHop != r.NextHop {
+		t.Errorf("listed nexthop = %s, want %s", routes[0].NextHop, r.NextHop)
+	}
+
+	if err := inj.Delete(r.Prefix); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	routes, err = inj.List()
+	if err != nil {
+		t.Fatalf("List after delete: %v", err)
+	}
+	if len(routes) != 0 {
+		t.Errorf("after Delete, List = %d routes, want 0", len(routes))
+	}
+}
+
+func TestKernelInjector_AddIsIdempotent(t *testing.T) {
+	withTestNetns(t)
+	inj := NewKernelInjector()
+	r := Route{
+		Prefix:  netip.MustParsePrefix("fd00:beef::/64"),
+		NextHop: netip.MustParseAddr("fd00:f1b::2"),
+	}
+	if err := inj.Add(r); err != nil {
+		t.Fatalf("first Add: %v", err)
+	}
+	if err := inj.Add(r); err != nil {
+		t.Errorf("second Add (must be idempotent via RouteReplace): %v", err)
+	}
+}
+
+func TestKernelInjector_DeleteAbsentIsNoop(t *testing.T) {
+	withTestNetns(t)
+	inj := NewKernelInjector()
+	if err := inj.Delete(netip.MustParsePrefix("fd00:0:0:99::/64")); err != nil {
+		t.Errorf("Delete of an absent prefix should be a no-op, got %v", err)
+	}
+}
+
+// TestKernelInjector_ListFiltersByProtocol confirms List only returns
+// Vinbero's RTPROT_BGP routes, not entries other daemons own.
+func TestKernelInjector_ListFiltersByProtocol(t *testing.T) {
+	withTestNetns(t)
+	link, err := netlink.LinkByName("fibtest0")
+	if err != nil {
+		t.Fatalf("LinkByName: %v", err)
+	}
+	// A non-BGP (static) route installed directly: List must skip it.
+	staticDst := &net.IPNet{IP: net.ParseIP("fd00:cafe::"), Mask: net.CIDRMask(64, 128)}
+	if err := netlink.RouteAdd(&netlink.Route{
+		Dst:       staticDst,
+		LinkIndex: link.Attrs().Index,
+		Protocol:  netlink.RouteProtocol(unix.RTPROT_STATIC),
+	}); err != nil {
+		t.Fatalf("RouteAdd static: %v", err)
+	}
+
+	inj := NewKernelInjector()
+	bgpPrefix := netip.MustParsePrefix("fd00:dead::/64")
+	if err := inj.Add(Route{Prefix: bgpPrefix, NextHop: netip.MustParseAddr("fd00:f1b::2")}); err != nil {
+		t.Fatalf("Add BGP route: %v", err)
+	}
+
+	routes, err := inj.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("List = %d routes, want 1 (BGP-only, static excluded)", len(routes))
+	}
+	if routes[0].Prefix != bgpPrefix {
+		t.Errorf("listed prefix = %s, want %s", routes[0].Prefix, bgpPrefix)
+	}
+}


### PR DESCRIPTION
## Summary
- First sub-PR of **Phase 1d** ([GoBGP integration plan](docs/plan/gobgp-integration.md)), which is split into 5 stacked sub-PRs (1d-a … 1d-e). **Stacked on #31**; base branch is \`feat/owner-tag-expand\`.
- \`pkg/fib\` installs IPv6 unicast routes learned over BGP into the kernel routing table. The XDP data plane resolves next hops with \`bpf_fib_lookup\` against the kernel FIB, so a BGP-received prefix is only usable once it is in the kernel FIB.
- \`Injector\` interface (\`Add\` / \`Delete\` / \`List\`) + netlink-backed \`KernelInjector\`. \`Add\` is idempotent (RouteReplace), \`Delete\` absorbs ESRCH, \`List\` filters to \`RTPROT_BGP\`.
- Every route is tagged \`RTPROT_BGP\` — \`ip route show proto bgp\` lists exactly Vinbero's BGP-driven entries, and \`List\` never returns routes other daemons own.
- \`vishvananda/netlink\` promoted from indirect to direct dependency.

## Scope
This sub-PR delivers only the injector and its tests. The BGP receive path that calls it lands in **Phase 1d-c**. Sub-PR breakdown:

| sub-PR | content |
|---|---|
| **1d-a** (this) | \`pkg/fib\` kernel FIB injector |
| 1d-b | \`RouteSubscriber\` — GoBGP \`WatchEvent\` bridge |
| 1d-c | VPNv4/v6 decode + map write |
| 1d-d | \`VrfBgpService\` — RT ↔ VRF binding |
| 1d-e | E2E test |

## Test plan
- [x] \`make lint\` (0 issues), \`make build\`
- [x] \`go test -exec sudo ./pkg/fib/\` — Add/List/Delete round-trip, Add idempotency, Delete-absent no-op, RTPROT_BGP filtering. Tests run inside a fresh netns with a dummy interface, so the host routing table is never touched.