### PR TITLE
feat(bgp): bridge GoBGP WatchEvent to RouteSubscriber (Phase 1d-b)

### DIFF
--- a/cmd/vinberod/main.go
+++ b/cmd/vinberod/main.go
@@ -127,6 +127,15 @@ func run(cliCtx *cli.Context) error {
 		if err := startBGPSession(ctx, bgpSession, cfg.BGP); err != nil {
 			return fmt.Errorf("start BGP: %w", err)
 		}
+		// Phase 1d-b: surface received routes in the log. Phase 1d-c
+		// replaces this handler with one that drives the data plane.
+		cancelSub, err := bgpSession.Subscribe("", func(ev bgp.RouteEvent) {
+			logBGPRoute(lg, ev)
+		})
+		if err != nil {
+			return fmt.Errorf("subscribe BGP routes: %w", err)
+		}
+		defer cancelSub()
 	}
 
 	lg.Info("Vinbero started successfully")
@@ -170,6 +179,23 @@ func startBGPSession(ctx context.Context, session bgp.Session, cfg config.BGPCon
 		}
 	}
 	return nil
+}
+
+// logBGPRoute is the Phase 1d-b route handler: it only records what the
+// BGP session received. The data-plane wiring (map writes, FIB
+// injection) arrives in Phase 1d-c.
+func logBGPRoute(lg *zap.Logger, ev bgp.RouteEvent) {
+	fields := []zap.Field{
+		zap.String("family", ev.Family.String()),
+		zap.Bool("withdraw", ev.IsWithdraw),
+	}
+	switch {
+	case ev.VPN != nil:
+		fields = append(fields, zap.String("prefix", ev.VPN.Prefix))
+	case ev.Unicast != nil:
+		fields = append(fields, zap.String("prefix", ev.Unicast.Prefix))
+	}
+	lg.Info("BGP route received", fields...)
 }
 
 func loadConfig(path string) (*config.Config, error) {

--- a/pkg/bgp/gobgp/subscriber.go
+++ b/pkg/bgp/gobgp/subscriber.go
@@ -1,0 +1,91 @@
+package gobgp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
+	gobgppkt "github.com/osrg/gobgp/v4/pkg/packet/bgp"
+	gobgpsrv "github.com/osrg/gobgp/v4/pkg/server"
+
+	"github.com/takehaya/vinbero/pkg/bgp"
+)
+
+// compile-time assertion that *Session also satisfies RouteSubscriber.
+var _ bgp.RouteSubscriber = (*Session)(nil)
+
+// Subscribe registers handler for post-policy route updates. The cancel
+// func tears down the underlying gobgp watcher; callers must invoke it
+// to avoid leaking the watch goroutine.
+//
+// handler is called from a gobgp-internal goroutine and must not block
+// (see bgp.RouteHandler). filter restricts delivery to one family; an
+// empty filter delivers every supported family.
+func (s *Session) Subscribe(filter bgp.Family, handler bgp.RouteHandler) (func(), error) {
+	if s.server == nil {
+		return nil, bgp.ErrSessionNotStarted
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cbs := gobgpsrv.WatchEventMessageCallbacks{
+		OnPathUpdate: func(paths []*apiutil.Path, _ time.Time) {
+			for _, p := range paths {
+				ev, ok := pathToRouteEvent(p)
+				if !ok {
+					continue // family Vinbero does not consume
+				}
+				if filter != "" && ev.Family != filter {
+					continue
+				}
+				handler(ev)
+			}
+		},
+	}
+	// WatchPostUpdate: post-import-policy routes, which is what the data
+	// plane should mirror. current=true replays the existing RIB so a
+	// subscriber that attaches after peers are up still sees them.
+	if err := s.server.WatchEvent(ctx, cbs, gobgpsrv.WatchPostUpdate(true, "", "")); err != nil {
+		cancel()
+		return nil, fmt.Errorf("watch event: %w", err)
+	}
+	return cancel, nil
+}
+
+// pathToRouteEvent converts a gobgp received Path into a Vinbero
+// RouteEvent. Phase 1d-b fills in only family / prefix / withdraw; the
+// SRv6 service SID and RD/RT decode lands in Phase 1d-c.
+func pathToRouteEvent(p *apiutil.Path) (bgp.RouteEvent, bool) {
+	fam, ok := apiFamilyToVinbero(p.Family)
+	if !ok {
+		return bgp.RouteEvent{}, false
+	}
+	var prefix string
+	if p.Nlri != nil {
+		prefix = p.Nlri.String()
+	}
+	ev := bgp.RouteEvent{Family: fam, IsWithdraw: p.Withdrawal}
+	switch fam {
+	case bgp.FamilyVPNv4, bgp.FamilyVPNv6:
+		ev.VPN = &bgp.VPNRoute{Family: fam, Prefix: prefix}
+	case bgp.FamilyIPv6Unicast:
+		ev.Unicast = &bgp.UnicastRoute{Prefix: prefix}
+	}
+	return ev, true
+}
+
+// apiFamilyToVinbero maps a gobgp route family to a Vinbero Family.
+// Unsupported families return ok=false so the caller skips them.
+func apiFamilyToVinbero(f gobgppkt.Family) (bgp.Family, bool) {
+	switch f {
+	case gobgppkt.RF_IPv4_VPN:
+		return bgp.FamilyVPNv4, true
+	case gobgppkt.RF_IPv6_VPN:
+		return bgp.FamilyVPNv6, true
+	case gobgppkt.RF_IPv6_UC:
+		return bgp.FamilyIPv6Unicast, true
+	case gobgppkt.RF_SR_POLICY_IPv6:
+		return bgp.FamilySRPolicyIPv6, true
+	default:
+		return "", false
+	}
+}

--- a/pkg/bgp/gobgp/subscriber_test.go
+++ b/pkg/bgp/gobgp/subscriber_test.go
@@ -1,0 +1,96 @@
+package gobgp
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
+	gobgppkt "github.com/osrg/gobgp/v4/pkg/packet/bgp"
+
+	"github.com/takehaya/vinbero/pkg/bgp"
+)
+
+func TestApiFamilyToVinbero(t *testing.T) {
+	tests := []struct {
+		name string
+		in   gobgppkt.Family
+		want bgp.Family
+		ok   bool
+	}{
+		{"vpnv4", gobgppkt.RF_IPv4_VPN, bgp.FamilyVPNv4, true},
+		{"vpnv6", gobgppkt.RF_IPv6_VPN, bgp.FamilyVPNv6, true},
+		{"ipv6-uc", gobgppkt.RF_IPv6_UC, bgp.FamilyIPv6Unicast, true},
+		{"sr-policy-v6", gobgppkt.RF_SR_POLICY_IPv6, bgp.FamilySRPolicyIPv6, true},
+		{"ipv4-uc-unconsumed", gobgppkt.RF_IPv4_UC, "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := apiFamilyToVinbero(tc.in)
+			if ok != tc.ok || got != tc.want {
+				t.Errorf("apiFamilyToVinbero(%v) = (%q, %v), want (%q, %v)",
+					tc.in, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+func TestPathToRouteEvent(t *testing.T) {
+	t.Run("vpnv6-withdraw", func(t *testing.T) {
+		ev, ok := pathToRouteEvent(&apiutil.Path{Family: gobgppkt.RF_IPv6_VPN, Withdrawal: true})
+		if !ok {
+			t.Fatal("pathToRouteEvent returned ok=false for VPNv6")
+		}
+		if ev.Family != bgp.FamilyVPNv6 {
+			t.Errorf("family = %q, want vpnv6", ev.Family)
+		}
+		if !ev.IsWithdraw {
+			t.Error("IsWithdraw = false, want true")
+		}
+		if ev.VPN == nil {
+			t.Error("VPN sub-struct must be populated for a VPN family")
+		}
+		if ev.Unicast != nil {
+			t.Error("Unicast must be nil for a VPN family")
+		}
+	})
+
+	t.Run("ipv6-unicast", func(t *testing.T) {
+		ev, ok := pathToRouteEvent(&apiutil.Path{Family: gobgppkt.RF_IPv6_UC})
+		if !ok {
+			t.Fatal("pathToRouteEvent returned ok=false for IPv6 unicast")
+		}
+		if ev.Unicast == nil {
+			t.Error("Unicast sub-struct must be populated")
+		}
+		if ev.VPN != nil {
+			t.Error("VPN must be nil for a unicast family")
+		}
+	})
+
+	t.Run("unconsumed-family-skipped", func(t *testing.T) {
+		if _, ok := pathToRouteEvent(&apiutil.Path{Family: gobgppkt.RF_IPv4_UC}); ok {
+			t.Error("pathToRouteEvent should skip families Vinbero does not consume")
+		}
+	})
+}
+
+func TestSubscribe_BeforeStartRejected(t *testing.T) {
+	s := newTestSession(t)
+	_, err := s.Subscribe("", func(bgp.RouteEvent) {})
+	if !errors.Is(err, bgp.ErrSessionNotStarted) {
+		t.Errorf("Subscribe before Start: got %v, want ErrSessionNotStarted", err)
+	}
+}
+
+func TestSubscribe_CancelIsSafe(t *testing.T) {
+	s := newTestSession(t)
+	startTestSession(t, s)
+	cancel, err := s.Subscribe("", func(bgp.RouteEvent) {})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	// cancel tears down the watcher; calling it twice must not panic
+	// (context.CancelFunc is idempotent).
+	cancel()
+	cancel()
+}


### PR DESCRIPTION
## Summary
- Second sub-PR of **Phase 1d**. **Stacked on #34** (1d-a); base branch is \`feat/bgp-netlink-fib\`.
- \`gobgp.Session\` now also implements \`bgp.RouteSubscriber\`. \`Subscribe\` wires GoBGP's \`WatchEvent\` (\`WatchPostUpdate\`, current=true so a late subscriber still sees the existing RIB) into a Vinbero \`RouteHandler\`, returning a cancel func that tears the watcher down.
- \`pathToRouteEvent\` converts a received \`apiutil.Path\` into a \`RouteEvent\`. This phase fills in only **family / prefix / withdraw**; the SRv6 service SID + RD/RT decode is Phase 1d-c. Families Vinbero does not consume (e.g. ipv4-unicast) are skipped.
- \`vinberod --bgp-enabled\` subscribes after the session starts and logs every received route (\`logBGPRoute\`).

## Scope
This sub-PR only observes and logs received routes. Phase 1d-c swaps the handler for one that drives the data plane (headend maps + kernel FIB via \`pkg/fib\` from 1d-a).

| sub-PR | content | status |
|---|---|---|
| 1d-a | \`pkg/fib\` kernel FIB injector | #34 |
| **1d-b** (this) | \`RouteSubscriber\` — WatchEvent bridge | — |
| 1d-c | VPNv4/v6 decode + map write | next |
| 1d-d | \`VrfBgpService\` — RT ↔ VRF binding | |
| 1d-e | E2E test | |

## Test plan
- [x] \`make lint\` (0 issues), \`make build\`
- [x] \`go test ./pkg/bgp/...\` — apiFamilyToVinbero conversion table, pathToRouteEvent (VPN / unicast / skipped family), Subscribe before-start rejection, cancel idempotency