### PR TITLE
feat(bgp): implement RouteAdvertiser for VPN / unicast routes (Phase 1e-a)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/cilium/ebpf v0.20.0
 	github.com/google/gopacket v1.1.19
+	github.com/google/uuid v1.6.0
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/osrg/gobgp/v4 v4.5.0
 	github.com/pkg/errors v0.9.1
@@ -28,7 +29,6 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/gaissmai/bart v0.26.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/k-sone/critbitgo v1.4.0 // indirect
 	github.com/orcaman/concurrent-map/v2 v2.0.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect

--- a/pkg/bgp/gobgp/advertise.go
+++ b/pkg/bgp/gobgp/advertise.go
@@ -1,0 +1,185 @@
+package gobgp
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+
+	"github.com/google/uuid"
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
+	gobgppkt "github.com/osrg/gobgp/v4/pkg/packet/bgp"
+
+	"github.com/takehaya/vinbero/pkg/bgp"
+)
+
+// Advertise injects a VPNv4 / VPNv6 route carrying an SRv6 service SID
+// into the BGP RIB. The gobgp path UUID is recorded so a later Withdraw
+// can remove that exact path.
+func (s *Session) Advertise(_ context.Context, r bgp.VPNRoute) error {
+	if s.server == nil {
+		return bgp.ErrSessionNotStarted
+	}
+	path, err := encodeVPNPath(r)
+	if err != nil {
+		return err
+	}
+	return s.addAndTrack(path, bgp.RouteKey{Family: r.Family, Prefix: r.Prefix, RD: r.RD})
+}
+
+// AdvertiseUnicast injects an IPv6 unicast route.
+func (s *Session) AdvertiseUnicast(_ context.Context, r bgp.UnicastRoute) error {
+	if s.server == nil {
+		return bgp.ErrSessionNotStarted
+	}
+	path, err := encodeUnicastPath(r)
+	if err != nil {
+		return err
+	}
+	return s.addAndTrack(path, bgp.RouteKey{Family: bgp.FamilyIPv6Unicast, Prefix: r.Prefix})
+}
+
+// Withdraw removes a previously advertised route. Withdrawing a route
+// that was never advertised is a no-op so callers can withdraw
+// idempotently.
+func (s *Session) Withdraw(_ context.Context, key bgp.RouteKey) error {
+	if s.server == nil {
+		return bgp.ErrSessionNotStarted
+	}
+	s.advMu.Lock()
+	id, ok := s.advertised[key]
+	if ok {
+		delete(s.advertised, key)
+	}
+	s.advMu.Unlock()
+	if !ok {
+		return nil
+	}
+	if err := s.server.DeletePath(apiutil.DeletePathRequest{UUIDs: []uuid.UUID{id}}); err != nil {
+		return fmt.Errorf("withdraw %s: %w", key.Prefix, err)
+	}
+	return nil
+}
+
+// addAndTrack adds path to the RIB and records its UUID under key so
+// Withdraw can later delete exactly this path.
+func (s *Session) addAndTrack(path *apiutil.Path, key bgp.RouteKey) error {
+	resps, err := s.server.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{path}})
+	if err != nil {
+		return fmt.Errorf("advertise %s: %w", key.Prefix, err)
+	}
+	if len(resps) == 0 {
+		return fmt.Errorf("advertise %s: gobgp returned no response", key.Prefix)
+	}
+	if resps[0].Error != nil {
+		return fmt.Errorf("advertise %s: %w", key.Prefix, resps[0].Error)
+	}
+	s.advMu.Lock()
+	s.advertised[key] = resps[0].UUID
+	s.advMu.Unlock()
+	return nil
+}
+
+// vinberoFamilyToAPI maps a Vinbero Family to a gobgp route family. It
+// is the inverse of apiFamilyToVinbero.
+func vinberoFamilyToAPI(f bgp.Family) (gobgppkt.Family, error) {
+	switch f {
+	case bgp.FamilyVPNv4:
+		return gobgppkt.RF_IPv4_VPN, nil
+	case bgp.FamilyVPNv6:
+		return gobgppkt.RF_IPv6_VPN, nil
+	case bgp.FamilyIPv6Unicast:
+		return gobgppkt.RF_IPv6_UC, nil
+	case bgp.FamilySRPolicyIPv6:
+		return gobgppkt.RF_SR_POLICY_IPv6, nil
+	default:
+		return 0, fmt.Errorf("unsupported BGP family %q", f)
+	}
+}
+
+// vpnEndpointBehavior is the SRv6 endpoint behavior advertised with a
+// VPN route: End.DT4 for VPNv4, End.DT6 for VPNv6.
+func vpnEndpointBehavior(f bgp.Family) gobgppkt.SRBehavior {
+	if f == bgp.FamilyVPNv6 {
+		return gobgppkt.END_DT6
+	}
+	return gobgppkt.END_DT4
+}
+
+// encodeVPNPath builds the gobgp Path for a VPNv4 / VPNv6 advertisement.
+// It is the inverse of decodeVPNRoute.
+func encodeVPNPath(r bgp.VPNRoute) (*apiutil.Path, error) {
+	family, err := vinberoFamilyToAPI(r.Family)
+	if err != nil {
+		return nil, err
+	}
+	rd, err := gobgppkt.ParseRouteDistinguisher(r.RD)
+	if err != nil {
+		return nil, fmt.Errorf("parse RD %q: %w", r.RD, err)
+	}
+	prefix, err := netip.ParsePrefix(r.Prefix)
+	if err != nil {
+		return nil, fmt.Errorf("parse prefix %q: %w", r.Prefix, err)
+	}
+	nlri, err := gobgppkt.NewLabeledVPNIPAddrPrefix(prefix, *gobgppkt.NewMPLSLabelStack(0), rd)
+	if err != nil {
+		return nil, fmt.Errorf("build VPN NLRI: %w", err)
+	}
+	attrs := []gobgppkt.PathAttributeInterface{gobgppkt.NewPathAttributeOrigin(0)}
+	if len(r.RTs) > 0 {
+		ecs := make([]gobgppkt.ExtendedCommunityInterface, 0, len(r.RTs))
+		for _, rt := range r.RTs {
+			ec, err := gobgppkt.ParseRouteTarget(rt)
+			if err != nil {
+				return nil, fmt.Errorf("parse RT %q: %w", rt, err)
+			}
+			ecs = append(ecs, ec)
+		}
+		attrs = append(attrs, gobgppkt.NewPathAttributeExtendedCommunities(ecs))
+	}
+	if r.SRv6SID != "" {
+		sid, err := netip.ParseAddr(r.SRv6SID)
+		if err != nil {
+			return nil, fmt.Errorf("parse SRv6 SID %q: %w", r.SRv6SID, err)
+		}
+		infoSubTLV := gobgppkt.NewSRv6InformationSubTLV(sid, vpnEndpointBehavior(r.Family))
+		svcTLV := gobgppkt.NewSRv6ServiceTLV(gobgppkt.TLVTypeSRv6L3Service, infoSubTLV)
+		attrs = append(attrs, gobgppkt.NewPathAttributePrefixSID(svcTLV))
+	}
+	nh, err := netip.ParseAddr(r.NextHop)
+	if err != nil {
+		return nil, fmt.Errorf("parse nexthop %q: %w", r.NextHop, err)
+	}
+	mpReach, err := gobgppkt.NewPathAttributeMpReachNLRI(family, []gobgppkt.PathNLRI{{NLRI: nlri}}, nh)
+	if err != nil {
+		return nil, fmt.Errorf("build MP_REACH_NLRI: %w", err)
+	}
+	attrs = append(attrs, mpReach)
+	return &apiutil.Path{Family: family, Nlri: nlri, Attrs: attrs}, nil
+}
+
+// encodeUnicastPath builds the gobgp Path for an IPv6 unicast
+// advertisement.
+func encodeUnicastPath(r bgp.UnicastRoute) (*apiutil.Path, error) {
+	prefix, err := netip.ParsePrefix(r.Prefix)
+	if err != nil {
+		return nil, fmt.Errorf("parse prefix %q: %w", r.Prefix, err)
+	}
+	nlri, err := gobgppkt.NewIPAddrPrefix(prefix)
+	if err != nil {
+		return nil, fmt.Errorf("build IPv6 NLRI: %w", err)
+	}
+	nh, err := netip.ParseAddr(r.NextHop)
+	if err != nil {
+		return nil, fmt.Errorf("parse nexthop %q: %w", r.NextHop, err)
+	}
+	mpReach, err := gobgppkt.NewPathAttributeMpReachNLRI(
+		gobgppkt.RF_IPv6_UC, []gobgppkt.PathNLRI{{NLRI: nlri}}, nh)
+	if err != nil {
+		return nil, fmt.Errorf("build MP_REACH_NLRI: %w", err)
+	}
+	return &apiutil.Path{
+		Family: gobgppkt.RF_IPv6_UC,
+		Nlri:   nlri,
+		Attrs:  []gobgppkt.PathAttributeInterface{gobgppkt.NewPathAttributeOrigin(0), mpReach},
+	}, nil
+}

