### PR TITLE
docs(loadmap): mark EVPN (RT2/3/4) as Supported

### DIFF
--- a/docs/loadmap.md
+++ b/docs/loadmap.md
@@ -89,8 +89,9 @@
 ### BGP control plane (SRv6 services)
 
 In-process GoBGP speaker for exchanging SRv6 service routes (RFC 9252).
-VPNv4/VPNv6 (L3) is implemented and installs SRv6 H.Encaps headend
-entries; EVPN (L2VPN) is on the roadmap below.
+VPNv4/VPNv6 (L3) installs SRv6 H.Encaps headend entries, and EVPN (L2VPN)
+bridges L2 over SRv6 with multi-homing; see the table below for the full
+status.
 
 | Function                   | Status    | Description                                              | Reference |
 |----------------------------|-----------|----------------------------------------------------------|-----------|
@@ -102,4 +103,4 @@ entries; EVPN (L2VPN) is on the roadmap below.
 | SR Policy (SAFI 73)        | Supported | Color-based steering (control + data plane)              | RFC 9256 |
 | BGP MUP                    |           | Mobile User Plane route exchange via the MUP SAFI        | draft-mpmz-bess-mup-safi |
 | Automatic advertise        |           | Advertise local SID/headend state without operator RPC   | RFC 9252 |
-| EVPN (RT2/3/4)             |           | L2VPN over BGP EVPN (MAC/IP, Inclusive Multicast, ESI)   | RFC 9252 |
+| EVPN (RT2/3/4)             | Supported | L2VPN over BGP EVPN: RT2 MAC/IP, RT3 Inclusive Multicast, RT4 Ethernet Segment + RFC 8584 DF election / Local-Bias split-horizon (multi-homing). IRB (RT2 L3) and RT5 not yet supported | RFC 9252 / 7432 / 8584 |


### PR DESCRIPTION
# What
- [x] Flip the loadmap EVPN row from roadmap-only to **Supported**
- [x] Note the remaining gaps (IRB / RT2 L3, and RT5 are not yet supported)
- [x] Update the intro paragraph that still said EVPN was "on the roadmap below"

# Why
EVPN over SRv6 — RT2 MAC/IP, RT3 Inclusive Multicast, RT4 Ethernet Segment with RFC 8584 DF election and Local-Bias split-horizon (multi-homing) — was merged in #44, but `docs/loadmap.md` still listed EVPN as roadmap-only. The doc was stale; this corrects the status to match what is actually in `main`.

# How
Doc-only change to `docs/loadmap.md`. The EVPN row now reads Supported and the Description spells out the supported route types plus the deferred IRB (RT2 L3) and RT5. References updated to RFC 9252 / 7432 / 8584.

This is intentionally separate from the in-flight SRv6 MUP branch (#45) since it is an independent doc-accuracy fix for an already-merged feature.

# Merge criteria
- [ ] Maintainer review (@takehaya)