### PR TITLE
feat(bgp): VRF-export driven automatic advertise (Phase 2a/2b)

### DIFF
--- a/.github/workflows/interop-clab.yaml
+++ b/.github/workflows/interop-clab.yaml
@@ -41,6 +41,7 @@ jobs:
       matrix:
         scenario:
           - l3vpn-2site          # SRv6 L3VPN (transposition)
+          - l3vpn-2site-auto     # SRv6 L3VPN via VRF-export auto-advertise (no vbctl)
           - sr-policy-2site      # color-based SR Policy steering (local + multi-hop chain)
           - sr-policy-bgp-2site  # SR Policy learned over BGP (SAFI 73)
           - evpn-2site           # EVPN RT2 (MAC/IP) L2VPN over BGP (SAFI 70)

--- a/cmd/vinberod/main.go
+++ b/cmd/vinberod/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/takehaya/vinbero/pkg/bgp"
 	"github.com/takehaya/vinbero/pkg/bgp/apply"
+	"github.com/takehaya/vinbero/pkg/bgp/export"
 	"github.com/takehaya/vinbero/pkg/bgp/gobgp"
 	"github.com/takehaya/vinbero/pkg/config"
 	"github.com/takehaya/vinbero/pkg/fib"
@@ -135,6 +136,9 @@ func run(cliCtx *cli.Context) error {
 	// must share one table or collide on policy_id. nil when BGP is disabled
 	// -> SrPolicyService RPCs return FailedPrecondition.
 	var applier *apply.Applier
+	// exporter / routeWatcher drive the auto-advertise path (VRF export).
+	// They stay nil unless BGP is enabled with bgp.global.auto_advertise.
+	var exporter *export.Exporter
 	if cliCtx.Bool("bgp-enabled") {
 		// Load config-time VRF <-> route-target bindings before the BGP
 		// session starts receiving. EVPN routes require a bridge-domain
@@ -145,13 +149,7 @@ func run(cliCtx *cli.Context) error {
 			if b.BDID > math.MaxUint16 {
 				return fmt.Errorf("bgp.vrf_bindings %q: bd_id %d out of range (max %d)", b.VRFName, b.BDID, math.MaxUint16)
 			}
-			if err := vrfBgpMgr.Bind(vrfbgp.Binding{
-				VRFName:        b.VRFName,
-				ImportRTs:      b.ImportRTs,
-				ExportRTs:      b.ExportRTs,
-				DefaultLocator: b.DefaultLocator,
-				BDID:           uint16(b.BDID),
-			}); err != nil {
+			if err := vrfBgpMgr.Bind(configToBinding(b)); err != nil {
 				return fmt.Errorf("bgp.vrf_bindings %q: %w", b.VRFName, err)
 			}
 		}
@@ -170,6 +168,20 @@ func run(cliCtx *cli.Context) error {
 			cfg.BGP.Global.LocalASN,
 			lg,
 		)
+		// Auto-advertise (VRF export) is opt-in via bgp.global.auto_advertise.
+		// The exporter shares the locator manager, VRF bindings, and BGP
+		// advertiser with the rest of the daemon and owns its route watcher.
+		if cfg.BGP.Global.AutoAdvertise {
+			exporter = export.New(
+				advertiser,
+				vin.GetMapOperations(),
+				locatorMgr,
+				vrfBgpMgr,
+				export.NetlinkVRFResolver{},
+				cfg.BGP.Global.SourceLocator,
+				lg,
+			)
+		}
 	}
 
 	srv := server.NewServer(cfg, vin.GetMapOperations(), vin.GetResourceManager(), vin.GetFDBWatcher(), locatorMgr, vrfBgpMgr, advertiser, srPolicyAdvertiser, evpnAdvertiser, mupAdvertiser, applier, lg)
@@ -212,6 +224,18 @@ func run(cliCtx *cli.Context) error {
 			return fmt.Errorf("subscribe BGP routes: %w", err)
 		}
 		defer cancelSub()
+
+		// Auto-advertise: the exporter enables each VRF binding with a
+		// redistribute set and starts watching. Starting after Subscribe means
+		// its ListExisting replay advertises boot-time prefixes through an
+		// already-running advertiser; the deferred Stop withdraws them before
+		// the session drops.
+		if exporter != nil {
+			if err := exporter.Start(ctx); err != nil {
+				return fmt.Errorf("start auto-advertise: %w", err)
+			}
+			defer exporter.Stop()
+		}
 	}
 
 	lg.Info("Vinbero started successfully")
@@ -257,6 +281,20 @@ func startBGPSession(ctx context.Context, session bgp.Session, cfg config.BGPCon
 		}
 	}
 	return nil
+}
+
+// configToBinding converts a config VRF binding into the runtime vrfbgp
+// Binding. The caller is responsible for validating b.BDID's range first.
+func configToBinding(b config.VrfBindingConfig) vrfbgp.Binding {
+	return vrfbgp.Binding{
+		VRFName:        b.VRFName,
+		RD:             b.RD,
+		ImportRTs:      b.ImportRTs,
+		ExportRTs:      b.ExportRTs,
+		Redistribute:   b.Redistribute,
+		DefaultLocator: b.DefaultLocator,
+		BDID:           uint16(b.BDID),
+	}
 }
 
 func loadConfig(path string) (*config.Config, error) {

--- a/cmd/vinberod/main.go
+++ b/cmd/vinberod/main.go
@@ -192,7 +192,10 @@ func run(cliCtx *cli.Context) error {
 				vrfBgpMgr,
 				export.NetlinkVRFResolver{},
 				cfg.BGP.Global.NextHop,
-				cfg.BGP.Global.UnderlayRedistribute,
+				export.UnderlayConfig{
+					Redistribute: cfg.BGP.Global.UnderlayRedistribute,
+					MaxPrefixes:  cfg.BGP.Global.UnderlayMaxPrefixes,
+				},
 				lg,
 			)
 		}

--- a/cmd/vinberod/main.go
+++ b/cmd/vinberod/main.go
@@ -305,6 +305,7 @@ func configToBinding(b config.VrfBindingConfig) vrfbgp.Binding {
 		ImportRTs:      b.ImportRTs,
 		ExportRTs:      b.ExportRTs,
 		Redistribute:   b.Redistribute,
+		MaxPrefixes:    b.MaxPrefixes,
 		DefaultLocator: b.DefaultLocator,
 		BDID:           uint16(b.BDID),
 	}

--- a/cmd/vinberod/main.go
+++ b/cmd/vinberod/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"net/netip"
 	"os"
 	"os/signal"
 	"syscall"
