### PR TITLE
feat(bgp): decode SRv6 service SID / RD / RT from VPN routes (Phase 1d-c)

### DIFF
--- a/pkg/bgp/gobgp/decode.go
+++ b/pkg/bgp/gobgp/decode.go
@@ -1,0 +1,106 @@
+package gobgp
+
+import (
+	"net/netip"
+
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
+	gobgppkt "github.com/osrg/gobgp/v4/pkg/packet/bgp"
+
+	"github.com/takehaya/vinbero/pkg/bgp"
+)
+
+// decodeVPNRoute builds the Vinbero VPNRoute view of a received VPNv4 /
+// VPNv6 path: RD + prefix from the NLRI, the SRv6 service SID from the
+// BGP Prefix-SID attribute (RFC 9252), route targets from extended
+// communities, and the next hop from MP_REACH_NLRI.
+func decodeVPNRoute(p *apiutil.Path, fam bgp.Family) *bgp.VPNRoute {
+	vr := &bgp.VPNRoute{Family: fam}
+	if vpn, ok := p.Nlri.(*gobgppkt.LabeledVPNIPAddrPrefix); ok {
+		vr.Prefix = vpn.Prefix.String()
+		if vpn.RD != nil {
+			vr.RD = vpn.RD.String()
+		}
+	} else if p.Nlri != nil {
+		// Unexpected NLRI shape: keep the generic rendering rather than
+		// dropping the route silently so the anomaly is still visible.
+		vr.Prefix = p.Nlri.String()
+	}
+	vr.SRv6SID = decodeSRv6SID(p.Attrs)
+	vr.RTs = decodeRouteTargets(p.Attrs)
+	vr.NextHop = decodeNextHop(p.Attrs)
+	return vr
+}
+
+// decodeSRv6SID walks the BGP Prefix-SID attribute (RFC 9252) and
+// returns the first SRv6 service SID, rendered as an IPv6 string. An
+// empty result means the path carried no SRv6 SID.
+func decodeSRv6SID(attrs []gobgppkt.PathAttributeInterface) string {
+	for _, a := range attrs {
+		psid, ok := a.(*gobgppkt.PathAttributePrefixSID)
+		if !ok {
+			continue
+		}
+		for _, tlv := range psid.TLVs {
+			svc, ok := tlv.(*gobgppkt.SRv6ServiceTLV)
+			if !ok {
+				continue
+			}
+			for _, st := range svc.SubTLVs {
+				info, ok := st.(*gobgppkt.SRv6InformationSubTLV)
+				if !ok {
+					continue
+				}
+				if sid, ok := netip.AddrFromSlice(info.SID); ok {
+					return sid.String()
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// decodeRouteTargets returns every route-target extended community on
+// the path, each rendered "as:admin" (e.g. "65000:100"). Non-RT
+// communities (Site-of-Origin etc.) share the same wire types and are
+// distinguished by sub-type.
+func decodeRouteTargets(attrs []gobgppkt.PathAttributeInterface) []string {
+	var rts []string
+	for _, a := range attrs {
+		ec, ok := a.(*gobgppkt.PathAttributeExtendedCommunities)
+		if !ok {
+			continue
+		}
+		for _, c := range ec.Value {
+			if _, sub := c.GetTypes(); sub == gobgppkt.EC_SUBTYPE_ROUTE_TARGET {
+				rts = append(rts, c.String())
+			}
+		}
+	}
+	return rts
+}
+
+// decodeNextHop returns the path's next hop. VPN families carry it in
+// MP_REACH_NLRI; plain IPv4 unicast uses the legacy NEXT_HOP attribute.
+func decodeNextHop(attrs []gobgppkt.PathAttributeInterface) string {
+	for _, a := range attrs {
+		switch attr := a.(type) {
+		case *gobgppkt.PathAttributeMpReachNLRI:
+			if attr.Nexthop.IsValid() {
+				return attr.Nexthop.String()
+			}
+		case *gobgppkt.PathAttributeNextHop:
+			if attr.Value.IsValid() {
+				return attr.Value.String()
+			}
+		}
+	}
+	return ""
+}
+
+// nlriString renders an NLRI, tolerating a nil interface value.
+func nlriString(n gobgppkt.NLRI) string {
+	if n == nil {
+		return ""
+	}
+	return n.String()
+}

--- a/pkg/bgp/gobgp/decode_test.go
+++ b/pkg/bgp/gobgp/decode_test.go
@@ -1,0 +1,85 @@
+package gobgp
+
+import (
+	"net/netip"
+	"testing"
+
+	gobgppkt "github.com/osrg/gobgp/v4/pkg/packet/bgp"
+)
+
+func TestDecodeSRv6SID(t *testing.T) {
+	sid := netip.MustParseAddr("fd00:1:1::100")
+	psid := &gobgppkt.PathAttributePrefixSID{
+		TLVs: []gobgppkt.PrefixSIDTLVInterface{
+			&gobgppkt.SRv6ServiceTLV{
+				SubTLVs: []gobgppkt.PrefixSIDTLVInterface{
+					&gobgppkt.SRv6InformationSubTLV{SID: sid.AsSlice()},
+				},
+			},
+		},
+	}
+	got := decodeSRv6SID([]gobgppkt.PathAttributeInterface{psid})
+	if got != sid.String() {
+		t.Errorf("decodeSRv6SID = %q, want %q", got, sid.String())
+	}
+}
+
+func TestDecodeSRv6SID_AbsentAttribute(t *testing.T) {
+	// A path with no Prefix-SID attribute yields an empty SID.
+	if got := decodeSRv6SID(nil); got != "" {
+		t.Errorf("decodeSRv6SID(nil) = %q, want empty", got)
+	}
+}
+
+func TestDecodeRouteTargets(t *testing.T) {
+	rt := gobgppkt.NewTwoOctetAsSpecificExtended(
+		gobgppkt.EC_SUBTYPE_ROUTE_TARGET, 65000, 100, true)
+	// A Site-of-Origin community shares the wire type but must not be
+	// reported as an RT.
+	soo := gobgppkt.NewTwoOctetAsSpecificExtended(
+		gobgppkt.EC_SUBTYPE_ROUTE_ORIGIN, 65000, 999, true)
+	ec := &gobgppkt.PathAttributeExtendedCommunities{
+		Value: []gobgppkt.ExtendedCommunityInterface{rt, soo},
+	}
+	got := decodeRouteTargets([]gobgppkt.PathAttributeInterface{ec})
+	if len(got) != 1 {
+		t.Fatalf("decodeRouteTargets returned %v, want exactly one RT", got)
+	}
+	if got[0] != "65000:100" {
+		t.Errorf("RT = %q, want 65000:100", got[0])
+	}
+}
+
+func TestDecodeRouteTargets_None(t *testing.T) {
+	if got := decodeRouteTargets(nil); got != nil {
+		t.Errorf("decodeRouteTargets(nil) = %v, want nil", got)
+	}
+}
+
+func TestDecodeNextHop(t *testing.T) {
+	t.Run("mp-reach", func(t *testing.T) {
+		nh := netip.MustParseAddr("2001:db8::1")
+		mp := &gobgppkt.PathAttributeMpReachNLRI{Nexthop: nh}
+		if got := decodeNextHop([]gobgppkt.PathAttributeInterface{mp}); got != nh.String() {
+			t.Errorf("decodeNextHop (mp-reach) = %q, want %q", got, nh.String())
+		}
+	})
+	t.Run("legacy-next-hop", func(t *testing.T) {
+		nh := netip.MustParseAddr("10.0.0.1")
+		attr := &gobgppkt.PathAttributeNextHop{Value: nh}
+		if got := decodeNextHop([]gobgppkt.PathAttributeInterface{attr}); got != nh.String() {
+			t.Errorf("decodeNextHop (legacy) = %q, want %q", got, nh.String())
+		}
+	})
+	t.Run("absent", func(t *testing.T) {
+		if got := decodeNextHop(nil); got != "" {
+			t.Errorf("decodeNextHop(nil) = %q, want empty", got)
+		}
+	})
+}
+
+func TestNlriString_Nil(t *testing.T) {
+	if got := nlriString(nil); got != "" {
+		t.Errorf("nlriString(nil) = %q, want empty", got)
+	}
+}

--- a/pkg/bgp/gobgp/subscriber.go
+++ b/pkg/bgp/gobgp/subscriber.go
@@ -52,23 +52,22 @@ func (s *Session) Subscribe(filter bgp.Family, handler bgp.RouteHandler) (func()
 }
 
 // pathToRouteEvent converts a gobgp received Path into a Vinbero
-// RouteEvent. Phase 1d-b fills in only family / prefix / withdraw; the
-// SRv6 service SID and RD/RT decode lands in Phase 1d-c.
+// RouteEvent. VPN families are fully decoded (RD / prefix / SRv6 SID /
+// route targets / next hop); IPv6 unicast carries prefix and next hop.
 func pathToRouteEvent(p *apiutil.Path) (bgp.RouteEvent, bool) {
 	fam, ok := apiFamilyToVinbero(p.Family)
 	if !ok {
 		return bgp.RouteEvent{}, false
 	}
-	var prefix string
-	if p.Nlri != nil {
-		prefix = p.Nlri.String()
-	}
 	ev := bgp.RouteEvent{Family: fam, IsWithdraw: p.Withdrawal}
 	switch fam {
 	case bgp.FamilyVPNv4, bgp.FamilyVPNv6:
-		ev.VPN = &bgp.VPNRoute{Family: fam, Prefix: prefix}
+		ev.VPN = decodeVPNRoute(p, fam)
 	case bgp.FamilyIPv6Unicast:
-		ev.Unicast = &bgp.UnicastRoute{Prefix: prefix}
+		ev.Unicast = &bgp.UnicastRoute{
+			Prefix:  nlriString(p.Nlri),
+			NextHop: decodeNextHop(p.Attrs),
+		}
 	}
 	return ev, true
 }


### PR DESCRIPTION
## Summary
- Third sub-PR of **Phase 1d**. **Stacked on #35** (1d-b); base branch is \`feat/bgp-route-subscriber\`.
- Received VPNv4 / VPNv6 paths are now fully decoded into \`bgp.VPNRoute\`:
  - **decodeSRv6SID** walks the BGP Prefix-SID attribute (RFC 9252): \`PathAttributePrefixSID\` → \`SRv6ServiceTLV\` → \`SRv6InformationSubTLV\`, returning the 16-byte service SID.
  - **decodeRouteTargets** pulls route-target extended communities, skipping Site-of-Origin and other communities that share the wire type (distinguished by sub-type).
  - **decodeNextHop** reads MP_REACH_NLRI (VPN families) or the legacy NEXT_HOP attribute (IPv4 unicast).
  - **decodeVPNRoute** assembles RD + prefix from the \`LabeledVPNIPAddrPrefix\` NLRI and stitches the above together.
- \`pathToRouteEvent\` now emits a complete \`VPNRoute\` instead of just family + prefix.

## Scope
This sub-PR only **decodes**. Turning a \`VPNRoute\` into a \`headend_v4/v6_map\` entry (via \`CreateHeadendV4/V6\`, with the encap source from a locator) is **Phase 1d-d**.

| sub-PR | content | status |
|---|---|---|
| 1d-a | \`pkg/fib\` kernel FIB injector | #34 |
| 1d-b | \`RouteSubscriber\` — WatchEvent bridge | #35 |
| **1d-c** (this) | SRv6 SID / RD / RT decode | — |
| 1d-d | VPNRoute → headend map write | next |
| 1d-e | \`VrfBgpService\` — RT ↔ VRF binding | |
| 1d-f | E2E test | |

## Test plan
- [x] \`make lint\` (0 issues), \`make build\`
- [x] \`go test ./pkg/bgp/...\` — decodeSRv6SID (present / absent), decodeRouteTargets (RT vs SoO discrimination), decodeNextHop (mp-reach / legacy / absent)