### PR TITLE
fix(gobgp): bound Session.Stop() so a wedged gobgp teardown can't hang

### DIFF
--- a/pkg/bgp/gobgp/session.go
+++ b/pkg/bgp/gobgp/session.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	gobgpapi "github.com/osrg/gobgp/v4/api"
@@ -108,11 +109,22 @@ func (s *Session) Start(ctx context.Context, cfg bgp.GlobalConfig) error {
 	return nil
 }
 
-// Stop tears the session down. It is safe to call on a Session that was
-// never started (no-op) so callers can defer it unconditionally. Even
-// when StopBgp errors, the Serve() goroutine is still reaped and the
-// handle cleared so the Session does not wedge -- the StopBgp error is
-// returned afterwards for the caller to log.
+// stopTimeout bounds the graceful gobgp teardown. gobgp's StopBgp and Stop both
+// funnel through a single management channel served by one goroutine, and the
+// caller blocks on an unbuffered channel receive with no ctx escape
+// (mgmtOperation). If that goroutine is wedged -- e.g. a shutdown race where the
+// Serve loop is mid-delivery of a peer-down/withdraw event to a watcher whose
+// reader has just been canceled -- the call never returns. This timeout keeps a
+// deferred Stop() (in tests and in daemon shutdown) from hanging the caller
+// indefinitely; the wedged gobgp goroutine is abandoned, which is acceptable on
+// the one-shot shutdown path where the process exits and reaps it.
+const stopTimeout = 10 * time.Second
+
+// Stop tears the session down. It is safe to call on a Session that was never
+// started (no-op) so callers can defer it unconditionally, and it always clears
+// the handle so the Session does not wedge. The graceful gobgp teardown is
+// bounded by stopTimeout (and by ctx): if gobgp does not return in time, Stop
+// abandons it and returns an error for the caller to log rather than blocking.
 func (s *Session) Stop(ctx context.Context) error {
 	if s.server == nil {
 		return nil
@@ -121,13 +133,34 @@ func (s *Session) Stop(ctx context.Context) error {
 	srv := s.server
 	s.server = nil
 	s.srvMu.Unlock()
-	stopErr := srv.StopBgp(ctx, &gobgpapi.StopBgpRequest{})
-	srv.Stop()
-	s.logger.Info("BGP session stopped")
-	if stopErr != nil {
-		return fmt.Errorf("stop bgp: %w", stopErr)
+
+	// Run the graceful stop off the caller's goroutine so a wedged gobgp
+	// management loop cannot hang us. StopBgp cancels the Serve context; the
+	// subsequent Stop() is gobgp's hard stop (its internal StopBgp then returns
+	// immediately with "not running").
+	done := make(chan error, 1)
+	go func() {
+		err := srv.StopBgp(ctx, &gobgpapi.StopBgpRequest{})
+		srv.Stop()
+		done <- err
+	}()
+
+	select {
+	case stopErr := <-done:
+		s.logger.Info("BGP session stopped")
+		if stopErr != nil {
+			return fmt.Errorf("stop bgp: %w", stopErr)
+		}
+		return nil
+	case <-ctx.Done():
+		s.logger.Warn("BGP session stop canceled by context; abandoning gobgp teardown",
+			zap.Error(ctx.Err()))
+		return fmt.Errorf("stop bgp: %w", ctx.Err())
+	case <-time.After(stopTimeout):
+		s.logger.Warn("BGP session stop timed out; abandoning gobgp teardown",
+			zap.Duration("timeout", stopTimeout))
+		return fmt.Errorf("stop bgp: timed out after %s", stopTimeout)
 	}
-	return nil
 }
 
 // AddPeer configures a neighbor. The peer starts the FSM immediately;


### PR DESCRIPTION
# What
- [x] Bound the graceful gobgp teardown in `Session.Stop()` with a 10s timeout (and the caller's ctx)
- [x] Run `StopBgp` + `Stop` off the caller's goroutine so a wedged management loop cannot block the caller
- [x] Verified the happy path is unaffected (gobgp e2e suite passes locally, ~16s)

# Why
The unit-test CI flake on `TestE2E_VPNv4RouteToHeadendMap` (10-minute timeout) traces to gobgp internals, not Vinbero logic. gobgp's `StopBgp` and `Stop` both funnel through one management channel served by a single goroutine; `mgmtOperation` queues the op and then blocks on an **unbuffered channel receive with no ctx escape**:

```go
select {
case s.mgmtCh <- op:
    return <-ch        // waits forever for the Serve loop to reply
case <-s.closeCh:
    return fmt.Errorf("server stopped")
}
```

If the Serve loop is wedged — a shutdown race where it is mid-delivery of a peer-down/withdraw event to a watcher whose reader was just canceled (the test's `cancelSub` runs just before `pe2.Stop()`) — the op is never serviced and `StopBgp` never returns. The test body passes; only the deferred `pe2.Stop()` in cleanup hangs, until the 10m test timeout. It reproduces only under CI load (locally the teardown finishes in ~3s), which is why it presents as a flake.

# How
`Session.Stop()` now runs `srv.StopBgp(...)` + `srv.Stop()` in a goroutine and `select`s on completion vs the caller's `ctx` vs a 10s `stopTimeout`. On timeout it logs a warning and returns an error instead of blocking; the wedged gobgp goroutine is abandoned, which is fine on the one-shot shutdown path (the process exits and reaps it). This also hardens daemon graceful-shutdown against the same wedge.

Local verification: `go test -exec sudo -run 'TestE2E|TestNetnsE2E' ./pkg/bgp/gobgp` passes (run twice). The flake can't be reproduced locally, so this bounds the failure mode rather than reproducing it; the mechanism is confirmed from the gobgp source (`mgmtOperation`).

This is independent of the in-flight SRv6 MUP branch (#45); it touches `Session.Stop()`, a pre-existing function, so once merged all PRs (including #45 after rebase) stop hitting the flake.

# Merge criteria
- [ ] Maintainer review (@takehaya)