--- a/pkg/bgp/gobgp/advertise_test.go
+++ b/pkg/bgp/gobgp/advertise_test.go
@@ -1,0 +1,135 @@
+package gobgp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	gobgppkt "github.com/osrg/gobgp/v4/pkg/packet/bgp"
+
+	"github.com/takehaya/vinbero/pkg/bgp"
+)
+
+// TestEncodeVPNPath_RoundTrip is the core symmetry check: a VPNRoute
+// encoded for advertisement must decode back to the same fields, so the
+// advertise and receive paths agree on the wire representation.
+func TestEncodeVPNPath_RoundTrip(t *testing.T) {
+	want := bgp.VPNRoute{
+		Family:  bgp.FamilyVPNv4,
+		Prefix:  "10.0.0.0/24",
+		RD:      "65000:100",
+		RTs:     []string{"65000:100"},
+		SRv6SID: "fd00:1:1:a::",
+		NextHop: "2001:db8::1",
+	}
+	path, err := encodeVPNPath(want)
+	if err != nil {
+		t.Fatalf("encodeVPNPath: %v", err)
+	}
+	got := decodeVPNRoute(path, bgp.FamilyVPNv4)
+	if got.Prefix != want.Prefix {
+		t.Errorf("Prefix round-trip: got %q, want %q", got.Prefix, want.Prefix)
+	}
+	if got.RD != want.RD {
+		t.Errorf("RD round-trip: got %q, want %q", got.RD, want.RD)
+	}
+	if got.SRv6SID != want.SRv6SID {
+		t.Errorf("SRv6SID round-trip: got %q, want %q", got.SRv6SID, want.SRv6SID)
+	}
+	if got.NextHop != want.NextHop {
+		t.Errorf("NextHop round-trip: got %q, want %q", got.NextHop, want.NextHop)
+	}
+	if len(got.RTs) != 1 || got.RTs[0] != "65000:100" {
+		t.Errorf("RTs round-trip: got %v, want [65000:100]", got.RTs)
+	}
+}
+
+func TestEncodeVPNPath_VPNv6Behavior(t *testing.T) {
+	// VPNv6 must advertise End.DT6, VPNv4 End.DT4.
+	if got := vpnEndpointBehavior(bgp.FamilyVPNv6); got != gobgppkt.END_DT6 {
+		t.Errorf("VPNv6 behavior = %v, want END_DT6", got)
+	}
+	if got := vpnEndpointBehavior(bgp.FamilyVPNv4); got != gobgppkt.END_DT4 {
+		t.Errorf("VPNv4 behavior = %v, want END_DT4", got)
+	}
+}
+
+func TestEncodeUnicastPath(t *testing.T) {
+	path, err := encodeUnicastPath(bgp.UnicastRoute{
+		Prefix: "2001:db8:dead::/64", NextHop: "fd00:f1b::2",
+	})
+	if err != nil {
+		t.Fatalf("encodeUnicastPath: %v", err)
+	}
+	if path.Family != gobgppkt.RF_IPv6_UC {
+		t.Errorf("family = %v, want RF_IPv6_UC", path.Family)
+	}
+	if got := decodeNextHop(path.Attrs); got != "fd00:f1b::2" {
+		t.Errorf("encoded nexthop = %q, want fd00:f1b::2", got)
+	}
+}
+
+func TestVinberoFamilyToAPI(t *testing.T) {
+	tests := []struct {
+		in   bgp.Family
+		want gobgppkt.Family
+	}{
+		{bgp.FamilyVPNv4, gobgppkt.RF_IPv4_VPN},
+		{bgp.FamilyVPNv6, gobgppkt.RF_IPv6_VPN},
+		{bgp.FamilyIPv6Unicast, gobgppkt.RF_IPv6_UC},
+		{bgp.FamilySRPolicyIPv6, gobgppkt.RF_SR_POLICY_IPv6},
+	}
+	for _, tc := range tests {
+		got, err := vinberoFamilyToAPI(tc.in)
+		if err != nil || got != tc.want {
+			t.Errorf("vinberoFamilyToAPI(%q) = (%v,%v), want (%v,nil)", tc.in, got, err, tc.want)
+		}
+	}
+	if _, err := vinberoFamilyToAPI(bgp.Family("bogus")); err == nil {
+		t.Error("vinberoFamilyToAPI of an unknown family should error")
+	}
+}
+
+func TestAdvertise_BeforeStartRejected(t *testing.T) {
+	s := newTestSession(t)
+	err := s.Advertise(context.Background(), bgp.VPNRoute{
+		Family: bgp.FamilyVPNv4, Prefix: "10.0.0.0/24", RD: "65000:1", NextHop: "2001:db8::1",
+	})
+	if !errors.Is(err, bgp.ErrSessionNotStarted) {
+		t.Errorf("Advertise before Start: got %v, want ErrSessionNotStarted", err)
+	}
+}
+
+// TestAdvertiseWithdraw drives a real in-process BgpServer: Advertise
+// installs the path into the local RIB (no peer needed), Withdraw
+// removes it, and a second Withdraw is a no-op.
+func TestAdvertiseWithdraw(t *testing.T) {
+	s := newTestSession(t)
+	startTestSession(t, s)
+
+	vr := bgp.VPNRoute{
+		Family: bgp.FamilyVPNv4, Prefix: "10.0.0.0/24", RD: "65000:100",
+		RTs: []string{"65000:100"}, SRv6SID: "fd00:1:1:a::", NextHop: "2001:db8::1",
+	}
+	if err := s.Advertise(context.Background(), vr); err != nil {
+		t.Fatalf("Advertise: %v", err)
+	}
+	key := bgp.RouteKey{Family: bgp.FamilyVPNv4, Prefix: "10.0.0.0/24", RD: "65000:100"}
+	if err := s.Withdraw(context.Background(), key); err != nil {
+		t.Fatalf("Withdraw: %v", err)
+	}
+	// A previously-withdrawn (or never-advertised) route withdraws as a no-op.
+	if err := s.Withdraw(context.Background(), key); err != nil {
+		t.Errorf("second Withdraw should be a no-op, got %v", err)
+	}
+}
+
+func TestAdvertiseUnicast(t *testing.T) {
+	s := newTestSession(t)
+	startTestSession(t, s)
+	if err := s.AdvertiseUnicast(context.Background(), bgp.UnicastRoute{
+		Prefix: "2001:db8:dead::/64", NextHop: "fd00:f1b::2",
+	}); err != nil {
+		t.Fatalf("AdvertiseUnicast: %v", err)
+	}
+}