@@ -145,6 +146,18 @@ func run(cliCtx *cli.Context) error {
 		// binding to be installed; applying bindings here (rather than via
 		// VrfBgpBind after boot) means a route that arrives early is not
 		// dropped for lack of one. Only relevant when BGP is enabled.
+		// Register config-declared locators before VRF bindings: the
+		// auto-advertise exporter resolves each binding's default_locator at
+		// EnableVRF time, and EnableVRF runs at startup before any RPC arrives.
+		for _, lc := range cfg.BGP.Locators {
+			loc, err := configToLocator(lc)
+			if err != nil {
+				return fmt.Errorf("bgp.locators %q: %w", lc.Name, err)
+			}
+			if err := locatorMgr.Add(loc); err != nil {
+				return fmt.Errorf("bgp.locators %q: %w", lc.Name, err)
+			}
+		}
 		for _, b := range cfg.BGP.VrfBindings {
 			if b.BDID > math.MaxUint16 {
 				return fmt.Errorf("bgp.vrf_bindings %q: bd_id %d out of range (max %d)", b.VRFName, b.BDID, math.MaxUint16)
@@ -178,7 +191,7 @@ func run(cliCtx *cli.Context) error {
 				locatorMgr,
 				vrfBgpMgr,
 				export.NetlinkVRFResolver{},
-				cfg.BGP.Global.SourceLocator,
+				cfg.BGP.Global.NextHop,
 				lg,
 			)
 		}
@@ -295,6 +308,34 @@ func configToBinding(b config.VrfBindingConfig) vrfbgp.Binding {
 		DefaultLocator: b.DefaultLocator,
 		BDID:           uint16(b.BDID),
 	}
+}
+
+// configToLocator converts a config locator declaration into a locator.Locator.
+func configToLocator(lc config.LocatorConfig) (*locator.Locator, error) {
+	prefix, err := netip.ParsePrefix(lc.Prefix)
+	if err != nil {
+		return nil, fmt.Errorf("invalid prefix %q: %w", lc.Prefix, err)
+	}
+	var behavior locator.Behavior
+	switch lc.Behavior {
+	case "", "classic":
+		behavior = locator.BehaviorClassic
+	case "usid":
+		behavior = locator.BehaviorUSID
+	default:
+		return nil, fmt.Errorf("unknown behavior %q (want classic|usid)", lc.Behavior)
+	}
+	return &locator.Locator{
+		Name:              lc.Name,
+		Prefix:            prefix,
+		BlockLen:          lc.BlockLen,
+		NodeLen:           lc.NodeLen,
+		FunctionLen:       lc.FunctionLen,
+		ArgumentLen:       lc.ArgumentLen,
+		Behavior:          behavior,
+		FunctionAutoStart: lc.FunctionAutoStart,
+		FunctionAutoEnd:   lc.FunctionAutoEnd,
+	}, nil
 }
 
 func loadConfig(path string) (*config.Config, error) {

--- a/cmd/vinberod/main.go
+++ b/cmd/vinberod/main.go
@@ -192,6 +192,7 @@ func run(cliCtx *cli.Context) error {
 				vrfBgpMgr,
 				export.NetlinkVRFResolver{},
 				cfg.BGP.Global.NextHop,
+				cfg.BGP.Global.UnderlayRedistribute,
 				lg,
 			)
 		}

--- a/docs/loadmap.md
+++ b/docs/loadmap.md
@@ -103,5 +103,5 @@ status.
 | VRF <-> route-target binding | Supported | Import-RT filter for received VPN routes               | RFC 9252 |
 | SR Policy (SAFI 73)        | Supported | Color-based steering (control + data plane)              | RFC 9256 |
 | BGP MUP (SAFI 85)          | Supported | MUP route exchange (ISD/DSD/T1ST/T2ST, IPv4/IPv6) + apply: GTP4/GTP6 downlink H.Encaps + uplink F-TEID (H.M.GTP4.D_TEID / H.M.GTP6.D_TEID) | draft-mpmz-bess-mup-safi |
-| Automatic advertise        |           | Advertise local SID/headend state without operator RPC   | RFC 9252 |
+| Automatic advertise        | Partial   | VRF-export driven (config bindings): connected/static prefixes auto-advertised as VPNv4/v6. RPC bindings / EVPN / SR Policy / MUP auto-advertise deferred | RFC 9252 |
 | EVPN (RT2/3/4)             | Supported | L2VPN over BGP EVPN: RT2 MAC/IP, RT3 Inclusive Multicast, RT4 Ethernet Segment + RFC 8584 DF election / Local-Bias split-horizon (multi-homing). IRB (RT2 L3) and RT5 not yet supported | RFC 9252 / 7432 / 8584 |

--- a/examples/interop-clab/scenarios/l3vpn-2site-auto/README.md
+++ b/examples/interop-clab/scenarios/l3vpn-2site-auto/README.md
@@ -1,0 +1,49 @@
+# l3vpn-2site-auto — auto-advertise SRv6 L3VPN interop (Vinbero ⇄ FRR)
+
+The auto-advertise variant of [l3vpn-2site](../l3vpn-2site/). The topology,
+addressing, and FRR PE are identical; the only difference is how the Vinbero PE
+originates its customer route.
+
+In `l3vpn-2site`, Vinbero advertises `10.1.0.0/24` with explicit
+`vbctl sid create` + `vbctl bgp advertise-vpn` calls. Here, Vinbero advertises
+it **automatically from config**: `bgp.global.auto_advertise: true` plus a
+`vrf_bindings` entry with `redistribute: [static]`. The exporter
+(`pkg/bgp/export`) mints the End.DT4/DT6 service SID from `LOC1` and advertises
+the VRF-local prefix on its own — no `vbctl` call, the receive-direction mirror
+of `pkg/bgp/apply`.
+
+## What differs from l3vpn-2site
+
+- **vinbero/vinbero.yml**: `bgp.locators` declares `LOC1` statically (the
+  exporter resolves a binding's `default_locator` at startup, before any RPC);
+  `bgp.global.auto_advertise: true`; `bgp.global.next_hop` is the PE loopback
+  (the BGP next hop must be a normal node address — a locator base is a
+  subnet-router anycast address that a receiving PE treats as local, breaking
+  forwarding); `vrf_bindings` carries `rd` / `import_rts` / `export_rts` /
+  `default_locator` / `redistribute`.
+- **vinbero/start.sh**: no `vbctl sid create` / `bgp advertise-vpn`. The
+  customer route is added with `proto static` so the `redistribute: [static]`
+  allowlist forwards it (a bare `ip route` is `RTPROT_BOOT`, excluded to avoid
+  leaking casual routes into the VPN).
+- **frr/start.sh**: the /128 glue route targets the auto-minted SID
+  `fd00:100:0:10::` (function `0x10`, the first auto-allocated End.DT4) instead
+  of the manual `fd00:100:0:1::`.
+
+The advertised SID is dynamic, so `test.sh` discovers Vinbero's End.DT4 SID
+rather than hard-coding it.
+
+## Run
+
+Needs Docker, `containerlab`, and `sudo`. From `examples/interop-clab/`:
+
+```bash
+make all SCENARIO=l3vpn-2site-auto
+```
+
+## What test.sh checks
+
+The same four things as `l3vpn-2site` — iBGP Established, FRR → Vinbero SRv6
+Service TLV decode (with RFC 9252 §4 transposition), Vinbero → FRR encode, and a
+bidirectional `ping` between `ce-tokyo` and `ce-osaka` over the SRv6 L3VPN —
+except the Vinbero → FRR route is originated by the auto-advertise exporter with
+no operator RPC.

--- a/examples/interop-clab/scenarios/l3vpn-2site-auto/clab.yml
+++ b/examples/interop-clab/scenarios/l3vpn-2site-auto/clab.yml
@@ -1,0 +1,84 @@
+# containerlab topology for the l3vpn-2site interop scenario.
+#
+# A textbook 2-site SRv6 L3VPN. Vinbero is the PE under test; FRR is the
+# independent third-party PE it interoperates with in this scenario:
+#
+#   ce-tokyo --- pe-tokyo ===== core ===== pe-osaka --- ce-osaka
+#  10.1.0.0/24  (Vinbero PE)  (IPv6 core)  (FRR PE)   10.2.0.0/24
+#
+# Both PEs are in ONE provider AS (65100) and run iBGP (VPNv4 + VPNv6)
+# peering on their loopbacks. iBGP is naturally multi-hop, so the session
+# crosses `core` with no ebgp-multihop knob. `core` is NOT in BGP -- it
+# only routes the IPv6 underlay with static routes (no IGP), so there is
+# no convergence race that could make the data-plane test flaky.
+#
+# Both customer sites sit in a single L3VPN / VRF, so the ce-tokyo and
+# ce-osaka hosts reach each other end to end over SRv6.
+#
+# `name:` is the scenario name, so containers are clab-l3vpn-2site-auto-<node>.
+name: l3vpn-2site-auto
+
+topology:
+  nodes:
+    # --- ce-tokyo: customer host behind the Vinbero PE ----------------------
+    ce-tokyo:
+      kind: linux
+      image: alpine:3.20
+      exec:
+        - ip addr add 10.1.0.10/24 dev eth1
+        - ip link set eth1 up
+        # Reach the far customer site through the local PE.
+        - ip route replace 10.2.0.0/24 via 10.1.0.1
+
+    # --- pe-tokyo: the Vinbero PE under test --------------------------------
+    pe-tokyo:
+      kind: linux
+      image: vinbero-interop:latest
+      # containerlab runs linux nodes privileged by default, which is
+      # what the XDP attach + BPF FS need.
+      binds:
+        - vinbero/vinbero.yml:/vinbero.yml
+        - vinbero/start.sh:/start.sh
+      exec:
+        - bash /start.sh
+
+    # --- core: provider backbone, plain IPv6 router -------------------------
+    # An SRv6 L3VPN transit router forwards purely by the outer IPv6
+    # header and needs NO SRv6-service awareness, so `core` is just a
+    # Linux node with IPv6 forwarding and static underlay routes.
+    core:
+      kind: linux
+      image: alpine:3.20
+      binds:
+        - core/start.sh:/start.sh
+      exec:
+        - sh /start.sh
+
+    # --- pe-osaka: the FRR PE (interop peer) --------------------------------
+    pe-osaka:
+      kind: linux
+      image: frr-interop:10.2.1
+      # /etc/frr/daemons is baked into the frr-interop image (it is
+      # image-level config); only the per-scenario files are bound here.
+      binds:
+        - frr/frr.conf:/etc/frr/frr.conf
+        - frr/start.sh:/start.sh
+      exec:
+        - sh /start.sh
+
+    # --- ce-osaka: customer host behind the FRR PE --------------------------
+    ce-osaka:
+      kind: linux
+      image: alpine:3.20
+      exec:
+        - ip addr add 10.2.0.10/24 dev eth1
+        - ip link set eth1 up
+        - ip route replace 10.1.0.0/24 via 10.2.0.1
+
+  links:
+    # CE <-> PE customer-facing ports.
+    - endpoints: [ce-tokyo:eth1, pe-tokyo:eth2]
+    - endpoints: [ce-osaka:eth1, pe-osaka:eth1]
+    # Provider underlay: pe-tokyo <-> core <-> pe-osaka.
+    - endpoints: [pe-tokyo:eth1, core:eth1]
+    - endpoints: [core:eth2, pe-osaka:eth2]

--- a/examples/interop-clab/scenarios/l3vpn-2site-auto/core/start.sh
+++ b/examples/interop-clab/scenarios/l3vpn-2site-auto/core/start.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Provider backbone router for the l3vpn-2site interop scenario.
+#
+# An SRv6 L3VPN transit node forwards purely by the *outer* IPv6 header,
+# so `core` needs NO SRv6-service awareness -- it is a plain IPv6
+# router. Static routes (no IGP) keep the underlay deterministic: there
+# is no convergence race that could make the data-plane test flaky.
+#
+# Underlay links:
+#   eth1  pe-tokyo <-> core      2001:db8:1::/64   (core = ::2, pe-tokyo = ::1)
+#   eth2  core     <-> pe-osaka  2001:db8:2::/64   (core = ::2, pe-osaka = ::1)
+
+# Best-effort: alpine's busybox `ip` is limited, so do not abort the
+# whole script if one harmless command (e.g. a re-add) returns nonzero.
+set -u
+
+# --- interface addressing --------------------------------------------------
+# busybox `ip` has no `nodad`; DAD on a point-to-point /64 is harmless.
+ip link set eth1 up
+ip -6 addr add 2001:db8:1::2/64 dev eth1 2>/dev/null || true
+ip link set eth2 up
+ip -6 addr add 2001:db8:2::2/64 dev eth2 2>/dev/null || true
+
+# --- IPv6 forwarding -------------------------------------------------------
+sysctl -w net.ipv6.conf.all.forwarding=1 >/dev/null 2>&1 || true
+sysctl -w net.ipv6.conf.eth1.forwarding=1 >/dev/null 2>&1 || true
+sysctl -w net.ipv6.conf.eth2.forwarding=1 >/dev/null 2>&1 || true
+
+# --- static underlay routes ------------------------------------------------
+# Towards pe-tokyo (eth1): its loopback + Vinbero's SRv6 locator block.
+ip -6 route replace 2001:db8:ff::1/128 via 2001:db8:1::1 dev eth1
+ip -6 route replace fd00:100::/48      via 2001:db8:1::1 dev eth1
+# Towards pe-osaka (eth2): its loopback + FRR's SRv6 locator block.
+ip -6 route replace 2001:db8:ff::2/128 via 2001:db8:2::1 dev eth2
+ip -6 route replace fd00:200::/48      via 2001:db8:2::1 dev eth2
+
+# Pre-resolve the underlay NDP neighbours so the first transit packet
+# is forwarded immediately rather than queued behind NDP resolution.
+ping6 -c 1 -W 2 2001:db8:1::1 >/dev/null 2>&1 || true
+ping6 -c 1 -W 2 2001:db8:2::1 >/dev/null 2>&1 || true
+
+echo "[start.sh] core IPv6 router ready"

--- a/examples/interop-clab/scenarios/l3vpn-2site-auto/frr/frr.conf
+++ b/examples/interop-clab/scenarios/l3vpn-2site-auto/frr/frr.conf
@@ -1,0 +1,116 @@
+frr version 10.2.1
+frr defaults traditional
+hostname pe-osaka
+log file /var/log/frr/frr.log
+log stdout
+service integrated-vtysh-config
+!
+! ---------------------------------------------------------------------------
+! pe-osaka -- the FRR PE for the l3vpn-2site interop scenario.
+!
+! This node is the independent RFC 9252 implementation. It:
+!   - owns an SRv6 locator (fd00:200::/48) under `segment-routing srv6`,
+!   - runs a VRF `vrf-cust` with the ce-osaka customer subnet,
+!   - exports that VRF into VPNv4/VPNv6 with an SRv6 service SID,
+!   - peers iBGP (AS 65100) with pe-tokyo (Vinbero) over the loopbacks.
+!
+! The config structure follows the FRR topotest
+! tests/topotests/bgp_srv6l3vpn_over_ipv6 (stable/10.2): the SRv6
+! locator is attached to the *default* BGP instance, and each VRF
+! instance carries `sid vpn export <index>` per address-family.
+! ---------------------------------------------------------------------------
+!
+! Loopback: iBGP peering address + SRv6 transport endpoint.
+interface lo
+ ipv6 address 2001:db8:ff::2/128
+exit
+!
+! eth1 faces ce-osaka: the customer-facing port, placed in vrf-cust.
+interface eth1 vrf vrf-cust
+ ip address 10.2.0.1/24
+exit
+!
+! eth2 faces the core: the IPv6 underlay link.
+interface eth2
+ ipv6 address 2001:db8:2::1/64
+exit
+!
+! ---------------------------------------------------------------------------
+! Static underlay routes. The core is not in BGP, so reachability to
+! pe-tokyo's loopback and Vinbero's SRv6 locator block is static.
+! ---------------------------------------------------------------------------
+ipv6 route 2001:db8:ff::1/128 2001:db8:2::2
+ipv6 route fd00:100::/48 2001:db8:2::2
+!
+! ---------------------------------------------------------------------------
+! SRv6 locator. The per-VRF VPN service SIDs are carved from this block.
+! uSID is intentionally NOT used -- classic full-length SIDs keep the
+! TLV layout simple for cross-implementation decode.
+! ---------------------------------------------------------------------------
+segment-routing
+ srv6
+  locators
+   locator LOC1
+    prefix fd00:200::/48
+   exit
+  exit
+ exit
+exit
+!
+! ---------------------------------------------------------------------------
+! BGP. The default instance runs the iBGP VPNv4/VPNv6 session and owns
+! the SRv6 locator; the per-VRF instance redistributes connected routes
+! and exports them with an SRv6 service SID.
+!
+! iBGP (both PEs in AS 65100): the session is multi-hop across the core
+! with no ebgp-multihop knob. `update-source lo` sources the session
+! from the loopback so it matches pe-tokyo's loopback neighbor address.
+! ---------------------------------------------------------------------------
+router bgp 65100
+ bgp router-id 10.255.0.2
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ !
+ neighbor 2001:db8:ff::1 remote-as 65100
+ neighbor 2001:db8:ff::1 update-source lo
+ neighbor 2001:db8:ff::1 timers 3 10
+ neighbor 2001:db8:ff::1 timers connect 1
+ neighbor 2001:db8:ff::1 capability extended-nexthop
+ !
+ segment-routing srv6
+  locator LOC1
+ exit
+ !
+ address-family ipv4 vpn
+  neighbor 2001:db8:ff::1 activate
+ exit-address-family
+ !
+ address-family ipv6 vpn
+  neighbor 2001:db8:ff::1 activate
+ exit-address-family
+exit
+!
+router bgp 65100 vrf vrf-cust
+ bgp router-id 10.255.0.2
+ !
+ address-family ipv4 unicast
+  redistribute connected
+  sid vpn export 1
+  rd vpn export 65200:200
+  rt vpn both 65000:200
+  import vpn
+  export vpn
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  redistribute connected
+  sid vpn export 2
+  rd vpn export 65200:206
+  rt vpn both 65000:206
+  import vpn
+  export vpn
+ exit-address-family
+exit
+!
+line vty
+!

--- a/examples/interop-clab/scenarios/l3vpn-2site-auto/frr/start.sh
+++ b/examples/interop-clab/scenarios/l3vpn-2site-auto/frr/start.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+# Bring up the FRR PE (pe-osaka) inside the containerlab node.
+#
+# The customer VRF must exist in the kernel *before* FRR loads
+# frr.conf -- zebra binds to existing devices, it does not create the
+# VRF master itself. eth1 (customer-facing) is enslaved to vrf-cust.
+#
+# Interfaces:
+#   eth1  pe-osaka <-> ce-osaka  customer 10.2.0.0/24  (in vrf-cust)
+#   eth2  pe-osaka <-> core      underlay 2001:db8:2::/64
+#   lo    loopback 2001:db8:ff::2  (iBGP peering / SRv6 transport)
+
+# SRv6 needs IPv6 forwarding and the seg6 dataplane knobs. These are
+# namespace-scoped, so they must be set inside the container.
+sysctl -w net.ipv4.ip_forward=1 2>/dev/null || true
+sysctl -w net.ipv6.conf.all.forwarding=1 2>/dev/null || true
+sysctl -w net.ipv6.conf.all.seg6_enabled=1 2>/dev/null || true
+sysctl -w net.ipv6.conf.default.seg6_enabled=1 2>/dev/null || true
+sysctl -w net.ipv6.conf.eth1.seg6_enabled=1 2>/dev/null || true
+sysctl -w net.ipv6.conf.eth2.seg6_enabled=1 2>/dev/null || true
+sysctl -w net.ipv4.conf.all.rp_filter=0 2>/dev/null || true
+sysctl -w net.ipv4.conf.default.rp_filter=0 2>/dev/null || true
+# VRF strict mode is required by the kernel before FRR's auto-installed
+# seg6local End.DT4 localsid (which uses `vrftable`) can come up.
+sysctl -w net.vrf.strict_mode=1 2>/dev/null || true
+
+# --- customer VRF + customer-facing port -----------------------------------
+# vrf-cust is the L3VPN tenant. eth1 faces ce-osaka and is enslaved to
+# the VRF; FRR exports the 10.2.0.0/24 connected prefix into VPNv4 with
+# an SRv6 service SID.
+if ! ip link show vrf-cust >/dev/null 2>&1; then
+    ip link add vrf-cust type vrf table 100
+fi
+if ! ip link show vrf-cust >/dev/null 2>&1; then
+    echo "ERROR: failed to create VRF vrf-cust -- is the kernel 'vrf' module loaded on the host? (modprobe vrf)" >&2
+    exit 1
+fi
+ip link set vrf-cust up
+ip link set eth1 master vrf-cust
+ip link set eth1 up
+
+# --- underlay link towards the core ----------------------------------------
+ip link set eth2 up 2>/dev/null || true
+
+# Vinbero's locator block as a *connected* prefix on eth2, added before
+# FRR starts so it is already present when the first VPN route arrives.
+# FRR's SRv6 nexthop validation rejects a service SID reachable only via
+# a gateway ("Must be Connected"); without this the 10.1.0.0/24 route
+# Vinbero advertises stays `invalid` and never installs into vrf-cust.
+ip -6 addr add fd00:100::ffff/48 dev eth2 nodad 2>/dev/null || true
+
+# FRR ships an entrypoint that starts the daemons selected in
+# /etc/frr/daemons. watchfrr then keeps them alive.
+/usr/lib/frr/frrinit.sh start
+
+# Give the daemons a moment, then load the integrated config so that
+# any ordering-sensitive SRv6/BGP statements apply cleanly.
+sleep 4
+vtysh -b || true
+
+# --- data-plane wiring (SRv6 L3VPN forwarding) -----------------------------
+# Wait for zebra to settle the locator + VPN routes before adding the
+# static glue the data plane needs.
+sleep 4
+
+# More-specific forwarding route for Vinbero's End.DT4 SID. The
+# connected /48 above would otherwise make FRR treat the SID as on-link
+# and NDP for it on eth2; this /128 sends the encapsulated return
+# traffic to the core (2001:db8:2::2), which routes it on to pe-tokyo.
+# fd00:100:0:10:: == the End.DT4 SID the auto-advertise exporter mints for
+# vrf-cust: LOC1's function_auto_start is 0x10 and End.DT4 is allocated first,
+# so 10.1.0.0/24 is advertised with this SID deterministically (unlike the
+# manual l3vpn-2site scenario, which pins fd00:100:0:1:: via vbctl).
+ip -6 route replace fd00:100:0:10::/128 via 2001:db8:2::2 dev eth2
+
+# FRR auto-installs its End.DT4 localsid at the transposed full SID
+# (fd00:200:0:0:1::). Vinbero applies RFC 9252 §4 transposition when it
+# decodes the route, so it encapsulates straight to that full SID --
+# no lab-side static localsid for the bare locator is needed.
+
+# Pre-resolve the NDP neighbour for the underlay so the first
+# encapsulated packet is not dropped on BPF_FIB_LKUP_RET_NO_NEIGH.
+ping6 -c 1 -W 2 2001:db8:2::2 >/dev/null 2>&1 || true
+
+echo "[start.sh] pe-osaka (FRR) PE data plane ready"

--- a/examples/interop-clab/scenarios/l3vpn-2site-auto/test.sh
+++ b/examples/interop-clab/scenarios/l3vpn-2site-auto/test.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+# l3vpn-2site interop scenario assertions (Vinbero <-> FRR).
+#
+# Verifies, against a running `make deploy` lab, the things the scenario
+# exists to prove:
+#   1. the iBGP session is ESTABLISHED on both sides;
+#   2. FRR -> Vinbero: a VPN route FRR advertises (with an RFC 9252
+#      SRv6 Service TLV) is decoded by Vinbero and lands in the headend
+#      map -- SRv6 Service TLV *decode* interop, including the RFC 9252
+#      §4 transposition reconstruction;
+#   3. Vinbero -> FRR: the route Vinbero advertises reaches FRR's VPN
+#      RIB with the SRv6 SID intact -- SRv6 Service TLV *encode* interop;
+#   4. data plane: a real `ping` succeeds both ways between ce-tokyo
+#      (10.1.0.10) and ce-osaka (10.2.0.10), riding the SRv6 L3VPN
+#      through both PEs and the core.
+#
+# DATA-PLANE FLAKINESS -- the data plane settles asynchronously (XDP
+# attach, BGP convergence, FRR's auto-installed seg6 localsid, NDP).
+# Before pinging, section 4 GATES on every readiness precondition:
+#   - both BGP sessions Established,
+#   - the learned VPN routes installed (Vinbero headend maps + FRR RIB),
+#   - the decap endpoints present (Vinbero SID function + FRR localsid),
+#   - the underlay NDP neighbours resolved end to end.
+# Only once all gates pass does it ping, with a generous retry. A slow
+# data plane therefore cannot produce a spurious FAIL.
+#
+# Exit non-zero on the first failed assertion.
+set -u
+
+PE_TOKYO=clab-l3vpn-2site-auto-pe-tokyo   # Vinbero PE
+PE_OSAKA=clab-l3vpn-2site-auto-pe-osaka   # FRR PE
+CORE=clab-l3vpn-2site-auto-core
+CE_TOKYO=clab-l3vpn-2site-auto-ce-tokyo
+CE_OSAKA=clab-l3vpn-2site-auto-ce-osaka
+
+# Customer prefixes.
+TOKYO_PREFIX=10.1.0.0/24      # ce-tokyo subnet, advertised by Vinbero
+OSAKA_PREFIX=10.2.0.0/24      # ce-osaka subnet, advertised by FRR
+
+# Data-plane endpoints: the two customer hosts.
+CE_TOKYO_ADDR=10.1.0.10
+CE_OSAKA_ADDR=10.2.0.10
+
+# Loopback peering addresses.
+VIN_LOOPBACK=2001:db8:ff::1   # pe-tokyo (Vinbero)
+FRR_LOOPBACK=2001:db8:ff::2   # pe-osaka (FRR)
+
+# FRR's End.DT4 service SID for the ce-osaka prefix. FRR carries the SID
+# function bits transposed in the VPN label, so the SID *on the wire* is
+# the bare locator fd00:200:: while FRR's seg6local localsid sits at the
+# transposed full SID below (function index 1 from `sid vpn export 1`).
+# Vinbero must fold the label back per RFC 9252 §4 and reconstruct it.
+FRR_FULL_SID=fd00:200:0:1::
+
+pass=0
+fail=0
+ok()   { echo "  PASS: $1"; pass=$((pass + 1)); }
+ng()   { echo "  FAIL: $1"; fail=$((fail + 1)); }
+
+dexec() { docker exec "$@"; }
+
+# retry CMD... -- run a command until it succeeds, default ~60s.
+# retry_n N CMD... -- same but with an explicit attempt count (2s each).
+retry()   { retry_n 30 "$@"; }
+retry_n() {
+    local n=$1; shift
+    local i
+    for i in $(seq 1 "$n"); do
+        if "$@" >/dev/null 2>&1; then return 0; fi
+        sleep 2
+    done
+    return 1
+}
+
+echo "=============================================="
+echo " l3vpn-2site interop scenario test (Vinbero <-> FRR)"
+echo "=============================================="
+
+# --- 1. iBGP session ESTABLISHED on both sides -----------------------------
+echo ""
+echo "[1] iBGP session ESTABLISHED"
+
+frr_established() {
+    dexec "$PE_OSAKA" vtysh -c "show bgp summary json" 2>/dev/null \
+      | python3 -c "import sys,json; d=json.load(sys.stdin); \
+sys.exit(0 if d.get('ipv4Vpn',{}).get('peers',{}).get('$VIN_LOOPBACK',{}).get('state')=='Established' else 1)"
+}
+if retry frr_established; then
+    ok "FRR sees peer $VIN_LOOPBACK Established (ipv4 vpn)"
+else
+    ng "FRR peer $VIN_LOOPBACK not Established"
+    dexec "$PE_OSAKA" vtysh -c "show bgp summary" || true
+fi
+
+# Vinbero side: the BGP applier logs the session; the in-process speaker
+# has no `peers` CLI, so the daemon log is the source of truth.
+if dexec "$PE_TOKYO" grep -q "BGP peer added" /var/log/vinberod.log 2>/dev/null; then
+    ok "Vinbero BGP speaker started and peer configured"
+else
+    ng "Vinbero BGP speaker did not start"
+fi
+
+# --- 2. FRR -> Vinbero: SRv6 Service TLV decode ----------------------------
+echo ""
+echo "[2] FRR -> Vinbero  (SRv6 Service TLV decode)"
+
+# Wait until FRR has actually advertised its VPNv4 route.
+frr_has_export() {
+    dexec "$PE_OSAKA" vtysh -c "show bgp ipv4 vpn $OSAKA_PREFIX" 2>/dev/null \
+      | grep -q "Remote SID:"
+}
+retry frr_has_export || true
+
+# 2a. FRR's VPNv4 route (ce-osaka subnet) lands in Vinbero's headend-v4 map.
+if retry bash -c "docker exec $PE_TOKYO vbctl headend-v4 list 2>/dev/null | grep -q '$OSAKA_PREFIX'"; then
+    ok "FRR VPNv4 route $OSAKA_PREFIX installed in Vinbero headend-v4 map"
+    dexec "$PE_TOKYO" vbctl headend-v4 list | sed 's/^/      /'
+else
+    ng "FRR VPNv4 route $OSAKA_PREFIX missing from Vinbero headend-v4 map"
+    dexec "$PE_TOKYO" vbctl headend-v4 list || true
+fi
+
+# frr_route_sid digs the first path's remoteSid out of vtysh JSON
+# (`show bgp <afi> vpn <prefix> json` is keyed by route-distinguisher,
+# each RD value carrying a `paths` list). Used here and in section 3.
+frr_route_sid() {
+    python3 -c "import sys,json; d=json.load(sys.stdin); \
+rds=[v for v in d.values() if isinstance(v,dict) and 'paths' in v]; \
+print(rds[0]['paths'][0].get('remoteSid','') if rds else '')"
+}
+
+# 2b. RFC 9252 §4 transposition. FRR carries the SID function bits in
+#     the VPN label, so the SID *on the wire* is the bare locator.
+#     Vinbero must fold the label back and reconstruct FRR's real
+#     End.DT4 localsid -- the headend SEGMENTS column must show the
+#     full SID, not the bare on-wire locator.
+frr_wire_sid=$(dexec "$PE_OSAKA" vtysh -c "show bgp ipv4 vpn $OSAKA_PREFIX json" 2>/dev/null \
+  | frr_route_sid 2>/dev/null)
+vin_seg=$(dexec "$PE_TOKYO" vbctl headend-v4 list 2>/dev/null \
+  | awk -v p="$OSAKA_PREFIX" '$1==p {print $NF}')
+if [ "$vin_seg" = "$FRR_FULL_SID" ] && [ "$frr_wire_sid" != "$FRR_FULL_SID" ]; then
+    ok "Vinbero folded the transposed SID: wire=$frr_wire_sid -> full=$vin_seg"
+else
+    ng "transposition decode wrong: wire='$frr_wire_sid' Vinbero='$vin_seg' want='$FRR_FULL_SID'"
+fi
+
+# --- 3. Vinbero -> FRR: SRv6 Service TLV encode ----------------------------
+echo ""
+echo "[3] Vinbero -> FRR  (SRv6 Service TLV encode)"
+
+# Vinbero auto-advertises the ce-tokyo subnet (10.1.0.0/24): the exporter mints
+# the End.DT4 SID from LOC1 and advertises the route with no vbctl call. The SID
+# is dynamic, so discover it from Vinbero rather than hard-coding it.
+VIN_SID=$(dexec "$PE_TOKYO" vbctl sid list 2>/dev/null \
+  | awk 'tolower($0) ~ /end_dt4/ {print $1; exit}')
+VIN_SID=${VIN_SID%/128}
+check_frr_rib() {
+    local got
+    got=$(dexec "$PE_OSAKA" vtysh -c "show bgp ipv4 vpn $TOKYO_PREFIX json" 2>/dev/null \
+      | frr_route_sid 2>/dev/null)
+    [ "$got" = "$VIN_SID" ]
+}
+if retry check_frr_rib; then
+    ok "FRR RIB has $TOKYO_PREFIX with SRv6 SID $VIN_SID"
+    dexec "$PE_OSAKA" vtysh -c "show bgp ipv4 vpn $TOKYO_PREFIX" | sed 's/^/      /'
+else
+    ng "FRR RIB missing $TOKYO_PREFIX / wrong SID"
+    dexec "$PE_OSAKA" vtysh -c "show bgp ipv4 vpn" || true
+fi
+
+# 3b. FRR installs the VPN route into vrf-cust as an SRv6 encap route.
+# Inspect the kernel FIB directly: the `ip route` text reliably shows
+# the `encap seg6` action, whereas `vtysh show ip route` text does not.
+frr_vrf_route() {
+    dexec "$PE_OSAKA" ip route show vrf vrf-cust "$TOKYO_PREFIX" 2>/dev/null \
+      | grep -q "encap seg6"
+}
+if retry frr_vrf_route; then
+    ok "FRR installed $TOKYO_PREFIX into vrf-cust as an SRv6 encap route"
+else
+    ng "FRR did not install $TOKYO_PREFIX into vrf-cust"
+    dexec "$PE_OSAKA" vtysh -c "show ip route vrf vrf-cust" || true
+fi
+
+# --- 4. Data plane: bidirectional SRv6 L3VPN ping --------------------------
+echo ""
+echo "[4] Data plane  (SRv6 L3VPN ping, both directions)"
+
+# 4.0 READINESS GATE. The data plane settles asynchronously; ping only
+# once every precondition holds, so a slow settle cannot flake the test.
+
+# (a) both BGP sessions Established (FRR side checked above; re-gate so
+#     section 4 is self-contained even if section 1 was slow).
+if retry frr_established; then
+    echo "  gate: iBGP session Established"
+else
+    ng "gate: iBGP session never reached Established"
+fi
+
+# (b) the learned VPN routes are installed on both PEs.
+gate_vin_headend() {
+    dexec "$PE_TOKYO" vbctl headend-v4 list 2>/dev/null | grep -q "$OSAKA_PREFIX"
+}
+gate_frr_rib() {
+    dexec "$PE_OSAKA" ip route show vrf vrf-cust "$TOKYO_PREFIX" 2>/dev/null \
+      | grep -q "encap seg6"
+}
+if retry gate_vin_headend; then
+    echo "  gate: ce-osaka prefix in Vinbero headend map"
+else
+    ng "gate: ce-osaka prefix never installed in Vinbero headend map"
+fi
+if retry gate_frr_rib; then
+    echo "  gate: ce-tokyo prefix in FRR vrf-cust RIB"
+else
+    ng "gate: ce-tokyo prefix never installed in FRR vrf-cust RIB"
+fi
+
+# (c) the decap endpoints exist on both PEs.
+gate_vin_sid() {
+    # Auto-advertise installs an End.DT4 SID function; its address is dynamic.
+    dexec "$PE_TOKYO" vbctl sid list 2>/dev/null | grep -qi "end_dt4"
+}
+gate_frr_localsid() {
+    # FRR auto-installs an End.DT4 seg6local route at its transposed SID.
+    dexec "$PE_OSAKA" ip -6 route show table all 2>/dev/null \
+      | grep -qi "seg6local"
+}
+if retry gate_vin_sid; then
+    echo "  gate: Vinbero End.DT4 SID function present"
+else
+    ng "gate: Vinbero End.DT4 SID function never appeared"
+fi
+if retry gate_frr_localsid; then
+    echo "  gate: FRR seg6local End.DT4 localsid present"
+else
+    ng "gate: FRR seg6local End.DT4 localsid never appeared"
+fi
+
+# (d) underlay reachability end to end: both PE loopbacks mutually
+#     reachable through the core, and the customer ARP/NDP resolved.
+#     Source from the loopback explicitly -- without -I the kernel may
+#     pick a link address the far PE has no route back to (the lab has
+#     no IGP, only the per-loopback static routes).
+gate_underlay_tokyo() {
+    dexec "$PE_TOKYO" ping6 -c 1 -W 2 -I "$VIN_LOOPBACK" "$FRR_LOOPBACK" \
+      >/dev/null 2>&1
+}
+gate_underlay_osaka() {
+    dexec "$PE_OSAKA" ping6 -c 1 -W 2 -I "$FRR_LOOPBACK" "$VIN_LOOPBACK" \
+      >/dev/null 2>&1
+}
+if retry gate_underlay_tokyo && retry gate_underlay_osaka; then
+    echo "  gate: PE loopbacks mutually reachable through the core"
+else
+    ng "gate: PE loopbacks not mutually reachable"
+fi
+
+# Warm the customer-side ARP so the first End.DT4 decap egress and the
+# first H.Encaps customer ingress do not race NDP/ARP resolution.
+dexec "$PE_TOKYO" ping -c 1 -W 2 "$CE_TOKYO_ADDR" >/dev/null 2>&1 || true
+dexec "$PE_OSAKA" ip vrf exec vrf-cust ping -c 1 -W 2 "$CE_OSAKA_ADDR" >/dev/null 2>&1 || true
+
+echo "  --- gates passed, starting data-plane ping ---"
+
+# 4a. ce-tokyo -> ce-osaka. ce-tokyo sends plaintext IPv4; Vinbero's XDP
+# H.Encaps it towards FRR's service SID, the core forwards by the outer
+# IPv6 header, FRR's seg6 End.DT4 decaps it into vrf-cust to ce-osaka.
+# Generous retry: even with the gates above, the very first packet can
+# still lose a beat behind XDP map propagation.
+ce_tokyo_to_osaka() {
+    dexec "$CE_TOKYO" ping -c 2 -W 2 "$CE_OSAKA_ADDR" >/dev/null 2>&1
+}
+if retry_n 45 ce_tokyo_to_osaka; then
+    ok "ce-tokyo ($CE_TOKYO_ADDR) -> ce-osaka ($CE_OSAKA_ADDR) ping over SRv6 L3VPN"
+    dexec "$CE_TOKYO" ping -c 3 -W 2 "$CE_OSAKA_ADDR" 2>&1 \
+      | grep -E 'packets transmitted|rtt|round-trip' | sed 's/^/      /'
+else
+    ng "ce-tokyo -> ce-osaka ping failed"
+    dexec "$CE_TOKYO" ping -c 3 -W 2 "$CE_OSAKA_ADDR" 2>&1 | sed 's/^/      /' || true
+fi
+
+# 4b. ce-osaka -> ce-tokyo (return direction). FRR H.Encaps the customer
+# traffic towards Vinbero's End.DT4 SID; the core forwards it; Vinbero's
+# XDP decaps it and forwards to ce-tokyo.
+ce_osaka_to_tokyo() {
+    dexec "$CE_OSAKA" ping -c 2 -W 2 "$CE_TOKYO_ADDR" >/dev/null 2>&1
+}
+if retry_n 45 ce_osaka_to_tokyo; then
+    ok "ce-osaka ($CE_OSAKA_ADDR) -> ce-tokyo ($CE_TOKYO_ADDR) ping over SRv6 L3VPN"
+    dexec "$CE_OSAKA" ping -c 3 -W 2 "$CE_TOKYO_ADDR" 2>&1 \
+      | grep -E 'packets transmitted|rtt|round-trip' | sed 's/^/      /'
+else
+    ng "ce-osaka -> ce-tokyo ping failed"
+    dexec "$CE_OSAKA" ping -c 3 -W 2 "$CE_TOKYO_ADDR" 2>&1 | sed 's/^/      /' || true
+fi
+
+# --- summary ---------------------------------------------------------------
+echo ""
+echo "=============================================="
+echo " RESULT: $pass passed, $fail failed"
+echo "=============================================="
+[ "$fail" -eq 0 ] || exit 1

--- a/examples/interop-clab/scenarios/l3vpn-2site-auto/test.sh
+++ b/examples/interop-clab/scenarios/l3vpn-2site-auto/test.sh
@@ -150,15 +150,20 @@ echo "[3] Vinbero -> FRR  (SRv6 Service TLV encode)"
 
 # Vinbero auto-advertises the ce-tokyo subnet (10.1.0.0/24): the exporter mints
 # the End.DT4 SID from LOC1 and advertises the route with no vbctl call. The SID
-# is dynamic, so discover it from Vinbero rather than hard-coding it.
-VIN_SID=$(dexec "$PE_TOKYO" vbctl sid list 2>/dev/null \
-  | awk 'tolower($0) ~ /end_dt4/ {print $1; exit}')
-VIN_SID=${VIN_SID%/128}
+# is dynamic, so discover it from Vinbero inside the retry -- it may not be in
+# sid_function_map yet on the first poll, and an empty SID must NOT false-PASS
+# the comparison (an empty FRR remote SID would otherwise match an empty VIN_SID).
+VIN_SID=""
 check_frr_rib() {
-    local got
+    local got sid
+    sid=$(dexec "$PE_TOKYO" vbctl sid list 2>/dev/null \
+      | awk 'tolower($0) ~ /end_dt4/ {print $1; exit}')
+    sid=${sid%/128}
+    [ -n "$sid" ] || return 1
+    VIN_SID="$sid"
     got=$(dexec "$PE_OSAKA" vtysh -c "show bgp ipv4 vpn $TOKYO_PREFIX json" 2>/dev/null \
       | frr_route_sid 2>/dev/null)
-    [ "$got" = "$VIN_SID" ]
+    [ -n "$got" ] && [ "$got" = "$sid" ]
 }
 if retry check_frr_rib; then
     ok "FRR RIB has $TOKYO_PREFIX with SRv6 SID $VIN_SID"

--- a/examples/interop-clab/scenarios/l3vpn-2site-auto/vinbero/start.sh
+++ b/examples/interop-clab/scenarios/l3vpn-2site-auto/vinbero/start.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Bring up the Vinbero PE (pe-tokyo) for the auto-advertise variant.
+#
+# Unlike l3vpn-2site, this scenario does NOT call `vbctl sid create` or
+# `vbctl bgp advertise-vpn`. The locator (LOC1), the vrf-cust binding, and the
+# auto_advertise toggle are declared in vinbero.yml; the exporter mints the
+# End.DT4/DT6 service SID and advertises the VRF-local customer prefix on its
+# own once it sees the route in the vrf-cust table.
+#
+# Interfaces:
+#   eth1  pe-tokyo <-> core   underlay 2001:db8:1::/64  (pe-tokyo = ::1)
+#   eth2  pe-tokyo <-> ce-tokyo  customer 10.1.0.0/24   (pe-tokyo = .1)
+#   lo    loopback 2001:db8:ff::1  (iBGP peering / SRv6 transport)
+
+setknob() {
+    sysctl -w "$1=$2" >/dev/null 2>&1 || true
+}
+
+# --- interface addressing --------------------------------------------------
+ip -6 addr add 2001:db8:1::1/64 dev eth1 2>/dev/null || true
+ip link set eth1 up
+ip addr add 10.1.0.1/24 dev eth2 2>/dev/null || true
+ip link set eth2 up
+ip -6 addr add 2001:db8:ff::1/128 dev lo 2>/dev/null || true
+ip link set lo up
+
+# --- SRv6 dataplane knobs (namespace-scoped, best-effort) ------------------
+setknob net.ipv4.ip_forward 1
+setknob net.ipv6.conf.all.forwarding 1
+setknob net.ipv6.conf.all.seg6_enabled 1
+setknob net.ipv6.conf.eth1.seg6_enabled 1
+setknob net.ipv6.conf.eth2.seg6_enabled 1
+setknob net.ipv4.conf.all.rp_filter 0
+setknob net.ipv4.conf.default.rp_filter 0
+setknob net.ipv4.conf.eth2.rp_filter 0
+
+ethtool -K eth1 txvlan off 2>/dev/null || true
+ethtool -K eth1 rxvlan off 2>/dev/null || true
+ethtool -K eth2 txvlan off 2>/dev/null || true
+ethtool -K eth2 rxvlan off 2>/dev/null || true
+
+# --- customer VRF (table 100): decap endpoint + auto-advertise source ------
+# The auto-advertise exporter resolves vrf-cust to its table id and watches
+# that table. The VRF must exist before vinberod starts so EnableVRF can
+# resolve it at startup.
+if ! ip link show vrf-cust >/dev/null 2>&1; then
+    ip link add vrf-cust type vrf table 100
+fi
+if ! ip link show vrf-cust >/dev/null 2>&1; then
+    echo "ERROR: failed to create VRF vrf-cust -- is the kernel 'vrf' module loaded on the host? (modprobe vrf)" >&2
+    exit 1
+fi
+ip link set vrf-cust up
+ip rule add l3mdev protocol kernel prio 1000 2>/dev/null || true
+# The local customer subnet, in table 100. `proto static` is required: the
+# route watcher's redistribute=[static] allowlist only forwards RTPROT_STATIC;
+# a bare `ip route` would be RTPROT_BOOT, which is intentionally excluded to
+# avoid leaking casually-added routes into the VPN. The End.DT4 BPF FIB lookup
+# (keyed by the vrf-cust ifindex) also resolves it for the decap return path.
+ip route replace 10.1.0.0/24 dev eth2 table 100 proto static
+
+# --- static underlay routes ------------------------------------------------
+# `src 2001:db8:ff::1` forces the outbound iBGP TCP connection to source from
+# our loopback so the loopback-to-loopback session establishes.
+ip -6 route replace 2001:db8:ff::2/128 via 2001:db8:1::2 dev eth1 \
+    src 2001:db8:ff::1
+ip -6 route replace fd00:200::/48 via 2001:db8:1::2 dev eth1
+
+# BPF filesystem for pinned maps / XDP links.
+mount -t bpf bpf /sys/fs/bpf 2>/dev/null || true
+
+mkdir -p /etc/vinbero
+cp /vinbero.yml /etc/vinbero/vinbero.yaml
+
+# Start the daemon. LOC1, the vrf-cust binding, and auto_advertise are all in
+# vinbero.yml, so no vbctl calls are needed: the exporter mints the End.DT4/DT6
+# SID and advertises 10.1.0.0/24 by itself.
+/usr/local/bin/vinberod --bgp-enabled -c /etc/vinbero/vinbero.yaml \
+    > /var/log/vinberod.log 2>&1 &
+echo $! > /var/run/vinberod.pid
+
+# Wait for the RPC server (localhost:8080) to accept connections.
+for i in $(seq 1 30); do
+    if /usr/local/bin/vbctl locator list >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+
+# Pre-resolve neighbours so the first XDP BPF FIB lookups never hit
+# BPF_FIB_LKUP_RET_NO_NEIGH on the first packet.
+ping6 -c 1 -W 2 2001:db8:1::2 >/dev/null 2>&1 || true
+ping -c 1 -W 2 10.1.0.10 >/dev/null 2>&1 || true
+
+echo "[start.sh] pe-tokyo (Vinbero, auto-advertise) PE ready"

--- a/examples/interop-clab/scenarios/l3vpn-2site-auto/vinbero/vinbero.yml
+++ b/examples/interop-clab/scenarios/l3vpn-2site-auto/vinbero/vinbero.yml
@@ -1,0 +1,90 @@
+internal:
+  # eth1 faces the core (SRv6 underlay): the XDP data plane here runs the
+  # End.DT4 *decap* of return traffic coming back from pe-osaka.
+  # eth2 faces ce-tokyo: the XDP data plane there runs the H.Encaps of
+  # plaintext customer traffic towards FRR's service SID.
+  devices:
+    - eth1
+    - eth2
+  bpf:
+    device_mode: "generic"
+    verifier_log_level: 2
+    verifier_log_size: 1073741823
+  server:
+    bind: "0.0.0.0:8080"
+  logger:
+    level: info
+    format: text
+    no_color: true
+    add_caller: false
+
+settings:
+  enable_stats: false
+  fdb_aging_seconds: 300
+  entries:
+    sid_function:
+      capacity: 1024
+    headendv4:
+      capacity: 1024
+    headendv6:
+      capacity: 1024
+    headend_l2:
+      capacity: 1024
+    fdb:
+      capacity: 8192
+    bd_peer:
+      capacity: 1024
+
+# In-process BGP speaker with VRF-export driven auto-advertise.
+#
+# Unlike l3vpn-2site, this scenario advertises the customer prefix WITHOUT a
+# `vbctl bgp advertise-vpn` call: the locator, the VRF binding, and the
+# auto_advertise toggle are all declared here, so the exporter mints the
+# End.DT4/DT6 service SID and advertises 10.1.0.0/24 on its own once it sees
+# the route in the vrf-cust table. The locator is declared in config (not over
+# RPC) because the exporter resolves default_locator at startup, before any
+# RPC arrives.
+bgp:
+  global:
+    local_asn: 65100
+    router_id: "10.255.0.1"
+    listen_port: 179
+    # Source locator for the receive applier's encap source AND the
+    # auto-advertise next hop (the locator block is reachable through the core,
+    # FRR has a static route to fd00:100::/48).
+    source_locator: "LOC1"
+    # Turn on the VRF-export auto-advertise path.
+    auto_advertise: true
+    # BGP next hop for auto-advertised routes: our loopback (a normal node
+    # address), NOT the locator base -- FRR treats a locator's subnet-router
+    # anycast address as local and would not forward toward it.
+    next_hop: "2001:db8:ff::1"
+  locators:
+    - name: LOC1
+      prefix: fd00:100::/48
+      block_len: 32
+      node_len: 16
+      function_len: 16
+      argument_len: 64
+      behavior: classic
+  vrf_bindings:
+    # vrf-cust's static routes (10.1.0.0/24, proto static) are auto-advertised
+    # as VPNv4 with RT 65000:200 (FRR's vrf-cust import RT) and an End.DT4 SID
+    # minted from LOC1.
+    - vrf_name: vrf-cust
+      rd: "65100:200"
+      # import_rts is required now that a binding exists: with any binding
+      # registered the applier stops accepting every route and filters by
+      # import RT. FRR exports 10.2.0.0/24 with RT 65000:200 (rt vpn both).
+      import_rts: ["65000:200"]
+      export_rts: ["65000:200"]
+      default_locator: LOC1
+      redistribute: [static]
+  peers:
+    - neighbor: "2001:db8:ff::2"
+      peer_asn: 65100
+      hold_time_sec: 30
+      keepalive_sec: 10
+      families:
+        - vpnv4
+        - vpnv6

--- a/pkg/bgp/apply/applier.go
+++ b/pkg/bgp/apply/applier.go
@@ -173,7 +173,7 @@ func (a *Applier) HasLocalSRPolicy(color uint32, endpoint netip.Addr) bool {
 
 func (a *Applier) applyVPN(vr *bgp.VPNRoute, withdraw bool) {
 	owner := bpf.OwnerBGPVPN(a.localASN, vr.RD)
-	rk := bgp.RouteKey{Family: vr.Family, Prefix: vr.Prefix, RD: vr.RD}
+	rk := vr.Key()
 	if withdraw {
 		// Release any SR Policy reference this route held. The withdraw
 		// event carries no color/next-hop, so the reverse index is the only

--- a/pkg/bgp/bgp.go
+++ b/pkg/bgp/bgp.go
@@ -139,6 +139,11 @@ type VPNRoute struct {
 	Color uint32
 }
 
+// Key returns the RouteKey that identifies this VPN route for withdrawal.
+func (r VPNRoute) Key() RouteKey {
+	return RouteKey{Family: r.Family, Prefix: r.Prefix, RD: r.RD}
+}
+
 // UnicastRoute is a plain IPv6 unicast route.
 type UnicastRoute struct {
 	Prefix  string
@@ -384,9 +389,9 @@ type MUPRoute struct {
 	TEID uint32
 	// TEIDLen is the significant TEID prefix length in bits: 32 for T1ST (exact),
 	// 0..32 for T2ST (EndpointAddressLength - 32 for IPv4). 0 means "any TEID".
-	TEIDLen uint8
-	QFI     uint8  // T1ST QoS Flow Identifier
-	RQI     uint8  // T1ST Reflective QoS Indicator
+	TEIDLen  uint8
+	QFI      uint8  // T1ST QoS Flow Identifier
+	RQI      uint8  // T1ST Reflective QoS Indicator
 	Endpoint string // T1ST gNB N3 address / T2ST GTP tunnel endpoint
 	Source   string // T1ST optional source address ("" if none)
 

--- a/pkg/bgp/export/exporter.go
+++ b/pkg/bgp/export/exporter.go
@@ -201,6 +201,14 @@ func (e *Exporter) unwind(names []string) {
 	for _, name := range names {
 		e.DisableVRF(name)
 	}
+	// Roll the underlay registration back too, so a failure after the underlay
+	// was enabled leaves no RT_TABLE_MAIN watch or underlay state behind.
+	e.mu.Lock()
+	if e.underlay != nil {
+		e.watcher.UnregisterTable(unix.RT_TABLE_MAIN)
+		e.underlay = nil
+	}
+	e.mu.Unlock()
 }
 
 // Stop halts the route watcher and withdraws every advertised route. It is
@@ -371,6 +379,12 @@ func (e *Exporter) OnRoute(table uint32, prefix netip.Prefix, added bool) {
 			zap.String("sid", vr.SRv6SID))
 		return
 	}
+	if _, ok := st.advertised[key]; !ok {
+		// We never advertised this prefix (skipped by max-prefix, or a failed
+		// initial Advertise): do not withdraw -- the same NLRI could belong to
+		// another owner in the gobgp tracking map.
+		return
+	}
 	if err := e.advertiser.Withdraw(context.Background(), key); err != nil {
 		e.logger.Error("withdraw VRF-local prefix",
 			zap.String("vrf", st.binding.VRFName), zap.String("prefix", vr.Prefix), zap.Error(err))
@@ -410,6 +424,11 @@ func (e *Exporter) applyUnderlay(prefix netip.Prefix, added bool) {
 		}
 		e.underlay.advertised[key] = struct{}{}
 		e.logger.Info("auto-advertised underlay prefix", zap.String("prefix", ur.Prefix))
+		return
+	}
+	if _, ok := e.underlay.advertised[key]; !ok {
+		// Never advertised (filtered, or a failed AdvertiseUnicast); skip the
+		// withdraw so we don't touch another owner's same-NLRI path.
 		return
 	}
 	if err := e.advertiser.Withdraw(context.Background(), key); err != nil {

--- a/pkg/bgp/export/exporter.go
+++ b/pkg/bgp/export/exporter.go
@@ -1,0 +1,369 @@
+// Package export is the advertise-direction counterpart of pkg/bgp/apply:
+// it turns Vinbero's VRF-local state into BGP VPNv4 / VPNv6 advertisements
+// without an operator running an explicit BgpRouteService call. This is the
+// VRF-export driven "automatic advertise" path (docs/plan/bgp-auto-advertise.md).
+//
+// The flow mirrors apply.applyVPN in reverse. Where the receive path takes a
+// VPN route, resolves its route targets to a VRF, and installs a headend
+// encap entry, the export path takes a VRF-local prefix, composes the VRF's
+// export route targets and its End.DT4/DT6 service SID, and advertises a VPN
+// route. The exporter owns its RouteWatcher: Start enables every VRF binding
+// that lists a redistribute set and begins watching, so the daemon wiring is a
+// single Start / Stop pair (mirroring vinbero.StartFDBWatcher).
+package export
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"sync"
+
+	"go.uber.org/zap"
+
+	v1 "github.com/takehaya/vinbero/api/vinbero/v1"
+	"github.com/takehaya/vinbero/pkg/bgp"
+	"github.com/takehaya/vinbero/pkg/bpf"
+	"github.com/takehaya/vinbero/pkg/locator"
+	"github.com/takehaya/vinbero/pkg/netlinkwatch"
+	"github.com/takehaya/vinbero/pkg/vrfbgp"
+)
+
+// Endpoint behaviors advertised for a VRF's local prefixes: End.DT4 for the
+// VPNv4 service SID, End.DT6 for VPNv6 (RFC 9252 §6). These are constant
+// expressions so they fold at compile time.
+const (
+	endpointActionDT4 = uint8(v1.Srv6LocalAction_SRV6_LOCAL_ACTION_END_DT4)
+	endpointActionDT6 = uint8(v1.Srv6LocalAction_SRV6_LOCAL_ACTION_END_DT6)
+)
+
+// SidOps is the subset of bpf.MapOperations the exporter needs to install
+// and remove the per-VRF Endpoint SID. Narrowing it to an interface keeps
+// the exporter unit-testable without a live BPF collection.
+type SidOps interface {
+	CreateSidFunction(triggerPrefix string, entry *bpf.SidFunctionEntry, aux *bpf.SidAuxEntry, owner bpf.OwnerTag) error
+	DeleteSidFunction(triggerPrefix string, requester bpf.OwnerTag) error
+}
+
+// VRFResolver maps a VRF name to the kernel ifindex of its l3mdev device and
+// the routing table id that device owns. The export path needs the ifindex to
+// build the End.DT4/DT6 aux entry and the table id to match incoming route
+// events to a VRF. The netlink-backed implementation lives in this package
+// (NetlinkVRFResolver); tests supply a fake.
+type VRFResolver interface {
+	Resolve(vrfName string) (ifindex uint32, table uint32, err error)
+}
+
+// vrfState is the per-VRF export bookkeeping: the binding, the resolved table,
+// the two Endpoint SIDs minted from the binding's locator, and the set of
+// prefixes currently advertised (so DisableVRF can withdraw them all and a
+// per-prefix withdraw can drop exactly one).
+type vrfState struct {
+	binding    vrfbgp.Binding
+	table      uint32
+	v4SID      netip.Addr
+	v6SID      netip.Addr
+	advertised map[bgp.RouteKey]struct{}
+}
+
+// Exporter advertises VRF-local prefixes as VPNv4 / VPNv6 routes. It is safe
+// for concurrent use: OnRoute runs on the RouteWatcher goroutine while
+// EnableVRF / DisableVRF run on the daemon's setup / teardown path, so one
+// mutex guards all state.
+type Exporter struct {
+	mu          sync.Mutex
+	advertiser  bgp.RouteAdvertiser
+	sidOps      SidOps
+	locators    *locator.Manager
+	vrfBindings *vrfbgp.Manager
+	resolver    VRFResolver
+	watcher     *netlinkwatch.RouteWatcher
+	srcLocator  string
+	logger      *zap.Logger
+	vrfs        map[string]*vrfState
+	byTable     map[uint32]*vrfState
+	// srcAddr is the SRv6 next hop (the advertising PE's reachable address),
+	// resolved once from srcLocator on the first EnableVRF and reused for every
+	// advertisement so the hot OnRoute path does no locator lookup.
+	srcAddr     netip.Addr
+	srcResolved bool
+}
+
+// New wires an Exporter and its RouteWatcher. srcLocator names the locator
+// whose prefix supplies the SRv6 next hop, matching the receive path's encap
+// source (apply.encapSource). vrfBindings is the shared binding registry the
+// applier also reads, so the advertise and receive directions agree on which
+// VRFs exist.
+func New(advertiser bgp.RouteAdvertiser, sidOps SidOps, locators *locator.Manager, vrfBindings *vrfbgp.Manager, resolver VRFResolver, srcLocator string, logger *zap.Logger) *Exporter {
+	e := &Exporter{
+		advertiser:  advertiser,
+		sidOps:      sidOps,
+		locators:    locators,
+		vrfBindings: vrfBindings,
+		resolver:    resolver,
+		srcLocator:  srcLocator,
+		logger:      logger.Named("bgp.export"),
+		vrfs:        make(map[string]*vrfState),
+		byTable:     make(map[uint32]*vrfState),
+	}
+	e.watcher = netlinkwatch.NewRouteWatcher(e, logger)
+	return e
+}
+
+// Start enables every VRF binding that lists a redistribute set and begins
+// watching the kernel routing tables. EnableVRF mints each VRF's End.DT4/DT6
+// service SID and returns the table the watcher must observe; the watcher's
+// ListExisting replay then advertises prefixes already present at boot. A
+// binding with no redistribute set is left receive-only.
+func (e *Exporter) Start(ctx context.Context) error {
+	enabled := make([]string, 0)
+	for _, b := range e.vrfBindings.List() {
+		if len(b.Redistribute) == 0 {
+			continue
+		}
+		table, err := e.EnableVRF(b)
+		if err != nil {
+			e.unwind(enabled)
+			return fmt.Errorf("auto-advertise vrf %q: %w", b.VRFName, err)
+		}
+		if err := e.watcher.RegisterTable(table, b.Redistribute); err != nil {
+			e.unwind(enabled)
+			return fmt.Errorf("auto-advertise vrf %q: %w", b.VRFName, err)
+		}
+		enabled = append(enabled, b.VRFName)
+	}
+	if err := e.watcher.Start(ctx); err != nil {
+		e.unwind(enabled)
+		return err
+	}
+	return nil
+}
+
+// unwind disables the VRFs already enabled in a Start that then failed, so a
+// partial startup leaves no Endpoint SID installed and no orphaned state. It is
+// the transactional counterpart of EnableVRF's own DT4-rollback-on-DT6-failure.
+func (e *Exporter) unwind(names []string) {
+	for _, name := range names {
+		e.DisableVRF(name)
+	}
+}
+
+// Stop halts the route watcher and withdraws every advertised route. It is
+// meant for graceful shutdown: the watcher stops first so no new advertisement
+// races the withdraw, then Close drains the advertised state.
+func (e *Exporter) Stop() {
+	e.watcher.Stop()
+	e.Close()
+}
+
+// EnableVRF makes b's local prefixes eligible for auto advertise and returns
+// the routing table id the watcher should observe. It resolves the VRF device,
+// mints an End.DT4 and an End.DT6 service SID from the binding's default
+// locator, and installs them into sid_function_map so a remote PE's receive
+// side can decapsulate toward this node. A binding without an RD or a default
+// locator is rejected because it cannot form a VPN route. EnableVRF does not
+// itself advertise anything; advertisements follow from OnRoute as prefixes
+// appear.
+func (e *Exporter) EnableVRF(b vrfbgp.Binding) (uint32, error) {
+	if b.RD == "" {
+		return 0, fmt.Errorf("vrf %q: rd is required for auto advertise", b.VRFName)
+	}
+	if b.DefaultLocator == "" {
+		return 0, fmt.Errorf("vrf %q: default_locator is required for auto advertise", b.VRFName)
+	}
+
+	ifindex, table, err := e.resolver.Resolve(b.VRFName)
+	if err != nil {
+		return 0, fmt.Errorf("resolve vrf %q: %w", b.VRFName, err)
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if err := e.ensureEncapSource(); err != nil {
+		return 0, fmt.Errorf("vrf %q: %w", b.VRFName, err)
+	}
+	if _, ok := e.vrfs[b.VRFName]; ok {
+		return 0, fmt.Errorf("vrf %q: already enabled", b.VRFName)
+	}
+	// Two VRFs resolving to the same routing table would collide in byTable,
+	// silently mis-attributing one VRF's prefixes to the other's RD/RT/SID.
+	// Reject the second one instead.
+	if existing, ok := e.byTable[table]; ok {
+		return 0, fmt.Errorf("vrf %q: routing table %d is already exported by vrf %q",
+			b.VRFName, table, existing.binding.VRFName)
+	}
+
+	v4SID, err := e.installEndpointSID(b.DefaultLocator, ifindex, endpointActionDT4)
+	if err != nil {
+		return 0, fmt.Errorf("vrf %q: install End.DT4 SID: %w", b.VRFName, err)
+	}
+	v6SID, err := e.installEndpointSID(b.DefaultLocator, ifindex, endpointActionDT6)
+	if err != nil {
+		// Roll the End.DT4 SID back so a half-enabled VRF leaves no orphan.
+		e.removeEndpointSID(v4SID)
+		return 0, fmt.Errorf("vrf %q: install End.DT6 SID: %w", b.VRFName, err)
+	}
+
+	st := &vrfState{
+		binding:    b,
+		table:      table,
+		v4SID:      v4SID,
+		v6SID:      v6SID,
+		advertised: make(map[bgp.RouteKey]struct{}),
+	}
+	e.vrfs[b.VRFName] = st
+	e.byTable[table] = st
+	e.logger.Info("VRF enabled for auto advertise",
+		zap.String("vrf", b.VRFName), zap.String("rd", b.RD),
+		zap.Uint32("table", table),
+		zap.String("dt4_sid", v4SID.String()), zap.String("dt6_sid", v6SID.String()))
+	return table, nil
+}
+
+// DisableVRF withdraws every prefix advertised for vrfName and releases its
+// Endpoint SIDs back to the locator pool. It is a no-op for an unknown VRF.
+func (e *Exporter) DisableVRF(vrfName string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	st, ok := e.vrfs[vrfName]
+	if !ok {
+		return
+	}
+	for key := range st.advertised {
+		if err := e.advertiser.Withdraw(context.Background(), key); err != nil {
+			e.logger.Warn("withdraw on disable",
+				zap.String("vrf", vrfName), zap.String("prefix", key.Prefix), zap.Error(err))
+		}
+	}
+	e.removeEndpointSID(st.v4SID)
+	e.removeEndpointSID(st.v6SID)
+	delete(e.byTable, st.table)
+	delete(e.vrfs, vrfName)
+	e.logger.Info("VRF disabled for auto advertise", zap.String("vrf", vrfName))
+}
+
+// Close disables every enabled VRF. It is the withdraw half of Stop; the
+// route watcher must already be stopped so no advertisement races it.
+func (e *Exporter) Close() {
+	e.mu.Lock()
+	names := make([]string, 0, len(e.vrfs))
+	for name := range e.vrfs {
+		names = append(names, name)
+	}
+	e.mu.Unlock()
+	for _, name := range names {
+		e.DisableVRF(name)
+	}
+}
+
+// OnRoute reacts to a VRF-local prefix appearing (added=true) or being removed
+// (added=false) in a routing table. It is the RouteWatcher (RouteSink)
+// callback. A prefix in a table no VRF owns is ignored. The underlying
+// advertiser.Withdraw is a no-op for a route that was never advertised, so
+// duplicate deletes are safe.
+func (e *Exporter) OnRoute(table uint32, prefix netip.Prefix, added bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	st, ok := e.byTable[table]
+	if !ok {
+		return
+	}
+	vr := e.buildVPNRoute(st, prefix)
+	key := vr.Key()
+	if added {
+		if _, dup := st.advertised[key]; dup {
+			// Already advertised (a ListExisting refresh or a duplicate
+			// RTM_NEWROUTE); the gobgp path is unchanged, so skip the redundant
+			// AddPath and log.
+			return
+		}
+		if err := e.advertiser.Advertise(context.Background(), vr); err != nil {
+			e.logger.Error("advertise VRF-local prefix",
+				zap.String("vrf", st.binding.VRFName), zap.String("prefix", vr.Prefix), zap.Error(err))
+			return
+		}
+		st.advertised[key] = struct{}{}
+		e.logger.Info("auto-advertised VRF-local prefix",
+			zap.String("vrf", st.binding.VRFName), zap.String("prefix", vr.Prefix),
+			zap.String("sid", vr.SRv6SID))
+		return
+	}
+	if err := e.advertiser.Withdraw(context.Background(), key); err != nil {
+		e.logger.Error("withdraw VRF-local prefix",
+			zap.String("vrf", st.binding.VRFName), zap.String("prefix", vr.Prefix), zap.Error(err))
+		return
+	}
+	delete(st.advertised, key)
+}
+
+// buildVPNRoute composes the VPNv4 / VPNv6 advertisement for a VRF-local
+// prefix: the family and Endpoint SID follow the prefix's address family, the
+// route targets and RD come from the binding, and the next hop is the cached
+// encap source. The caller holds e.mu (srcAddr is resolved before any VRF is
+// enabled). It performs no I/O so it is the natural unit-test seam.
+func (e *Exporter) buildVPNRoute(st *vrfState, prefix netip.Prefix) bgp.VPNRoute {
+	addr := prefix.Addr().Unmap()
+	family := bgp.FamilyVPNv6
+	sid := st.v6SID
+	if addr.Is4() {
+		family = bgp.FamilyVPNv4
+		sid = st.v4SID
+	}
+	// Normalize so a 4-in-6 address renders as a plain IPv4 prefix string.
+	norm := netip.PrefixFrom(addr, prefix.Bits())
+	return bgp.VPNRoute{
+		Family:  family,
+		Prefix:  norm.String(),
+		RD:      st.binding.RD,
+		RTs:     st.binding.ExportRTs,
+		SRv6SID: sid.String(),
+		NextHop: e.srcAddr.String(),
+	}
+}
+
+// ensureEncapSource resolves the SRv6 next hop from the source locator once and
+// caches it. It mirrors apply.encapSource so the advertise and receive
+// directions agree on the PE's address. The caller holds e.mu.
+func (e *Exporter) ensureEncapSource() error {
+	if e.srcResolved {
+		return nil
+	}
+	if e.srcLocator == "" {
+		return fmt.Errorf("bgp.global.source_locator is not configured")
+	}
+	loc, ok := e.locators.Get(e.srcLocator)
+	if !ok {
+		return fmt.Errorf("source locator %q is not registered", e.srcLocator)
+	}
+	e.srcAddr = loc.Prefix.Masked().Addr()
+	e.srcResolved = true
+	return nil
+}
+
+// installEndpointSID mints a function from locatorName, builds the SID, and
+// installs it into sid_function_map as an l3vrf endpoint owned by Vinbero
+// (OwnerBuiltin). On any failure the function is returned to the pool so a
+// failed install leaks nothing. The caller holds e.mu.
+func (e *Exporter) installEndpointSID(locatorName string, ifindex uint32, action uint8) (netip.Addr, error) {
+	sid, _, err := e.locators.AllocateSID(locatorName, nil)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+	entry := &bpf.SidFunctionEntry{Action: action}
+	aux := bpf.NewSidAuxL3Vrf(ifindex)
+	if err := e.sidOps.CreateSidFunction(sid.String()+"/128", entry, aux, bpf.OwnerBuiltin); err != nil {
+		e.locators.ReleaseSID(sid)
+		return netip.Addr{}, err
+	}
+	return sid, nil
+}
+
+// removeEndpointSID deletes the Endpoint SID from sid_function_map and returns
+// its function to the locator pool. Best-effort: a delete failure is logged,
+// not propagated, so teardown of the rest of the VRF still proceeds. The
+// caller holds e.mu.
+func (e *Exporter) removeEndpointSID(sid netip.Addr) {
+	if err := e.sidOps.DeleteSidFunction(sid.String()+"/128", bpf.OwnerBuiltin); err != nil {
+		e.logger.Warn("delete Endpoint SID", zap.String("sid", sid.String()), zap.Error(err))
+	}
+	e.locators.ReleaseSID(sid)
+}

--- a/pkg/bgp/export/exporter.go
+++ b/pkg/bgp/export/exporter.go
@@ -282,6 +282,15 @@ func (e *Exporter) OnRoute(table uint32, prefix netip.Prefix, added bool) {
 			// AddPath and log.
 			return
 		}
+		if st.binding.MaxPrefixes > 0 && uint32(len(st.advertised)) >= st.binding.MaxPrefixes {
+			// Per-VRF prefix cap reached: do not originate more, bounding the
+			// blast radius of a flood of VRF-local routes.
+			e.logger.Warn("VRF prefix limit reached; not advertising",
+				zap.String("vrf", st.binding.VRFName),
+				zap.String("prefix", vr.Prefix),
+				zap.Uint32("max", st.binding.MaxPrefixes))
+			return
+		}
 		if err := e.advertiser.Advertise(context.Background(), vr); err != nil {
 			e.logger.Error("advertise VRF-local prefix",
 				zap.String("vrf", st.binding.VRFName), zap.String("prefix", vr.Prefix), zap.Error(err))

--- a/pkg/bgp/export/exporter.go
+++ b/pkg/bgp/export/exporter.go
@@ -77,30 +77,31 @@ type Exporter struct {
 	vrfBindings *vrfbgp.Manager
 	resolver    VRFResolver
 	watcher     *netlinkwatch.RouteWatcher
-	srcLocator  string
-	logger      *zap.Logger
-	vrfs        map[string]*vrfState
-	byTable     map[uint32]*vrfState
-	// srcAddr is the SRv6 next hop (the advertising PE's reachable address),
-	// resolved once from srcLocator on the first EnableVRF and reused for every
-	// advertisement so the hot OnRoute path does no locator lookup.
-	srcAddr     netip.Addr
-	srcResolved bool
+	// nextHop is the BGP next hop stamped on every advertised route: the
+	// advertising PE's own reachable IPv6 address (typically its loopback). It
+	// is deliberately NOT the locator base -- a locator prefix's subnet-router
+	// anycast address (e.g. fd00:100::) is treated as a local address by a
+	// receiving PE, which then fails to forward the SRv6-encapsulated traffic.
+	// The next hop must be an ordinary node address.
+	nextHop string
+	logger  *zap.Logger
+	vrfs    map[string]*vrfState
+	byTable map[uint32]*vrfState
 }
 
-// New wires an Exporter and its RouteWatcher. srcLocator names the locator
-// whose prefix supplies the SRv6 next hop, matching the receive path's encap
-// source (apply.encapSource). vrfBindings is the shared binding registry the
-// applier also reads, so the advertise and receive directions agree on which
-// VRFs exist.
-func New(advertiser bgp.RouteAdvertiser, sidOps SidOps, locators *locator.Manager, vrfBindings *vrfbgp.Manager, resolver VRFResolver, srcLocator string, logger *zap.Logger) *Exporter {
+// New wires an Exporter and its RouteWatcher. nextHop is the advertising PE's
+// reachable IPv6 address (its loopback), stamped as the BGP next hop on every
+// advertised route. vrfBindings is the shared binding registry the applier
+// also reads, so the advertise and receive directions agree on which VRFs
+// exist.
+func New(advertiser bgp.RouteAdvertiser, sidOps SidOps, locators *locator.Manager, vrfBindings *vrfbgp.Manager, resolver VRFResolver, nextHop string, logger *zap.Logger) *Exporter {
 	e := &Exporter{
 		advertiser:  advertiser,
 		sidOps:      sidOps,
 		locators:    locators,
 		vrfBindings: vrfBindings,
 		resolver:    resolver,
-		srcLocator:  srcLocator,
+		nextHop:     nextHop,
 		logger:      logger.Named("bgp.export"),
 		vrfs:        make(map[string]*vrfState),
 		byTable:     make(map[uint32]*vrfState),
@@ -113,7 +114,9 @@ func New(advertiser bgp.RouteAdvertiser, sidOps SidOps, locators *locator.Manage
 // watching the kernel routing tables. EnableVRF mints each VRF's End.DT4/DT6
 // service SID and returns the table the watcher must observe; the watcher's
 // ListExisting replay then advertises prefixes already present at boot. A
-// binding with no redistribute set is left receive-only.
+// binding with no redistribute set is left receive-only. If any binding fails
+// to enable, the VRFs already enabled in this call are unwound so a partial
+// startup leaves no orphaned SID.
 func (e *Exporter) Start(ctx context.Context) error {
 	enabled := make([]string, 0)
 	for _, b := range e.vrfBindings.List() {
@@ -170,6 +173,12 @@ func (e *Exporter) EnableVRF(b vrfbgp.Binding) (uint32, error) {
 	if b.DefaultLocator == "" {
 		return 0, fmt.Errorf("vrf %q: default_locator is required for auto advertise", b.VRFName)
 	}
+	if e.nextHop == "" {
+		return 0, fmt.Errorf("vrf %q: bgp.global.next_hop is required for auto advertise", b.VRFName)
+	}
+	if _, err := netip.ParseAddr(e.nextHop); err != nil {
+		return 0, fmt.Errorf("vrf %q: bgp.global.next_hop %q is invalid: %w", b.VRFName, e.nextHop, err)
+	}
 
 	ifindex, table, err := e.resolver.Resolve(b.VRFName)
 	if err != nil {
@@ -178,9 +187,6 @@ func (e *Exporter) EnableVRF(b vrfbgp.Binding) (uint32, error) {
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	if err := e.ensureEncapSource(); err != nil {
-		return 0, fmt.Errorf("vrf %q: %w", b.VRFName, err)
-	}
 	if _, ok := e.vrfs[b.VRFName]; ok {
 		return 0, fmt.Errorf("vrf %q: already enabled", b.VRFName)
 	}
@@ -297,9 +303,9 @@ func (e *Exporter) OnRoute(table uint32, prefix netip.Prefix, added bool) {
 
 // buildVPNRoute composes the VPNv4 / VPNv6 advertisement for a VRF-local
 // prefix: the family and Endpoint SID follow the prefix's address family, the
-// route targets and RD come from the binding, and the next hop is the cached
-// encap source. The caller holds e.mu (srcAddr is resolved before any VRF is
-// enabled). It performs no I/O so it is the natural unit-test seam.
+// route targets and RD come from the binding, and the next hop is the
+// configured PE address. The caller holds e.mu. It performs no I/O so it is the
+// natural unit-test seam.
 func (e *Exporter) buildVPNRoute(st *vrfState, prefix netip.Prefix) bgp.VPNRoute {
 	addr := prefix.Addr().Unmap()
 	family := bgp.FamilyVPNv6
@@ -316,27 +322,8 @@ func (e *Exporter) buildVPNRoute(st *vrfState, prefix netip.Prefix) bgp.VPNRoute
 		RD:      st.binding.RD,
 		RTs:     st.binding.ExportRTs,
 		SRv6SID: sid.String(),
-		NextHop: e.srcAddr.String(),
+		NextHop: e.nextHop,
 	}
-}
-
-// ensureEncapSource resolves the SRv6 next hop from the source locator once and
-// caches it. It mirrors apply.encapSource so the advertise and receive
-// directions agree on the PE's address. The caller holds e.mu.
-func (e *Exporter) ensureEncapSource() error {
-	if e.srcResolved {
-		return nil
-	}
-	if e.srcLocator == "" {
-		return fmt.Errorf("bgp.global.source_locator is not configured")
-	}
-	loc, ok := e.locators.Get(e.srcLocator)
-	if !ok {
-		return fmt.Errorf("source locator %q is not registered", e.srcLocator)
-	}
-	e.srcAddr = loc.Prefix.Masked().Addr()
-	e.srcResolved = true
-	return nil
 }
 
 // installEndpointSID mints a function from locatorName, builds the SID, and

--- a/pkg/bgp/export/exporter.go
+++ b/pkg/bgp/export/exporter.go
@@ -55,6 +55,15 @@ type VRFResolver interface {
 	Resolve(vrfName string) (ifindex uint32, table uint32, err error)
 }
 
+// UnderlayConfig configures IPv6 unicast underlay advertisement.
+type UnderlayConfig struct {
+	// Redistribute lists the main-table route protocols ("connected"/"static")
+	// whose IPv6 prefixes are advertised as IPv6 unicast. Empty = disabled.
+	Redistribute []string
+	// MaxPrefixes caps how many underlay prefixes are advertised (0 = unlimited).
+	MaxPrefixes uint32
+}
+
 // vrfState is the per-VRF export bookkeeping: the binding, the resolved table,
 // the two Endpoint SIDs minted from the binding's locator, and the set of
 // prefixes currently advertised (so DisableVRF can withdraw them all and a
@@ -90,48 +99,67 @@ type Exporter struct {
 	// is deliberately NOT the locator base -- a locator prefix's subnet-router
 	// anycast address (e.g. fd00:100::) is treated as a local address by a
 	// receiving PE, which then fails to forward the SRv6-encapsulated traffic.
-	// The next hop must be an ordinary node address.
-	nextHop string
-	// underlayRedist lists the protocols whose main-table IPv6 prefixes are
-	// advertised as IPv6 unicast. Empty = no underlay advertise.
-	underlayRedist []string
-	logger         *zap.Logger
-	vrfs           map[string]*vrfState
-	byTable        map[uint32]*vrfState
-	underlay       *underlayState // non-nil once Start enables underlay advertise
+	// Validated once in Start.
+	nextHop     string
+	underlayCfg UnderlayConfig
+	logger      *zap.Logger
+	vrfs        map[string]*vrfState
+	byTable     map[uint32]*vrfState
+	underlay    *underlayState // non-nil once Start enables underlay advertise
 }
 
 // New wires an Exporter and its RouteWatcher. nextHop is the advertising PE's
 // reachable IPv6 address (its loopback), stamped as the BGP next hop on every
-// advertised route. underlayRedist lists the protocols whose main-table IPv6
-// prefixes are advertised as IPv6 unicast (empty = none). vrfBindings is the
-// shared binding registry the applier also reads, so the advertise and receive
-// directions agree on which VRFs exist.
-func New(advertiser bgp.RouteAdvertiser, sidOps SidOps, locators *locator.Manager, vrfBindings *vrfbgp.Manager, resolver VRFResolver, nextHop string, underlayRedist []string, logger *zap.Logger) *Exporter {
+// advertised route. underlay configures IPv6 unicast underlay advertisement.
+// vrfBindings is the shared binding registry the applier also reads, so the
+// advertise and receive directions agree on which VRFs exist.
+func New(advertiser bgp.RouteAdvertiser, sidOps SidOps, locators *locator.Manager, vrfBindings *vrfbgp.Manager, resolver VRFResolver, nextHop string, underlay UnderlayConfig, logger *zap.Logger) *Exporter {
 	e := &Exporter{
-		advertiser:     advertiser,
-		sidOps:         sidOps,
-		locators:       locators,
-		vrfBindings:    vrfBindings,
-		resolver:       resolver,
-		nextHop:        nextHop,
-		underlayRedist: underlayRedist,
-		logger:         logger.Named("bgp.export"),
-		vrfs:           make(map[string]*vrfState),
-		byTable:        make(map[uint32]*vrfState),
+		advertiser:  advertiser,
+		sidOps:      sidOps,
+		locators:    locators,
+		vrfBindings: vrfBindings,
+		resolver:    resolver,
+		nextHop:     nextHop,
+		underlayCfg: underlay,
+		logger:      logger.Named("bgp.export"),
+		vrfs:        make(map[string]*vrfState),
+		byTable:     make(map[uint32]*vrfState),
 	}
-	e.watcher = netlinkwatch.NewRouteWatcher(e, logger)
+	// Nest the watcher's logger under bgp.export so its lines are attributable.
+	e.watcher = netlinkwatch.NewRouteWatcher(e, e.logger)
 	return e
 }
 
-// Start enables every VRF binding that lists a redistribute set, enables the
-// IPv6 unicast underlay if configured, and begins watching the kernel routing
-// tables. EnableVRF mints each VRF's End.DT4/DT6 service SID and returns the
-// table the watcher must observe; the watcher's ListExisting replay then
-// advertises prefixes already present at boot. A binding with no redistribute
-// set is left receive-only. If any binding fails to enable, the VRFs already
-// enabled in this call are unwound so a partial startup leaves no orphaned SID.
+// validateNextHop checks the BGP next hop once at Start: it must be a non-empty
+// IPv6 (not v4-mapped) address. SRv6 VPN / unicast transport is IPv6-only; an
+// IPv4 next hop serializes into a route no PE can forward toward.
+func (e *Exporter) validateNextHop() error {
+	if e.nextHop == "" {
+		return fmt.Errorf("bgp.global.next_hop is required for auto advertise")
+	}
+	a, err := netip.ParseAddr(e.nextHop)
+	if err != nil {
+		return fmt.Errorf("bgp.global.next_hop %q is invalid: %w", e.nextHop, err)
+	}
+	if !a.Is6() || a.Is4In6() {
+		return fmt.Errorf("bgp.global.next_hop %q must be an IPv6 address", e.nextHop)
+	}
+	return nil
+}
+
+// Start validates the next hop, enables every VRF binding that lists a
+// redistribute set, enables the IPv6 unicast underlay if configured, and begins
+// watching the kernel routing tables. EnableVRF mints each VRF's End.DT4/DT6
+// service SID and returns the table the watcher must observe; the watcher's
+// ListExisting replay then advertises prefixes already present at boot. A
+// binding with no redistribute set is left receive-only. If any step fails, the
+// VRFs already enabled in this call are unwound so a partial startup leaves no
+// orphaned SID.
 func (e *Exporter) Start(ctx context.Context) error {
+	if err := e.validateNextHop(); err != nil {
+		return err
+	}
 	enabled := make([]string, 0)
 	for _, b := range e.vrfBindings.List() {
 		if len(b.Redistribute) == 0 {
@@ -142,21 +170,19 @@ func (e *Exporter) Start(ctx context.Context) error {
 			e.unwind(enabled)
 			return fmt.Errorf("auto-advertise vrf %q: %w", b.VRFName, err)
 		}
+		// Record the VRF as enabled before RegisterTable, so a RegisterTable
+		// failure unwinds THIS VRF's SIDs too, not just the earlier ones.
+		enabled = append(enabled, b.VRFName)
 		if err := e.watcher.RegisterTable(table, b.Redistribute); err != nil {
 			e.unwind(enabled)
 			return fmt.Errorf("auto-advertise vrf %q: %w", b.VRFName, err)
 		}
-		enabled = append(enabled, b.VRFName)
 	}
-	if len(e.underlayRedist) > 0 {
-		if e.nextHop == "" {
-			e.unwind(enabled)
-			return fmt.Errorf("underlay redistribute requires bgp.global.next_hop")
-		}
+	if len(e.underlayCfg.Redistribute) > 0 {
 		e.mu.Lock()
 		e.underlay = &underlayState{advertised: make(map[bgp.RouteKey]struct{})}
 		e.mu.Unlock()
-		if err := e.watcher.RegisterTable(unix.RT_TABLE_MAIN, e.underlayRedist); err != nil {
+		if err := e.watcher.RegisterTable(unix.RT_TABLE_MAIN, e.underlayCfg.Redistribute); err != nil {
 			e.unwind(enabled)
 			return fmt.Errorf("underlay redistribute: %w", err)
 		}
@@ -200,16 +226,16 @@ func (e *Exporter) EnableVRF(b vrfbgp.Binding) (uint32, error) {
 	if b.DefaultLocator == "" {
 		return 0, fmt.Errorf("vrf %q: default_locator is required for auto advertise", b.VRFName)
 	}
-	if e.nextHop == "" {
-		return 0, fmt.Errorf("vrf %q: bgp.global.next_hop is required for auto advertise", b.VRFName)
-	}
-	if _, err := netip.ParseAddr(e.nextHop); err != nil {
-		return 0, fmt.Errorf("vrf %q: bgp.global.next_hop %q is invalid: %w", b.VRFName, e.nextHop, err)
-	}
 
 	ifindex, table, err := e.resolver.Resolve(b.VRFName)
 	if err != nil {
 		return 0, fmt.Errorf("resolve vrf %q: %w", b.VRFName, err)
+	}
+	// A VRF must own a dedicated table. The reserved main/local/default tables
+	// belong to the underlay path (RT_TABLE_MAIN) and the rest of the system; a
+	// VRF resolving to one of them would mis-dispatch in OnRoute.
+	if table == unix.RT_TABLE_MAIN || table == unix.RT_TABLE_LOCAL || table == unix.RT_TABLE_DEFAULT {
+		return 0, fmt.Errorf("vrf %q: routing table %d is reserved", b.VRFName, table)
 	}
 
 	e.mu.Lock()
@@ -354,16 +380,27 @@ func (e *Exporter) OnRoute(table uint32, prefix netip.Prefix, added bool) {
 }
 
 // applyUnderlay advertises or withdraws a main-table prefix as an IPv6 unicast
-// route. Only IPv6 prefixes are eligible (an IPv4 main-table route is not an
-// SRv6 underlay prefix). The caller holds e.mu.
+// route. Only global IPv6 prefixes are eligible: link-local, the unspecified
+// address, the default route, and IPv4 are never valid SRv6 underlay
+// advertisements. The MaxPrefixes cap bounds the blast radius of a main-table
+// route flood. The caller holds e.mu.
 func (e *Exporter) applyUnderlay(prefix netip.Prefix, added bool) {
-	if !prefix.Addr().Unmap().Is6() {
+	addr := prefix.Addr().Unmap()
+	if !addr.Is6() {
+		return
+	}
+	if addr.IsLinkLocalUnicast() || addr.IsUnspecified() || prefix.Bits() == 0 {
 		return
 	}
 	ur := bgp.UnicastRoute{Prefix: prefix.String(), NextHop: e.nextHop}
 	key := bgp.RouteKey{Family: bgp.FamilyIPv6Unicast, Prefix: ur.Prefix}
 	if added {
 		if _, dup := e.underlay.advertised[key]; dup {
+			return
+		}
+		if e.underlayCfg.MaxPrefixes > 0 && uint32(len(e.underlay.advertised)) >= e.underlayCfg.MaxPrefixes {
+			e.logger.Warn("underlay prefix limit reached; not advertising",
+				zap.String("prefix", ur.Prefix), zap.Uint32("max", e.underlayCfg.MaxPrefixes))
 			return
 		}
 		if err := e.advertiser.AdvertiseUnicast(context.Background(), ur); err != nil {

--- a/pkg/bgp/export/exporter.go
+++ b/pkg/bgp/export/exporter.go
@@ -7,9 +7,10 @@
 // VPN route, resolves its route targets to a VRF, and installs a headend
 // encap entry, the export path takes a VRF-local prefix, composes the VRF's
 // export route targets and its End.DT4/DT6 service SID, and advertises a VPN
-// route. The exporter owns its RouteWatcher: Start enables every VRF binding
-// that lists a redistribute set and begins watching, so the daemon wiring is a
-// single Start / Stop pair (mirroring vinbero.StartFDBWatcher).
+// route. The exporter also auto-advertises main-table IPv6 prefixes as IPv6
+// unicast (underlay reachability). It owns its RouteWatcher: Start enables
+// every VRF binding that lists a redistribute set and begins watching, so the
+// daemon wiring is a single Start / Stop pair (mirroring vinbero.StartFDBWatcher).
 package export
 
 import (
@@ -19,6 +20,7 @@ import (
 	"sync"
 
 	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 
 	v1 "github.com/takehaya/vinbero/api/vinbero/v1"
 	"github.com/takehaya/vinbero/pkg/bgp"
@@ -65,10 +67,16 @@ type vrfState struct {
 	advertised map[bgp.RouteKey]struct{}
 }
 
-// Exporter advertises VRF-local prefixes as VPNv4 / VPNv6 routes. It is safe
-// for concurrent use: OnRoute runs on the RouteWatcher goroutine while
-// EnableVRF / DisableVRF run on the daemon's setup / teardown path, so one
-// mutex guards all state.
+// underlayState tracks the IPv6 unicast underlay prefixes advertised from the
+// main routing table.
+type underlayState struct {
+	advertised map[bgp.RouteKey]struct{}
+}
+
+// Exporter advertises VRF-local prefixes as VPNv4 / VPNv6 routes and main-table
+// IPv6 prefixes as IPv6 unicast. It is safe for concurrent use: OnRoute runs on
+// the RouteWatcher goroutine while EnableVRF / DisableVRF run on the daemon's
+// setup / teardown path, so one mutex guards all state.
 type Exporter struct {
 	mu          sync.Mutex
 	advertiser  bgp.RouteAdvertiser
@@ -84,39 +92,45 @@ type Exporter struct {
 	// receiving PE, which then fails to forward the SRv6-encapsulated traffic.
 	// The next hop must be an ordinary node address.
 	nextHop string
-	logger  *zap.Logger
-	vrfs    map[string]*vrfState
-	byTable map[uint32]*vrfState
+	// underlayRedist lists the protocols whose main-table IPv6 prefixes are
+	// advertised as IPv6 unicast. Empty = no underlay advertise.
+	underlayRedist []string
+	logger         *zap.Logger
+	vrfs           map[string]*vrfState
+	byTable        map[uint32]*vrfState
+	underlay       *underlayState // non-nil once Start enables underlay advertise
 }
 
 // New wires an Exporter and its RouteWatcher. nextHop is the advertising PE's
 // reachable IPv6 address (its loopback), stamped as the BGP next hop on every
-// advertised route. vrfBindings is the shared binding registry the applier
-// also reads, so the advertise and receive directions agree on which VRFs
-// exist.
-func New(advertiser bgp.RouteAdvertiser, sidOps SidOps, locators *locator.Manager, vrfBindings *vrfbgp.Manager, resolver VRFResolver, nextHop string, logger *zap.Logger) *Exporter {
+// advertised route. underlayRedist lists the protocols whose main-table IPv6
+// prefixes are advertised as IPv6 unicast (empty = none). vrfBindings is the
+// shared binding registry the applier also reads, so the advertise and receive
+// directions agree on which VRFs exist.
+func New(advertiser bgp.RouteAdvertiser, sidOps SidOps, locators *locator.Manager, vrfBindings *vrfbgp.Manager, resolver VRFResolver, nextHop string, underlayRedist []string, logger *zap.Logger) *Exporter {
 	e := &Exporter{
-		advertiser:  advertiser,
-		sidOps:      sidOps,
-		locators:    locators,
-		vrfBindings: vrfBindings,
-		resolver:    resolver,
-		nextHop:     nextHop,
-		logger:      logger.Named("bgp.export"),
-		vrfs:        make(map[string]*vrfState),
-		byTable:     make(map[uint32]*vrfState),
+		advertiser:     advertiser,
+		sidOps:         sidOps,
+		locators:       locators,
+		vrfBindings:    vrfBindings,
+		resolver:       resolver,
+		nextHop:        nextHop,
+		underlayRedist: underlayRedist,
+		logger:         logger.Named("bgp.export"),
+		vrfs:           make(map[string]*vrfState),
+		byTable:        make(map[uint32]*vrfState),
 	}
 	e.watcher = netlinkwatch.NewRouteWatcher(e, logger)
 	return e
 }
 
-// Start enables every VRF binding that lists a redistribute set and begins
-// watching the kernel routing tables. EnableVRF mints each VRF's End.DT4/DT6
-// service SID and returns the table the watcher must observe; the watcher's
-// ListExisting replay then advertises prefixes already present at boot. A
-// binding with no redistribute set is left receive-only. If any binding fails
-// to enable, the VRFs already enabled in this call are unwound so a partial
-// startup leaves no orphaned SID.
+// Start enables every VRF binding that lists a redistribute set, enables the
+// IPv6 unicast underlay if configured, and begins watching the kernel routing
+// tables. EnableVRF mints each VRF's End.DT4/DT6 service SID and returns the
+// table the watcher must observe; the watcher's ListExisting replay then
+// advertises prefixes already present at boot. A binding with no redistribute
+// set is left receive-only. If any binding fails to enable, the VRFs already
+// enabled in this call are unwound so a partial startup leaves no orphaned SID.
 func (e *Exporter) Start(ctx context.Context) error {
 	enabled := make([]string, 0)
 	for _, b := range e.vrfBindings.List() {
@@ -133,6 +147,19 @@ func (e *Exporter) Start(ctx context.Context) error {
 			return fmt.Errorf("auto-advertise vrf %q: %w", b.VRFName, err)
 		}
 		enabled = append(enabled, b.VRFName)
+	}
+	if len(e.underlayRedist) > 0 {
+		if e.nextHop == "" {
+			e.unwind(enabled)
+			return fmt.Errorf("underlay redistribute requires bgp.global.next_hop")
+		}
+		e.mu.Lock()
+		e.underlay = &underlayState{advertised: make(map[bgp.RouteKey]struct{})}
+		e.mu.Unlock()
+		if err := e.watcher.RegisterTable(unix.RT_TABLE_MAIN, e.underlayRedist); err != nil {
+			e.unwind(enabled)
+			return fmt.Errorf("underlay redistribute: %w", err)
+		}
 	}
 	if err := e.watcher.Start(ctx); err != nil {
 		e.unwind(enabled)
@@ -247,8 +274,9 @@ func (e *Exporter) DisableVRF(vrfName string) {
 	e.logger.Info("VRF disabled for auto advertise", zap.String("vrf", vrfName))
 }
 
-// Close disables every enabled VRF. It is the withdraw half of Stop; the
-// route watcher must already be stopped so no advertisement races it.
+// Close disables every enabled VRF and withdraws the underlay prefixes. It is
+// the withdraw half of Stop; the route watcher must already be stopped so no
+// advertisement races it.
 func (e *Exporter) Close() {
 	e.mu.Lock()
 	names := make([]string, 0, len(e.vrfs))
@@ -259,16 +287,31 @@ func (e *Exporter) Close() {
 	for _, name := range names {
 		e.DisableVRF(name)
 	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.underlay != nil {
+		for key := range e.underlay.advertised {
+			if err := e.advertiser.Withdraw(context.Background(), key); err != nil {
+				e.logger.Warn("withdraw underlay on close",
+					zap.String("prefix", key.Prefix), zap.Error(err))
+			}
+		}
+		e.underlay = nil
+	}
 }
 
-// OnRoute reacts to a VRF-local prefix appearing (added=true) or being removed
+// OnRoute reacts to a prefix appearing (added=true) or being removed
 // (added=false) in a routing table. It is the RouteWatcher (RouteSink)
-// callback. A prefix in a table no VRF owns is ignored. The underlying
-// advertiser.Withdraw is a no-op for a route that was never advertised, so
-// duplicate deletes are safe.
+// callback. A main-table prefix is advertised as IPv6 unicast underlay; a
+// prefix in a VRF table is advertised as a VPN route; a prefix in any other
+// table is ignored.
 func (e *Exporter) OnRoute(table uint32, prefix netip.Prefix, added bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	if e.underlay != nil && table == unix.RT_TABLE_MAIN {
+		e.applyUnderlay(prefix, added)
+		return
+	}
 	st, ok := e.byTable[table]
 	if !ok {
 		return
@@ -308,6 +351,36 @@ func (e *Exporter) OnRoute(table uint32, prefix netip.Prefix, added bool) {
 		return
 	}
 	delete(st.advertised, key)
+}
+
+// applyUnderlay advertises or withdraws a main-table prefix as an IPv6 unicast
+// route. Only IPv6 prefixes are eligible (an IPv4 main-table route is not an
+// SRv6 underlay prefix). The caller holds e.mu.
+func (e *Exporter) applyUnderlay(prefix netip.Prefix, added bool) {
+	if !prefix.Addr().Unmap().Is6() {
+		return
+	}
+	ur := bgp.UnicastRoute{Prefix: prefix.String(), NextHop: e.nextHop}
+	key := bgp.RouteKey{Family: bgp.FamilyIPv6Unicast, Prefix: ur.Prefix}
+	if added {
+		if _, dup := e.underlay.advertised[key]; dup {
+			return
+		}
+		if err := e.advertiser.AdvertiseUnicast(context.Background(), ur); err != nil {
+			e.logger.Error("advertise underlay prefix",
+				zap.String("prefix", ur.Prefix), zap.Error(err))
+			return
+		}
+		e.underlay.advertised[key] = struct{}{}
+		e.logger.Info("auto-advertised underlay prefix", zap.String("prefix", ur.Prefix))
+		return
+	}
+	if err := e.advertiser.Withdraw(context.Background(), key); err != nil {
+		e.logger.Error("withdraw underlay prefix",
+			zap.String("prefix", ur.Prefix), zap.Error(err))
+		return
+	}
+	delete(e.underlay.advertised, key)
 }
 
 // buildVPNRoute composes the VPNv4 / VPNv6 advertisement for a VRF-local

--- a/pkg/bgp/export/exporter_test.go
+++ b/pkg/bgp/export/exporter_test.go
@@ -100,7 +100,7 @@ func newTestExporter(t *testing.T) (*Exporter, *fakeAdvertiser, *fakeSidOps) {
 	}
 	adv := &fakeAdvertiser{}
 	sid := &fakeSidOps{}
-	e := New(adv, sid, locs, vrfbgp.NewManager(), fakeResolver{ifindex: 10, table: testTable}, "2001:db8:ff::1", nil, zap.NewNop())
+	e := New(adv, sid, locs, vrfbgp.NewManager(), fakeResolver{ifindex: 10, table: testTable}, "2001:db8:ff::1", UnderlayConfig{}, zap.NewNop())
 	return e, adv, sid
 }
 
@@ -328,15 +328,41 @@ func TestOnRouteUnderlayAdvertisesIPv6Unicast(t *testing.T) {
 	if adv.unicast[0].Prefix != "2001:db8:ff::1/128" || adv.unicast[0].NextHop != "2001:db8:ff::1" {
 		t.Errorf("unicast route = %+v", adv.unicast[0])
 	}
-	// An IPv4 main-table route is not an SRv6 underlay prefix; skip it.
+	// IPv4, link-local, and the default route are never SRv6 underlay
+	// advertisements; they must be skipped.
 	e.OnRoute(unix.RT_TABLE_MAIN, netip.MustParsePrefix("10.9.0.0/24"), true)
+	e.OnRoute(unix.RT_TABLE_MAIN, netip.MustParsePrefix("fe80::/64"), true)
+	e.OnRoute(unix.RT_TABLE_MAIN, netip.MustParsePrefix("::/0"), true)
 	if len(adv.unicast) != 1 {
-		t.Errorf("IPv4 underlay route must be skipped, got %d", len(adv.unicast))
+		t.Errorf("IPv4 / link-local / default underlay routes must be skipped, got %d", len(adv.unicast))
 	}
 	// Withdraw on delete.
 	e.OnRoute(unix.RT_TABLE_MAIN, netip.MustParsePrefix("2001:db8:ff::1/128"), false)
 	if len(adv.withdrawn) != 1 {
 		t.Errorf("underlay delete should withdraw, got %d", len(adv.withdrawn))
+	}
+}
+
+func TestEnableVRFRejectsReservedTable(t *testing.T) {
+	// A VRF resolving to the reserved main table (254) must be rejected before
+	// any SID is minted, so it never mis-dispatches into the underlay path.
+	e := New(&fakeAdvertiser{}, &fakeSidOps{}, locator.NewManager(), vrfbgp.NewManager(),
+		fakeResolver{ifindex: 10, table: unix.RT_TABLE_MAIN}, "2001:db8:ff::1", UnderlayConfig{}, zap.NewNop())
+	if _, err := e.EnableVRF(testBinding()); err == nil {
+		t.Error("EnableVRF must reject a VRF resolving to the reserved main table")
+	}
+}
+
+func TestOnRouteUnderlayRespectsMaxPrefixes(t *testing.T) {
+	adv := &fakeAdvertiser{}
+	e := New(adv, &fakeSidOps{}, locator.NewManager(), vrfbgp.NewManager(),
+		fakeResolver{ifindex: 10, table: testTable}, "2001:db8:ff::1",
+		UnderlayConfig{Redistribute: []string{"connected"}, MaxPrefixes: 1}, zap.NewNop())
+	e.underlay = &underlayState{advertised: make(map[bgp.RouteKey]struct{})}
+	e.OnRoute(unix.RT_TABLE_MAIN, netip.MustParsePrefix("2001:db8:1::/64"), true)
+	e.OnRoute(unix.RT_TABLE_MAIN, netip.MustParsePrefix("2001:db8:2::/64"), true)
+	if len(adv.unicast) != 1 {
+		t.Errorf("underlay max_prefixes=1 should cap at 1, got %d", len(adv.unicast))
 	}
 }
 

--- a/pkg/bgp/export/exporter_test.go
+++ b/pkg/bgp/export/exporter_test.go
@@ -1,0 +1,345 @@
+package export
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/takehaya/vinbero/pkg/bgp"
+	"github.com/takehaya/vinbero/pkg/bpf"
+	"github.com/takehaya/vinbero/pkg/locator"
+	"github.com/takehaya/vinbero/pkg/vrfbgp"
+)
+
+// fakeAdvertiser records advertise / withdraw calls so a test can assert what
+// the exporter pushed without a live BGP session.
+type fakeAdvertiser struct {
+	advertised []bgp.VPNRoute
+	withdrawn  []bgp.RouteKey
+	advErr     error
+}
+
+func (f *fakeAdvertiser) Advertise(_ context.Context, r bgp.VPNRoute) error {
+	if f.advErr != nil {
+		return f.advErr
+	}
+	f.advertised = append(f.advertised, r)
+	return nil
+}
+
+func (f *fakeAdvertiser) AdvertiseUnicast(_ context.Context, _ bgp.UnicastRoute) error {
+	return nil
+}
+
+func (f *fakeAdvertiser) Withdraw(_ context.Context, key bgp.RouteKey) error {
+	f.withdrawn = append(f.withdrawn, key)
+	return nil
+}
+
+// sidCreate captures one CreateSidFunction call's identity (the trigger
+// prefix and the endpoint behavior).
+type sidCreate struct {
+	prefix string
+	action uint8
+}
+
+type fakeSidOps struct {
+	created    []sidCreate
+	deleted    []string
+	failOnCall int // 0 = never; N = fail the Nth CreateSidFunction call
+	calls      int
+}
+
+func (f *fakeSidOps) CreateSidFunction(triggerPrefix string, entry *bpf.SidFunctionEntry, _ *bpf.SidAuxEntry, _ bpf.OwnerTag) error {
+	f.calls++
+	if f.failOnCall != 0 && f.calls == f.failOnCall {
+		return errors.New("create failed")
+	}
+	f.created = append(f.created, sidCreate{prefix: triggerPrefix, action: entry.Action})
+	return nil
+}
+
+func (f *fakeSidOps) DeleteSidFunction(triggerPrefix string, _ bpf.OwnerTag) error {
+	f.deleted = append(f.deleted, triggerPrefix)
+	return nil
+}
+
+type fakeResolver struct {
+	ifindex uint32
+	table   uint32
+	err     error
+}
+
+func (f fakeResolver) Resolve(_ string) (uint32, uint32, error) {
+	return f.ifindex, f.table, f.err
+}
+
+const testTable = 100
+
+func newTestExporter(t *testing.T) (*Exporter, *fakeAdvertiser, *fakeSidOps) {
+	t.Helper()
+	locs := locator.NewManager()
+	if err := locs.Add(&locator.Locator{
+		Name:              "LOC1",
+		Prefix:            netip.MustParsePrefix("fd00:1:1::/48"),
+		BlockLen:          32,
+		NodeLen:           16,
+		FunctionLen:       16,
+		ArgumentLen:       64,
+		Behavior:          locator.BehaviorClassic,
+		FunctionAutoStart: 0x10,
+		FunctionAutoEnd:   0xfffe,
+	}); err != nil {
+		t.Fatalf("add locator: %v", err)
+	}
+	adv := &fakeAdvertiser{}
+	sid := &fakeSidOps{}
+	e := New(adv, sid, locs, vrfbgp.NewManager(), fakeResolver{ifindex: 10, table: testTable}, "LOC1", zap.NewNop())
+	return e, adv, sid
+}
+
+func testBinding() vrfbgp.Binding {
+	return vrfbgp.Binding{
+		VRFName:        "vrf1",
+		RD:             "65000:100",
+		ExportRTs:      []string{"65000:100"},
+		DefaultLocator: "LOC1",
+	}
+}
+
+// sidForAction returns the trigger prefix the exporter installed for the given
+// endpoint behavior, so a test can correlate an advertised SID back to its
+// sid_function_map entry.
+func sidForAction(created []sidCreate, action uint8) (string, bool) {
+	for _, c := range created {
+		if c.action == action {
+			return c.prefix, true
+		}
+	}
+	return "", false
+}
+
+func TestEnableVRFInstallsBothEndpointSIDs(t *testing.T) {
+	e, _, sid := newTestExporter(t)
+	if _, err := e.EnableVRF(testBinding()); err != nil {
+		t.Fatalf("EnableVRF: %v", err)
+	}
+	if len(sid.created) != 2 {
+		t.Fatalf("want 2 endpoint SIDs installed, got %d: %+v", len(sid.created), sid.created)
+	}
+	if _, ok := sidForAction(sid.created, endpointActionDT4); !ok {
+		t.Errorf("no End.DT4 SID installed: %+v", sid.created)
+	}
+	if _, ok := sidForAction(sid.created, endpointActionDT6); !ok {
+		t.Errorf("no End.DT6 SID installed: %+v", sid.created)
+	}
+}
+
+func TestEnableVRFRejectsMissingRDOrLocator(t *testing.T) {
+	e, _, _ := newTestExporter(t)
+	noRD := testBinding()
+	noRD.RD = ""
+	if _, err := e.EnableVRF(noRD); err == nil {
+		t.Error("EnableVRF without RD should fail")
+	}
+	noLoc := testBinding()
+	noLoc.DefaultLocator = ""
+	if _, err := e.EnableVRF(noLoc); err == nil {
+		t.Error("EnableVRF without default_locator should fail")
+	}
+}
+
+func TestEnableVRFRejectsDuplicate(t *testing.T) {
+	e, _, _ := newTestExporter(t)
+	if _, err := e.EnableVRF(testBinding()); err != nil {
+		t.Fatalf("first EnableVRF: %v", err)
+	}
+	if _, err := e.EnableVRF(testBinding()); err == nil {
+		t.Error("second EnableVRF for the same VRF should fail")
+	}
+}
+
+func TestEnableVRFRollsBackDT4WhenDT6Fails(t *testing.T) {
+	e, _, sid := newTestExporter(t)
+	// DT4 installs (call 1), DT6 (call 2) fails -> the DT4 rollback path runs.
+	sid.failOnCall = 2
+	if _, err := e.EnableVRF(testBinding()); err == nil {
+		t.Fatal("EnableVRF should fail when the DT6 SID install fails")
+	}
+	if len(sid.created) != 1 {
+		t.Fatalf("want 1 SID installed (DT4) before the failure, got %d", len(sid.created))
+	}
+	if len(sid.deleted) != 1 {
+		t.Fatalf("want the DT4 SID rolled back, got %d deletes", len(sid.deleted))
+	}
+	if sid.created[0].prefix != sid.deleted[0] {
+		t.Errorf("rolled-back SID %q != installed DT4 SID %q", sid.deleted[0], sid.created[0].prefix)
+	}
+	// Re-enable must work (the DT4 function was returned to the pool).
+	sid.failOnCall = 0
+	if _, err := e.EnableVRF(testBinding()); err != nil {
+		t.Fatalf("re-enable after rollback: %v", err)
+	}
+}
+
+func TestOnRouteAdvertisesV4(t *testing.T) {
+	e, adv, sid := newTestExporter(t)
+	if _, err := e.EnableVRF(testBinding()); err != nil {
+		t.Fatalf("EnableVRF: %v", err)
+	}
+	e.OnRoute(testTable, netip.MustParsePrefix("10.0.0.0/24"), true)
+
+	if len(adv.advertised) != 1 {
+		t.Fatalf("want 1 advertised route, got %d", len(adv.advertised))
+	}
+	r := adv.advertised[0]
+	if r.Family != bgp.FamilyVPNv4 {
+		t.Errorf("family = %q, want vpnv4", r.Family)
+	}
+	if r.Prefix != "10.0.0.0/24" {
+		t.Errorf("prefix = %q", r.Prefix)
+	}
+	if r.RD != "65000:100" {
+		t.Errorf("rd = %q", r.RD)
+	}
+	if len(r.RTs) != 1 || r.RTs[0] != "65000:100" {
+		t.Errorf("rts = %v", r.RTs)
+	}
+	if r.NextHop != "fd00:1:1::" {
+		t.Errorf("nexthop = %q, want fd00:1:1::", r.NextHop)
+	}
+	wantSID, ok := sidForAction(sid.created, endpointActionDT4)
+	if !ok || r.SRv6SID+"/128" != wantSID {
+		t.Errorf("SID = %q, want the DT4 endpoint %q", r.SRv6SID, wantSID)
+	}
+}
+
+func TestOnRouteAdvertisesV6(t *testing.T) {
+	e, adv, sid := newTestExporter(t)
+	if _, err := e.EnableVRF(testBinding()); err != nil {
+		t.Fatalf("EnableVRF: %v", err)
+	}
+	e.OnRoute(testTable, netip.MustParsePrefix("2001:db8::/64"), true)
+
+	if len(adv.advertised) != 1 {
+		t.Fatalf("want 1 advertised route, got %d", len(adv.advertised))
+	}
+	r := adv.advertised[0]
+	if r.Family != bgp.FamilyVPNv6 {
+		t.Errorf("family = %q, want vpnv6", r.Family)
+	}
+	wantSID, ok := sidForAction(sid.created, endpointActionDT6)
+	if !ok || r.SRv6SID+"/128" != wantSID {
+		t.Errorf("SID = %q, want the DT6 endpoint %q", r.SRv6SID, wantSID)
+	}
+}
+
+func TestOnRouteIgnoresUnknownTable(t *testing.T) {
+	e, adv, _ := newTestExporter(t)
+	if _, err := e.EnableVRF(testBinding()); err != nil {
+		t.Fatalf("EnableVRF: %v", err)
+	}
+	e.OnRoute(testTable+1, netip.MustParsePrefix("10.0.0.0/24"), true)
+	if len(adv.advertised) != 0 {
+		t.Errorf("a route in an unowned table must not be advertised, got %d", len(adv.advertised))
+	}
+}
+
+func TestOnRouteWithdrawMirrorsAdvertise(t *testing.T) {
+	e, adv, _ := newTestExporter(t)
+	if _, err := e.EnableVRF(testBinding()); err != nil {
+		t.Fatalf("EnableVRF: %v", err)
+	}
+	prefix := netip.MustParsePrefix("10.0.0.0/24")
+	e.OnRoute(testTable, prefix, true)
+	e.OnRoute(testTable, prefix, false)
+
+	if len(adv.withdrawn) != 1 {
+		t.Fatalf("want 1 withdraw, got %d", len(adv.withdrawn))
+	}
+	k := adv.withdrawn[0]
+	if k.Family != bgp.FamilyVPNv4 || k.Prefix != "10.0.0.0/24" || k.RD != "65000:100" {
+		t.Errorf("withdraw key = %+v", k)
+	}
+}
+
+func TestDisableVRFWithdrawsAllAndReleases(t *testing.T) {
+	e, adv, sid := newTestExporter(t)
+	if _, err := e.EnableVRF(testBinding()); err != nil {
+		t.Fatalf("EnableVRF: %v", err)
+	}
+	e.OnRoute(testTable, netip.MustParsePrefix("10.0.0.0/24"), true)
+	e.OnRoute(testTable, netip.MustParsePrefix("10.0.1.0/24"), true)
+
+	e.DisableVRF("vrf1")
+
+	if len(adv.withdrawn) != 2 {
+		t.Errorf("want 2 prefixes withdrawn on disable, got %d", len(adv.withdrawn))
+	}
+	if len(sid.deleted) != 2 {
+		t.Errorf("want 2 endpoint SIDs deleted on disable, got %d", len(sid.deleted))
+	}
+	// The VRF is gone, so re-enabling must succeed (and reusing the released
+	// functions must not error).
+	if _, err := e.EnableVRF(testBinding()); err != nil {
+		t.Fatalf("re-enable after disable: %v", err)
+	}
+}
+
+func TestCloseDisablesEveryVRF(t *testing.T) {
+	e, adv, _ := newTestExporter(t)
+	if _, err := e.EnableVRF(testBinding()); err != nil {
+		t.Fatalf("EnableVRF: %v", err)
+	}
+	e.OnRoute(testTable, netip.MustParsePrefix("10.0.0.0/24"), true)
+	e.Close()
+	if len(adv.withdrawn) != 1 {
+		t.Errorf("Close should withdraw advertised routes, got %d", len(adv.withdrawn))
+	}
+}
+
+func TestEnableVRFRejectsDuplicateTable(t *testing.T) {
+	e, _, _ := newTestExporter(t)
+	if _, err := e.EnableVRF(testBinding()); err != nil {
+		t.Fatalf("first EnableVRF: %v", err)
+	}
+	// Different VRF name, same table id (the fake resolver always returns
+	// testTable), which would otherwise overwrite byTable and mis-attribute
+	// prefixes.
+	other := testBinding()
+	other.VRFName = "vrf2"
+	if _, err := e.EnableVRF(other); err == nil {
+		t.Error("EnableVRF should reject a second VRF mapping to an already-exported table")
+	}
+}
+
+func TestOnRouteAdvertiseFailureNotRecorded(t *testing.T) {
+	e, adv, _ := newTestExporter(t)
+	if _, err := e.EnableVRF(testBinding()); err != nil {
+		t.Fatalf("EnableVRF: %v", err)
+	}
+	adv.advErr = errors.New("advertise failed")
+	e.OnRoute(testTable, netip.MustParsePrefix("10.0.0.0/24"), true)
+	// The advertise failed, so the route must NOT be recorded -- otherwise a
+	// later disable/Close would withdraw a route that was never advertised.
+	e.DisableVRF("vrf1")
+	if len(adv.withdrawn) != 0 {
+		t.Errorf("a failed advertise must not be recorded, but disable withdrew %d", len(adv.withdrawn))
+	}
+}
+
+func TestOnRouteAddIsIdempotent(t *testing.T) {
+	e, adv, _ := newTestExporter(t)
+	if _, err := e.EnableVRF(testBinding()); err != nil {
+		t.Fatalf("EnableVRF: %v", err)
+	}
+	p := netip.MustParsePrefix("10.0.0.0/24")
+	e.OnRoute(testTable, p, true)
+	e.OnRoute(testTable, p, true) // duplicate NEWROUTE / ListExisting refresh
+	if len(adv.advertised) != 1 {
+		t.Errorf("a duplicate add should advertise once, got %d", len(adv.advertised))
+	}
+}

--- a/pkg/bgp/export/exporter_test.go
+++ b/pkg/bgp/export/exporter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 
 	"github.com/takehaya/vinbero/pkg/bgp"
 	"github.com/takehaya/vinbero/pkg/bpf"
@@ -18,6 +19,7 @@ import (
 // the exporter pushed without a live BGP session.
 type fakeAdvertiser struct {
 	advertised []bgp.VPNRoute
+	unicast    []bgp.UnicastRoute
 	withdrawn  []bgp.RouteKey
 	advErr     error
 }
@@ -30,7 +32,8 @@ func (f *fakeAdvertiser) Advertise(_ context.Context, r bgp.VPNRoute) error {
 	return nil
 }
 
-func (f *fakeAdvertiser) AdvertiseUnicast(_ context.Context, _ bgp.UnicastRoute) error {
+func (f *fakeAdvertiser) AdvertiseUnicast(_ context.Context, r bgp.UnicastRoute) error {
+	f.unicast = append(f.unicast, r)
 	return nil
 }
 
@@ -97,7 +100,7 @@ func newTestExporter(t *testing.T) (*Exporter, *fakeAdvertiser, *fakeSidOps) {
 	}
 	adv := &fakeAdvertiser{}
 	sid := &fakeSidOps{}
-	e := New(adv, sid, locs, vrfbgp.NewManager(), fakeResolver{ifindex: 10, table: testTable}, "2001:db8:ff::1", zap.NewNop())
+	e := New(adv, sid, locs, vrfbgp.NewManager(), fakeResolver{ifindex: 10, table: testTable}, "2001:db8:ff::1", nil, zap.NewNop())
 	return e, adv, sid
 }
 
@@ -312,6 +315,28 @@ func TestCloseDisablesEveryVRF(t *testing.T) {
 	e.Close()
 	if len(adv.withdrawn) != 1 {
 		t.Errorf("Close should withdraw advertised routes, got %d", len(adv.withdrawn))
+	}
+}
+
+func TestOnRouteUnderlayAdvertisesIPv6Unicast(t *testing.T) {
+	e, adv, _ := newTestExporter(t)
+	e.underlay = &underlayState{advertised: make(map[bgp.RouteKey]struct{})}
+	e.OnRoute(unix.RT_TABLE_MAIN, netip.MustParsePrefix("2001:db8:ff::1/128"), true)
+	if len(adv.unicast) != 1 {
+		t.Fatalf("want 1 IPv6 unicast advertised, got %d", len(adv.unicast))
+	}
+	if adv.unicast[0].Prefix != "2001:db8:ff::1/128" || adv.unicast[0].NextHop != "2001:db8:ff::1" {
+		t.Errorf("unicast route = %+v", adv.unicast[0])
+	}
+	// An IPv4 main-table route is not an SRv6 underlay prefix; skip it.
+	e.OnRoute(unix.RT_TABLE_MAIN, netip.MustParsePrefix("10.9.0.0/24"), true)
+	if len(adv.unicast) != 1 {
+		t.Errorf("IPv4 underlay route must be skipped, got %d", len(adv.unicast))
+	}
+	// Withdraw on delete.
+	e.OnRoute(unix.RT_TABLE_MAIN, netip.MustParsePrefix("2001:db8:ff::1/128"), false)
+	if len(adv.withdrawn) != 1 {
+		t.Errorf("underlay delete should withdraw, got %d", len(adv.withdrawn))
 	}
 }
 

--- a/pkg/bgp/export/exporter_test.go
+++ b/pkg/bgp/export/exporter_test.go
@@ -343,6 +343,19 @@ func TestOnRouteUnderlayAdvertisesIPv6Unicast(t *testing.T) {
 	}
 }
 
+func TestOnRouteWithdrawUnadvertisedIsNoop(t *testing.T) {
+	e, adv, _ := newTestExporter(t)
+	if _, err := e.EnableVRF(testBinding()); err != nil {
+		t.Fatalf("EnableVRF: %v", err)
+	}
+	// Delete a prefix we never advertised (capped, or its Advertise failed):
+	// must NOT issue a Withdraw that could hit another owner's same-NLRI path.
+	e.OnRoute(testTable, netip.MustParsePrefix("10.5.0.0/24"), false)
+	if len(adv.withdrawn) != 0 {
+		t.Errorf("withdraw of an unadvertised prefix must be a no-op, got %d", len(adv.withdrawn))
+	}
+}
+
 func TestEnableVRFRejectsReservedTable(t *testing.T) {
 	// A VRF resolving to the reserved main table (254) must be rejected before
 	// any SID is minted, so it never mis-dispatches into the underlay path.

--- a/pkg/bgp/export/exporter_test.go
+++ b/pkg/bgp/export/exporter_test.go
@@ -289,6 +289,20 @@ func TestDisableVRFWithdrawsAllAndReleases(t *testing.T) {
 	}
 }
 
+func TestOnRouteRespectsMaxPrefixes(t *testing.T) {
+	e, adv, _ := newTestExporter(t)
+	b := testBinding()
+	b.MaxPrefixes = 1
+	if _, err := e.EnableVRF(b); err != nil {
+		t.Fatalf("EnableVRF: %v", err)
+	}
+	e.OnRoute(testTable, netip.MustParsePrefix("10.0.0.0/24"), true)
+	e.OnRoute(testTable, netip.MustParsePrefix("10.0.1.0/24"), true)
+	if len(adv.advertised) != 1 {
+		t.Errorf("max_prefixes=1 should cap advertisements at 1, got %d", len(adv.advertised))
+	}
+}
+
 func TestCloseDisablesEveryVRF(t *testing.T) {
 	e, adv, _ := newTestExporter(t)
 	if _, err := e.EnableVRF(testBinding()); err != nil {

--- a/pkg/bgp/export/exporter_test.go
+++ b/pkg/bgp/export/exporter_test.go
@@ -97,7 +97,7 @@ func newTestExporter(t *testing.T) (*Exporter, *fakeAdvertiser, *fakeSidOps) {
 	}
 	adv := &fakeAdvertiser{}
 	sid := &fakeSidOps{}
-	e := New(adv, sid, locs, vrfbgp.NewManager(), fakeResolver{ifindex: 10, table: testTable}, "LOC1", zap.NewNop())
+	e := New(adv, sid, locs, vrfbgp.NewManager(), fakeResolver{ifindex: 10, table: testTable}, "2001:db8:ff::1", zap.NewNop())
 	return e, adv, sid
 }
 
@@ -208,8 +208,8 @@ func TestOnRouteAdvertisesV4(t *testing.T) {
 	if len(r.RTs) != 1 || r.RTs[0] != "65000:100" {
 		t.Errorf("rts = %v", r.RTs)
 	}
-	if r.NextHop != "fd00:1:1::" {
-		t.Errorf("nexthop = %q, want fd00:1:1::", r.NextHop)
+	if r.NextHop != "2001:db8:ff::1" {
+		t.Errorf("nexthop = %q, want 2001:db8:ff::1", r.NextHop)
 	}
 	wantSID, ok := sidForAction(sid.created, endpointActionDT4)
 	if !ok || r.SRv6SID+"/128" != wantSID {

--- a/pkg/bgp/export/netlink_resolver.go
+++ b/pkg/bgp/export/netlink_resolver.go
@@ -1,0 +1,26 @@
+package export
+
+import (
+	"fmt"
+
+	"github.com/vishvananda/netlink"
+)
+
+// NetlinkVRFResolver is the production VRFResolver: it looks a VRF device up
+// by name over netlink and returns its ifindex and the routing table its
+// l3mdev owns. The exporter needs the ifindex to build the End.DT4/DT6 aux
+// entry and the table id to match route events to the VRF.
+type NetlinkVRFResolver struct{}
+
+// Resolve implements VRFResolver.
+func (NetlinkVRFResolver) Resolve(vrfName string) (ifindex uint32, table uint32, err error) {
+	link, err := netlink.LinkByName(vrfName)
+	if err != nil {
+		return 0, 0, fmt.Errorf("lookup link %q: %w", vrfName, err)
+	}
+	vrf, ok := link.(*netlink.Vrf)
+	if !ok {
+		return 0, 0, fmt.Errorf("link %q is not a VRF device (type %s)", vrfName, link.Type())
+	}
+	return uint32(link.Attrs().Index), vrf.Table, nil
+}

--- a/pkg/bgp/gobgp/advertise.go
+++ b/pkg/bgp/gobgp/advertise.go
@@ -25,7 +25,7 @@ func (s *Session) Advertise(_ context.Context, r bgp.VPNRoute) error {
 	if err != nil {
 		return err
 	}
-	return s.addAndTrack(srv, path, bgp.RouteKey{Family: r.Family, Prefix: r.Prefix, RD: r.RD})
+	return s.addAndTrack(srv, path, r.Key())
 }
 
 // AdvertiseUnicast injects an IPv6 unicast route.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -99,6 +99,10 @@ type BGPGlobalConfig struct {
 	// prefix's subnet-router anycast address is treated as local by a receiving
 	// PE, which then fails to forward the SRv6-encapsulated traffic.
 	NextHop string `yaml:"next_hop,omitempty"`
+	// UnderlayRedistribute lists the route protocols ("connected"/"static")
+	// whose main-table IPv6 prefixes are auto-advertised as IPv6 unicast
+	// (underlay reachability). Empty = no underlay advertise.
+	UnderlayRedistribute []string `yaml:"underlay_redistribute,omitempty"`
 }
 
 // BGPPeerConfig describes one BGP neighbor.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,11 +31,21 @@ type BGPConfig struct {
 // its bridge-domain binding exists and is dropped. bd_id is the bridge domain
 // for EVPN routes matching import_rts (0 for L3VPN-only bindings).
 type VrfBindingConfig struct {
-	VRFName        string   `yaml:"vrf_name,omitempty"`
-	ImportRTs      []string `yaml:"import_rts,omitempty"`
-	ExportRTs      []string `yaml:"export_rts,omitempty"`
-	DefaultLocator string   `yaml:"default_locator,omitempty"`
-	BDID           uint32   `yaml:"bd_id,omitempty"`
+	VRFName   string   `yaml:"vrf_name,omitempty"`
+	ImportRTs []string `yaml:"import_rts,omitempty"`
+	ExportRTs []string `yaml:"export_rts,omitempty"`
+	// RD is the route distinguisher used when auto-advertising this VRF's
+	// local prefixes. Required for auto advertise; receive-only bindings may
+	// leave it empty.
+	RD             string `yaml:"rd,omitempty"`
+	DefaultLocator string `yaml:"default_locator,omitempty"`
+	BDID           uint32 `yaml:"bd_id,omitempty"`
+	// Redistribute lists the route protocols whose VRF-local prefixes are
+	// auto-advertised as VPNv4/VPNv6 when bgp.global.auto_advertise is on.
+	// Recognized values are "connected" (RTPROT_KERNEL) and "static"
+	// (RTPROT_STATIC). Routes Vinbero itself installed (RTPROT_BGP) are never
+	// redistributed, so a received route is not re-advertised back out.
+	Redistribute []string `yaml:"redistribute,omitempty"`
 }
 
 // BGPGlobalConfig is the speaker's own BGP identity.
@@ -51,6 +61,12 @@ type BGPGlobalConfig struct {
 	// §6-5). Unused until Phase 1d; accepted now so config files are
 	// forward-compatible.
 	SourceLocator string `yaml:"source_locator,omitempty"`
+	// AutoAdvertise turns on the VRF-export driven auto advertise path
+	// (pkg/bgp/export): VRF-local prefixes matching a binding's redistribute
+	// list are advertised as VPNv4/VPNv6 without an explicit BgpRouteService
+	// call. Defaults to false so the operator-explicit path stays the only
+	// behavior unless opted in.
+	AutoAdvertise bool `yaml:"auto_advertise,omitempty" default:"false"`
 }
 
 // BGPPeerConfig describes one BGP neighbor.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,29 @@ type BGPConfig struct {
 	Global      BGPGlobalConfig    `yaml:"global,omitempty"`
 	Peers       []BGPPeerConfig    `yaml:"peers,omitempty"`
 	VrfBindings []VrfBindingConfig `yaml:"vrf_bindings,omitempty"`
+	// Locators are SRv6 locator pools registered at startup, before the BGP
+	// session settles. Auto-advertise needs each VRF binding's default_locator
+	// to exist when the exporter enables it, and the receive applier needs the
+	// source_locator present to materialize headend entries -- both run before
+	// any RPC, so config is the only way to have them ready in time. Locators
+	// can still also be created over the LocatorService RPC.
+	Locators []LocatorConfig `yaml:"locators,omitempty"`
+}
+
+// LocatorConfig declares an SRv6 locator pool statically. It mirrors the
+// LocatorService RPC fields so the BGP paths that need a locator at startup
+// (auto-advertise, the receive applier's encap source) do not depend on an RPC
+// arriving first.
+type LocatorConfig struct {
+	Name              string `yaml:"name,omitempty"`
+	Prefix            string `yaml:"prefix,omitempty"`
+	BlockLen          uint8  `yaml:"block_len,omitempty"`
+	NodeLen           uint8  `yaml:"node_len,omitempty"`
+	FunctionLen       uint8  `yaml:"function_len,omitempty"`
+	ArgumentLen       uint8  `yaml:"argument_len,omitempty"`
+	Behavior          string `yaml:"behavior,omitempty" default:"classic"`
+	FunctionAutoStart uint32 `yaml:"function_auto_start,omitempty" default:"16"`
+	FunctionAutoEnd   uint32 `yaml:"function_auto_end,omitempty" default:"65534"`
 }
 
 // VrfBindingConfig is a VRF <-> route-target binding applied at startup,
@@ -67,6 +90,12 @@ type BGPGlobalConfig struct {
 	// call. Defaults to false so the operator-explicit path stays the only
 	// behavior unless opted in.
 	AutoAdvertise bool `yaml:"auto_advertise,omitempty" default:"false"`
+	// NextHop is the BGP next hop the auto-advertise path stamps on routes it
+	// originates: this PE's own reachable IPv6 address (its loopback). Required
+	// when auto_advertise is on. It must NOT be a locator base -- a locator
+	// prefix's subnet-router anycast address is treated as local by a receiving
+	// PE, which then fails to forward the SRv6-encapsulated traffic.
+	NextHop string `yaml:"next_hop,omitempty"`
 }
 
 // BGPPeerConfig describes one BGP neighbor.
@@ -177,6 +206,9 @@ func Load(s string) (*Config, error) {
 	// deliberately (e.g. settings.fdb_aging_seconds: 0 means "disabled").
 	for i := range cfg.BGP.Peers {
 		defaults.SetDefaults(&cfg.BGP.Peers[i])
+	}
+	for i := range cfg.BGP.Locators {
+		defaults.SetDefaults(&cfg.BGP.Locators[i])
 	}
 	cfg.Original = s
 	return &cfg, nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -103,6 +103,9 @@ type BGPGlobalConfig struct {
 	// whose main-table IPv6 prefixes are auto-advertised as IPv6 unicast
 	// (underlay reachability). Empty = no underlay advertise.
 	UnderlayRedistribute []string `yaml:"underlay_redistribute,omitempty"`
+	// UnderlayMaxPrefixes caps how many underlay prefixes are advertised
+	// (0 = unlimited).
+	UnderlayMaxPrefixes uint32 `yaml:"underlay_max_prefixes,omitempty"`
 }
 
 // BGPPeerConfig describes one BGP neighbor.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,6 +69,9 @@ type VrfBindingConfig struct {
 	// (RTPROT_STATIC). Routes Vinbero itself installed (RTPROT_BGP) are never
 	// redistributed, so a received route is not re-advertised back out.
 	Redistribute []string `yaml:"redistribute,omitempty"`
+	// MaxPrefixes caps how many prefixes auto-advertise originates for this VRF
+	// (0 = unlimited), bounding the blast radius of a VRF-route flood.
+	MaxPrefixes uint32 `yaml:"max_prefixes,omitempty"`
 }
 
 // BGPGlobalConfig is the speaker's own BGP identity.

--- a/pkg/config/config_bgp_test.go
+++ b/pkg/config/config_bgp_test.go
@@ -100,3 +100,81 @@ func TestLoad_ExplicitZeroSurvives(t *testing.T) {
 			cfg.Setting.FdbAgingSeconds)
 	}
 }
+
+// TestLoad_BGPAutoAdvertiseFields pins that the auto-advertise config surface
+// round-trips through Load: the global next_hop / underlay fields, the per-VRF
+// rd / redistribute / max_prefixes, and the locator defaults (which live on a
+// slice-of-struct field, so the second SetDefaults pass must reach them).
+func TestLoad_BGPAutoAdvertiseFields(t *testing.T) {
+	const y = `
+bgp:
+  global:
+    local_asn: 65100
+    auto_advertise: true
+    next_hop: "2001:db8:ff::1"
+    underlay_redistribute: [connected]
+    underlay_max_prefixes: 100
+  locators:
+    - name: LOC1
+      prefix: "fd00:100::/48"
+      block_len: 32
+      node_len: 16
+      function_len: 16
+      argument_len: 64
+  vrf_bindings:
+    - vrf_name: vrf1
+      rd: "65100:200"
+      import_rts: ["65000:200"]
+      export_rts: ["65000:200"]
+      default_locator: LOC1
+      redistribute: [connected, static]
+      max_prefixes: 1000
+`
+	cfg, err := Load(y)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	g := cfg.BGP.Global
+	if !g.AutoAdvertise {
+		t.Error("AutoAdvertise = false, want true")
+	}
+	if g.NextHop != "2001:db8:ff::1" {
+		t.Errorf("NextHop = %q", g.NextHop)
+	}
+	if len(g.UnderlayRedistribute) != 1 || g.UnderlayRedistribute[0] != "connected" {
+		t.Errorf("UnderlayRedistribute = %v", g.UnderlayRedistribute)
+	}
+	if g.UnderlayMaxPrefixes != 100 {
+		t.Errorf("UnderlayMaxPrefixes = %d, want 100", g.UnderlayMaxPrefixes)
+	}
+	if len(cfg.BGP.Locators) != 1 {
+		t.Fatalf("Locators len = %d, want 1", len(cfg.BGP.Locators))
+	}
+	loc := cfg.BGP.Locators[0]
+	if loc.Name != "LOC1" || loc.Prefix != "fd00:100::/48" {
+		t.Errorf("locator = %+v", loc)
+	}
+	// Defaults reach the slice-of-struct locator via the second pass.
+	if loc.Behavior != "classic" {
+		t.Errorf("locator Behavior = %q, want classic (default)", loc.Behavior)
+	}
+	if loc.FunctionAutoStart != 16 {
+		t.Errorf("locator FunctionAutoStart = %d, want 16 (default)", loc.FunctionAutoStart)
+	}
+	if loc.FunctionAutoEnd != 65534 {
+		t.Errorf("locator FunctionAutoEnd = %d, want 65534 (default)", loc.FunctionAutoEnd)
+	}
+	if len(cfg.BGP.VrfBindings) != 1 {
+		t.Fatalf("VrfBindings len = %d, want 1", len(cfg.BGP.VrfBindings))
+	}
+	b := cfg.BGP.VrfBindings[0]
+	if b.RD != "65100:200" {
+		t.Errorf("binding RD = %q", b.RD)
+	}
+	if len(b.Redistribute) != 2 {
+		t.Errorf("binding Redistribute = %v", b.Redistribute)
+	}
+	if b.MaxPrefixes != 1000 {
+		t.Errorf("binding MaxPrefixes = %d, want 1000", b.MaxPrefixes)
+	}
+}

--- a/pkg/fib/route.go
+++ b/pkg/fib/route.go
@@ -123,7 +123,7 @@ func fromNetlinkRoute(nl *netlink.Route) (Route, bool) {
 	if nl.Dst == nil {
 		return Route{}, false
 	}
-	prefix, ok := ipNetToPrefix(nl.Dst)
+	prefix, ok := IPNetToPrefix(nl.Dst)
 	if !ok {
 		return Route{}, false
 	}
@@ -147,7 +147,10 @@ func prefixToIPNet(p netip.Prefix) (*net.IPNet, error) {
 	}, nil
 }
 
-func ipNetToPrefix(n *net.IPNet) (netip.Prefix, bool) {
+// IPNetToPrefix converts a kernel route destination (*net.IPNet) to a
+// netip.Prefix, normalizing a 4-in-6 address to a plain IPv4 prefix. ok is
+// false when the address cannot be represented as a netip.Addr.
+func IPNetToPrefix(n *net.IPNet) (netip.Prefix, bool) {
 	addr, ok := netip.AddrFromSlice(n.IP)
 	if !ok {
 		return netip.Prefix{}, false

--- a/pkg/fib/route_test.go
+++ b/pkg/fib/route_test.go
@@ -11,6 +11,18 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func TestIPNetToPrefix(t *testing.T) {
+	// A 4-in-6 net.IP must render as a plain IPv4 prefix.
+	v4 := &net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(24, 32)}
+	if p, ok := IPNetToPrefix(v4); !ok || p.String() != "10.0.0.0/24" || !p.Addr().Is4() {
+		t.Errorf("IPNetToPrefix(10.0.0.0/24) = %q ok=%v is4=%v", p, ok, p.Addr().Is4())
+	}
+	_, v6, _ := net.ParseCIDR("2001:db8::/64")
+	if p, ok := IPNetToPrefix(v6); !ok || p.String() != "2001:db8::/64" {
+		t.Errorf("IPNetToPrefix(2001:db8::/64) = %q ok=%v", p, ok)
+	}
+}
+
 // withTestNetns moves the calling goroutine's OS thread into a fresh
 // network namespace with one up dummy interface, so route mutations
 // never touch the host's real routing table. Requires CAP_NET_ADMIN

--- a/pkg/netlinkwatch/route_watcher.go
+++ b/pkg/netlinkwatch/route_watcher.go
@@ -1,0 +1,179 @@
+package netlinkwatch
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"sync"
+
+	"github.com/takehaya/vinbero/pkg/fib"
+	"github.com/vishvananda/netlink"
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+)
+
+// RouteSink consumes VRF-local route changes the RouteWatcher observes. The
+// auto-advertise exporter (pkg/bgp/export) satisfies it; keeping it an
+// interface lets the watcher be tested without a BGP session.
+type RouteSink interface {
+	OnRoute(table uint32, prefix netip.Prefix, added bool)
+}
+
+// protocolNames maps the operator-facing redistribute keywords to the kernel
+// route protocols they cover. The set is an allowlist: only the listed
+// protocols are redistributed, so routes Vinbero installs itself (RTPROT_BGP)
+// can never match and a received route is never advertised back out. "static"
+// covers RTPROT_STATIC only (controller-authored static routes); RTPROT_BOOT,
+// the default protocol for an unqualified `ip route add`, is intentionally
+// excluded so a casually-added route does not leak into the VPN.
+var protocolNames = map[string][]int{
+	"connected": {unix.RTPROT_KERNEL},
+	"static":    {unix.RTPROT_STATIC},
+}
+
+// RouteWatcher watches Linux route updates via Netlink and forwards the ones
+// belonging to a registered VRF table (and a redistributed protocol) to a
+// RouteSink. It mirrors FDBWatcher's lifecycle: subscribe in Start, drain on a
+// goroutine, stop by closing done.
+type RouteWatcher struct {
+	sink    RouteSink
+	logger  *zap.Logger
+	mu      sync.RWMutex
+	watched map[uint32]map[int]struct{} // table id -> allowed RTPROT_* set
+	done    chan struct{}
+	wg      sync.WaitGroup
+}
+
+// NewRouteWatcher creates a RouteWatcher that delivers matching route changes
+// to sink.
+func NewRouteWatcher(sink RouteSink, logger *zap.Logger) *RouteWatcher {
+	return &RouteWatcher{
+		sink:    sink,
+		logger:  logger.Named("route.watch"),
+		watched: make(map[uint32]map[int]struct{}),
+		done:    make(chan struct{}),
+	}
+}
+
+// RegisterTable registers the given routing table for redistribution: once
+// Start is running, routes in that table whose protocol is covered by protocols
+// (the redistribute keywords "connected" / "static") are forwarded to the sink.
+// An unknown keyword is rejected so a config typo surfaces instead of silently
+// redistributing nothing.
+func (w *RouteWatcher) RegisterTable(table uint32, protocols []string) error {
+	set := make(map[int]struct{})
+	for _, name := range protocols {
+		protos, ok := protocolNames[name]
+		if !ok {
+			return fmt.Errorf("unknown redistribute protocol %q (want connected|static)", name)
+		}
+		for _, p := range protos {
+			set[p] = struct{}{}
+		}
+	}
+	if len(set) == 0 {
+		return fmt.Errorf("table %d: redistribute list is empty", table)
+	}
+	w.mu.Lock()
+	w.watched[table] = set
+	w.mu.Unlock()
+	w.logger.Info("registered VRF table for route redistribution",
+		zap.Uint32("table", table), zap.Strings("protocols", protocols))
+	return nil
+}
+
+// UnregisterTable stops forwarding routes for a table.
+func (w *RouteWatcher) UnregisterTable(table uint32) {
+	w.mu.Lock()
+	delete(w.watched, table)
+	w.mu.Unlock()
+}
+
+// Start subscribes to route updates and begins forwarding. ListExisting
+// replays the current routing tables so prefixes present before startup are
+// advertised too, matching FDBWatcher.
+func (w *RouteWatcher) Start(ctx context.Context) error {
+	updates := make(chan netlink.RouteUpdate, 256)
+	if err := netlink.RouteSubscribeWithOptions(updates, w.done, netlink.RouteSubscribeOptions{
+		ListExisting: true,
+		// A larger socket buffer reduces the chance of an ENOBUFS overflow
+		// during the ListExisting dump or a route-churn burst; ErrorCallback
+		// surfaces any subscription error (including a dump interruption)
+		// instead of letting it pass silently.
+		ReceiveBufferSize: 1 << 20,
+		ErrorCallback: func(err error) {
+			w.logger.Error("netlink route subscription error", zap.Error(err))
+		},
+	}); err != nil {
+		return err
+	}
+	w.wg.Go(func() {
+		w.processUpdates(ctx, updates)
+	})
+	return nil
+}
+
+func (w *RouteWatcher) processUpdates(ctx context.Context, updates <-chan netlink.RouteUpdate) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.done:
+			return
+		case update, ok := <-updates:
+			if !ok {
+				// A clean Stop() closes w.done first, so reaching here with
+				// w.done still open means the netlink socket closed the channel
+				// on its own (e.g. an ENOBUFS overflow). Log loudly: route
+				// changes are no longer observed, so advertised routes can
+				// silently go stale until the daemon restarts.
+				select {
+				case <-w.done:
+				default:
+					w.logger.Error("netlink route update channel closed unexpectedly; " +
+						"auto-advertise is no longer tracking route changes")
+				}
+				return
+			}
+			w.handleRouteUpdate(update)
+		}
+	}
+}
+
+func (w *RouteWatcher) handleRouteUpdate(u netlink.RouteUpdate) {
+	table := uint32(u.Table)
+	w.mu.RLock()
+	protos, watched := w.watched[table]
+	w.mu.RUnlock()
+	if !watched {
+		return
+	}
+	if _, allow := protos[int(u.Protocol)]; !allow {
+		return
+	}
+	// A nil destination is the default route / a route with no prefix; there
+	// is nothing specific to advertise, so skip it.
+	if u.Dst == nil {
+		return
+	}
+	prefix, ok := fib.IPNetToPrefix(u.Dst)
+	if !ok {
+		return
+	}
+	switch u.Type {
+	case unix.RTM_NEWROUTE:
+		w.sink.OnRoute(table, prefix, true)
+	case unix.RTM_DELROUTE:
+		w.sink.OnRoute(table, prefix, false)
+	}
+}
+
+// Stop ends the watch and waits for the drain goroutine to exit.
+func (w *RouteWatcher) Stop() {
+	select {
+	case <-w.done:
+	default:
+		close(w.done)
+	}
+	w.wg.Wait()
+}

--- a/pkg/netlinkwatch/route_watcher_test.go
+++ b/pkg/netlinkwatch/route_watcher_test.go
@@ -1,0 +1,145 @@
+package netlinkwatch
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+)
+
+type sinkCall struct {
+	table  uint32
+	prefix netip.Prefix
+	added  bool
+}
+
+type fakeSink struct {
+	calls []sinkCall
+}
+
+func (f *fakeSink) OnRoute(table uint32, prefix netip.Prefix, added bool) {
+	f.calls = append(f.calls, sinkCall{table: table, prefix: prefix, added: added})
+}
+
+func mustIPNet(t *testing.T, cidr string) *net.IPNet {
+	t.Helper()
+	_, n, err := net.ParseCIDR(cidr)
+	if err != nil {
+		t.Fatalf("parse %q: %v", cidr, err)
+	}
+	return n
+}
+
+func newRoute(table uint32, proto int, dst *net.IPNet) netlink.Route {
+	return netlink.Route{
+		Table:    int(table),
+		Protocol: netlink.RouteProtocol(proto),
+		Dst:      dst,
+	}
+}
+
+func TestRegisterTableRejectsUnknownProtocol(t *testing.T) {
+	w := NewRouteWatcher(&fakeSink{}, zap.NewNop())
+	if err := w.RegisterTable(100, []string{"bgp"}); err == nil {
+		t.Error("registering an unknown redistribute protocol should fail")
+	}
+}
+
+func TestRegisterTableRejectsEmpty(t *testing.T) {
+	w := NewRouteWatcher(&fakeSink{}, zap.NewNop())
+	if err := w.RegisterTable(100, nil); err == nil {
+		t.Error("registering an empty redistribute list should fail")
+	}
+}
+
+func TestHandleRouteForwardsConnectedV4(t *testing.T) {
+	sink := &fakeSink{}
+	w := NewRouteWatcher(sink, zap.NewNop())
+	if err := w.RegisterTable(100, []string{"connected"}); err != nil {
+		t.Fatalf("RegisterTable: %v", err)
+	}
+	w.handleRouteUpdate(netlink.RouteUpdate{
+		Type:  unix.RTM_NEWROUTE,
+		Route: newRoute(100, unix.RTPROT_KERNEL, mustIPNet(t, "10.0.0.0/24")),
+	})
+	if len(sink.calls) != 1 {
+		t.Fatalf("want 1 forwarded route, got %d", len(sink.calls))
+	}
+	c := sink.calls[0]
+	if c.table != 100 || c.prefix.String() != "10.0.0.0/24" || !c.added {
+		t.Errorf("forwarded %+v", c)
+	}
+}
+
+func TestHandleRouteIgnoresUnwatchedTable(t *testing.T) {
+	sink := &fakeSink{}
+	w := NewRouteWatcher(sink, zap.NewNop())
+	if err := w.RegisterTable(100, []string{"connected"}); err != nil {
+		t.Fatalf("RegisterTable: %v", err)
+	}
+	w.handleRouteUpdate(netlink.RouteUpdate{
+		Type:  unix.RTM_NEWROUTE,
+		Route: newRoute(200, unix.RTPROT_KERNEL, mustIPNet(t, "10.0.0.0/24")),
+	})
+	if len(sink.calls) != 0 {
+		t.Errorf("a route in an unwatched table must be dropped, got %d", len(sink.calls))
+	}
+}
+
+// TestHandleRouteDropsBGPProtocol is the loop-prevention guard: a route
+// Vinbero itself installed (RTPROT_BGP) must never be redistributed back out,
+// even when "connected"/"static" are registered. The allowlist excludes it.
+func TestHandleRouteDropsBGPProtocol(t *testing.T) {
+	sink := &fakeSink{}
+	w := NewRouteWatcher(sink, zap.NewNop())
+	if err := w.RegisterTable(100, []string{"connected", "static"}); err != nil {
+		t.Fatalf("RegisterTable: %v", err)
+	}
+	w.handleRouteUpdate(netlink.RouteUpdate{
+		Type:  unix.RTM_NEWROUTE,
+		Route: newRoute(100, unix.RTPROT_BGP, mustIPNet(t, "10.0.0.0/24")),
+	})
+	if len(sink.calls) != 0 {
+		t.Errorf("a BGP-protocol route must not be redistributed (loop), got %d", len(sink.calls))
+	}
+}
+
+func TestHandleRouteIgnoresNilDst(t *testing.T) {
+	sink := &fakeSink{}
+	w := NewRouteWatcher(sink, zap.NewNop())
+	if err := w.RegisterTable(100, []string{"connected"}); err != nil {
+		t.Fatalf("RegisterTable: %v", err)
+	}
+	w.handleRouteUpdate(netlink.RouteUpdate{
+		Type:  unix.RTM_NEWROUTE,
+		Route: newRoute(100, unix.RTPROT_KERNEL, nil),
+	})
+	if len(sink.calls) != 0 {
+		t.Errorf("a route with no destination must be dropped, got %d", len(sink.calls))
+	}
+}
+
+func TestHandleRouteDelMapsToWithdraw(t *testing.T) {
+	sink := &fakeSink{}
+	w := NewRouteWatcher(sink, zap.NewNop())
+	if err := w.RegisterTable(100, []string{"static"}); err != nil {
+		t.Fatalf("RegisterTable: %v", err)
+	}
+	w.handleRouteUpdate(netlink.RouteUpdate{
+		Type:  unix.RTM_DELROUTE,
+		Route: newRoute(100, unix.RTPROT_STATIC, mustIPNet(t, "2001:db8::/64")),
+	})
+	if len(sink.calls) != 1 {
+		t.Fatalf("want 1 forwarded route, got %d", len(sink.calls))
+	}
+	c := sink.calls[0]
+	if c.added {
+		t.Errorf("RTM_DELROUTE must map to added=false, got %+v", c)
+	}
+	if c.prefix.String() != "2001:db8::/64" {
+		t.Errorf("prefix = %q", c.prefix.String())
+	}
+}

--- a/pkg/vrfbgp/manager.go
+++ b/pkg/vrfbgp/manager.go
@@ -19,9 +19,18 @@ var ErrBindingNotFound = errors.New("vrfbgp: binding not found")
 
 // Binding is one VRF's BGP route-target policy.
 type Binding struct {
-	VRFName        string
-	ImportRTs      []string
-	ExportRTs      []string
+	VRFName string
+	// RD is the route distinguisher this VRF advertises its local prefixes
+	// under (RFC 4364). It is empty for receive-only bindings; the auto
+	// advertise path (pkg/bgp/export) requires it to be non-empty before it
+	// will export a prefix, so a binding without an RD simply never exports.
+	RD        string
+	ImportRTs []string
+	ExportRTs []string
+	// Redistribute lists the route protocols ("connected" / "static") whose
+	// VRF-local prefixes the auto-advertise path (pkg/bgp/export) exports.
+	// Empty means the binding is receive-only.
+	Redistribute   []string
 	DefaultLocator string
 	// BDID is the bridge domain a received EVPN route (RT2/3/4) installs
 	// into when its route targets match ImportRTs. It is 0 for L3VPN-only

--- a/pkg/vrfbgp/manager.go
+++ b/pkg/vrfbgp/manager.go
@@ -30,7 +30,11 @@ type Binding struct {
 	// Redistribute lists the route protocols ("connected" / "static") whose
 	// VRF-local prefixes the auto-advertise path (pkg/bgp/export) exports.
 	// Empty means the binding is receive-only.
-	Redistribute   []string
+	Redistribute []string
+	// MaxPrefixes caps how many prefixes the auto-advertise path originates for
+	// this VRF (0 = unlimited). It bounds the blast radius of a misbehaving or
+	// hostile VRF-route writer flooding the VPN.
+	MaxPrefixes    uint32
 	DefaultLocator string
 	// BDID is the bridge domain a received EVPN route (RT2/3/4) installs
 	// into when its route targets match ImportRTs. It is 0 for L3VPN-only


### PR DESCRIPTION
## Summary

VRF-export driven automatic advertise: VRF-local connected/static prefixes are
advertised as VPNv4/VPNv6 without an explicit BgpRouteService RPC — the
advertise-direction mirror of `pkg/bgp/apply.applyVPN`. Opt-in via
`bgp.global.auto_advertise`.

## What's included

- `pkg/bgp/export.Exporter`: mints per-VRF End.DT4/DT6 service SIDs from the
  binding's default locator, watches kernel routing tables via a new
  `pkg/netlinkwatch.RouteWatcher`, and advertises VRF-local prefixes.
- Config: `bgp.global.auto_advertise` / `next_hop` / `underlay_redistribute`,
  `bgp.locators` (static locator declaration), `vrf_bindings` `rd` /
  `redistribute` / `max_prefixes`.
- IPv6 unicast underlay auto-advertise (main-table IPv6 prefixes).
- Per-VRF max-prefix cap.
- Loop prevention: the redistribute allowlist covers `connected`
  (RTPROT_KERNEL) and `static` (RTPROT_STATIC) only; RTPROT_BGP and RTPROT_BOOT
  are excluded so a received or casually-added route is never re-advertised.

## Testing

- Unit tests for the exporter and route watcher (loop prevention, SID rollback,
  same-table rejection, advertise-failure, max-prefix, underlay).
- E2E: `examples/interop-clab/scenarios/l3vpn-2site-auto` — Vinbero
  auto-advertises a VRF-local prefix to FRR with no `vbctl` call; bidirectional
  ping over the SRv6 L3VPN passes 8/8. Added to the interop CI matrix.

## Review

A multi-perspective review surfaced six should-fix items (netlink overflow
silent death, non-transactional Start, duplicate-table guard, RTPROT_BOOT
exclusion, SID-rollback test coverage, advertise-failure test); all addressed.

## Deferred (separate PRs)

- VrfBgpBind RPC binding auto-advertise (proto + ListExisting timing).
- EVPN / SR Policy / MUP auto-advertise.
- Owner-scoped advertised-path tracking in the gobgp adapter.