--- a/pkg/bgp/gobgp/session.go
+++ b/pkg/bgp/gobgp/session.go
@@ -12,7 +12,9 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
+	"github.com/google/uuid"
 	gobgpapi "github.com/osrg/gobgp/v4/api"
 	gobgpsrv "github.com/osrg/gobgp/v4/pkg/server"
 	"go.uber.org/zap"
@@ -23,17 +25,31 @@ import (
 // Session is the GoBGP-backed bgp.Session. A zero Session is not
 // usable; construct one with NewSession. Start / Stop are not safe for
 // concurrent use -- the daemon drives them from a single goroutine.
+//
+// It also satisfies bgp.RouteAdvertiser; advertised tracks the gobgp
+// path UUID for each advertised route so Withdraw can delete the exact
+// path. advMu guards that map since advertise / withdraw can be driven
+// from concurrent RPC handlers.
 type Session struct {
 	logger *zap.Logger
 	server *gobgpsrv.BgpServer
+
+	advMu      sync.Mutex
+	advertised map[bgp.RouteKey]uuid.UUID
 }
 
-// compile-time assertion that *Session satisfies the interface.
-var _ bgp.Session = (*Session)(nil)
+// compile-time assertions for the interfaces *Session satisfies.
+var (
+	_ bgp.Session         = (*Session)(nil)
+	_ bgp.RouteAdvertiser = (*Session)(nil)
+)
 
 // NewSession returns an unstarted Session.
 func NewSession(logger *zap.Logger) *Session {
-	return &Session{logger: logger.Named("bgp.gobgp")}
+	return &Session{
+		logger:     logger.Named("bgp.gobgp"),
+		advertised: make(map[bgp.RouteKey]uuid.UUID),
+	}
 }
 
 // Start brings up the in-process BgpServer and runs the OPEN handshake


### PR DESCRIPTION
## Summary
First sub-PR of **Phase 1e** (the advertise direction). **Stacked on #37** (Phase 1d); base branch is \`feat/bgp-vpn-receive\`.

\`gobgp.Session\` now also satisfies \`bgp.RouteAdvertiser\`:
- **Advertise** injects a VPNv4/VPNv6 route with an SRv6 service SID. \`encodeVPNPath\` is the inverse of Phase 1d-c's \`decodeVPNRoute\`: it builds the VPN NLRI, the Prefix-SID attribute (End.DT4 for VPNv4 / End.DT6 for VPNv6), route targets, and MP_REACH_NLRI.
- **AdvertiseUnicast** injects an IPv6 unicast route.
- **Withdraw** deletes the exact path by the gobgp UUID recorded at advertise time; withdrawing a never-advertised route is a no-op.

The Session tracks advertised path UUIDs under a \`RouteKey\` (family / prefix / RD) behind a mutex, since advertise / withdraw can be driven from concurrent RPC handlers.

## Scope
This sub-PR delivers only the \`RouteAdvertiser\` mechanism. Wiring RPC-created entries to it (via a \`bgp_advertise\` proto field) is **1e-b**; SR Policy is **1e-c**.

| sub-PR | content | status |
|---|---|---|
| **1e-a** (this) | \`RouteAdvertiser\` — Advertise / Withdraw | — |
| 1e-b | \`bgp_advertise\` field + RPC handler wiring | next |
| 1e-c | SR Policy receive / advertise | |

SID Structure sub-sub-TLV encoding is intentionally omitted to stay symmetric with the 1d-c decoder (which does not read it); it lands in Phase 2 with uSID.

## Test plan
- [x] \`make lint\` (0 issues), \`make build\`
- [x] \`go test -exec sudo ./pkg/bgp/...\` — encodeVPNPath ↔ decodeVPNRoute round-trip, VPNv4/v6 End.DT4/DT6 behavior, vinberoFamilyToAPI, Advertise-before-start rejection, Advertise/Withdraw against a real in-process BgpServer, double-withdraw no-op

## Dependency
Adds \`github.com/google/uuid\` as a direct dependency (path UUID tracking).