### PR TITLE
feat(bgp): EVPN RT2 auto-advertise (local MAC → RT2)

### DIFF
--- a/cmd/vinberod/main.go
+++ b/cmd/vinberod/main.go
@@ -211,7 +211,6 @@ func run(cliCtx *cli.Context) error {
 				bgpSession,
 				vin.GetMapOperations(),
 				locatorMgr,
-				vrfBgpMgr,
 				cfg.BGP.Global.NextHop,
 				lg,
 			)

--- a/cmd/vinberod/main.go
+++ b/cmd/vinberod/main.go
@@ -140,6 +140,9 @@ func run(cliCtx *cli.Context) error {
 	// exporter / routeWatcher drive the auto-advertise path (VRF export).
 	// They stay nil unless BGP is enabled with bgp.global.auto_advertise.
 	var exporter *export.Exporter
+	// evpnExporter drives EVPN RT2 auto-advertise (local MAC -> RT2). nil unless
+	// BGP is enabled with bgp.global.evpn_auto_advertise.
+	var evpnExporter *export.EVPNExporter
 	if cliCtx.Bool("bgp-enabled") {
 		// Load config-time VRF <-> route-target bindings before the BGP
 		// session starts receiving. EVPN routes require a bridge-domain
@@ -199,6 +202,20 @@ func run(cliCtx *cli.Context) error {
 				lg,
 			)
 		}
+		// EVPN RT2 auto-advertise (local MAC -> RT2) is opt-in via
+		// bgp.global.evpn_auto_advertise. It shares the locator manager, VRF
+		// bindings, and BGP advertiser; the FDBWatcher feeds it local MACs and
+		// BridgeCreate/BridgeDelete enable/disable each bound bridge domain.
+		if cfg.BGP.Global.EVPNAutoAdvertise {
+			evpnExporter = export.NewEVPNExporter(
+				bgpSession,
+				vin.GetMapOperations(),
+				locatorMgr,
+				vrfBgpMgr,
+				cfg.BGP.Global.NextHop,
+				lg,
+			)
+		}
 	}
 
 	// exporter implements server.VrfExporter; avoid leaking a typed nil into
@@ -207,7 +224,13 @@ func run(cliCtx *cli.Context) error {
 	if exporter != nil {
 		vrfExp = exporter
 	}
-	srv := server.NewServer(cfg, vin.GetMapOperations(), vin.GetResourceManager(), vin.GetFDBWatcher(), locatorMgr, vrfBgpMgr, advertiser, srPolicyAdvertiser, evpnAdvertiser, mupAdvertiser, applier, vrfExp, lg)
+	// evpnExporter implements server.EvpnBridgeHook; same typed-nil avoidance so
+	// BridgeCreate's nil check holds when EVPN auto-advertise is off.
+	var evpnBridge server.EvpnBridgeHook
+	if evpnExporter != nil {
+		evpnBridge = evpnExporter
+	}
+	srv := server.NewServer(cfg, vin.GetMapOperations(), vin.GetResourceManager(), vin.GetFDBWatcher(), locatorMgr, vrfBgpMgr, advertiser, srPolicyAdvertiser, evpnAdvertiser, mupAdvertiser, applier, vrfExp, evpnBridge, lg)
 
 	if bgpSession != nil {
 		// Registered before the Start attempt so a partial failure
@@ -247,6 +270,18 @@ func run(cliCtx *cli.Context) error {
 				return fmt.Errorf("start auto-advertise: %w", err)
 			}
 			defer exporter.Stop()
+		}
+		// EVPN RT2 auto-advertise: feed the FDBWatcher's local MAC events to the
+		// EVPN exporter. The sink is set here, after the FDBWatcher has already
+		// started (StartFDBWatcher, above), so MACs present at that boot
+		// ListExisting replay are NOT captured; a MAC learned after a BridgeCreate
+		// enables its bridge domain is. Replaying a bridge's existing FDB on enable
+		// (an FDB dump seam symmetric with RouteWatcher.DumpTable) is a follow-up.
+		// Close (withdraw RT2s + release SIDs) runs before the BGP session drops,
+		// like exporter.Stop above.
+		if evpnExporter != nil {
+			vin.GetFDBWatcher().SetMACSink(evpnExporter)
+			defer evpnExporter.Close()
 		}
 	}
 

--- a/pkg/bgp/export/evpn.go
+++ b/pkg/bgp/export/evpn.go
@@ -54,7 +54,6 @@ type EVPNExporter struct {
 	evpn     EVPNAdvertiser
 	sidOps   SidOps
 	locators *locator.Manager
-	bindings *vrfbgp.Manager
 	// nextHop is the BGP next hop stamped on every RT2: this PE's reachable IPv6
 	// address (its loopback), NOT the locator base -- same rule as the L3VPN path.
 	nextHop string
@@ -63,18 +62,35 @@ type EVPNExporter struct {
 }
 
 // NewEVPNExporter wires an EVPN RT2 exporter. nextHop is the advertising PE's
-// reachable IPv6 address (its loopback). bindings is the shared binding registry
-// the L3VPN path also reads; an EVPN binding is one whose BDID is non-zero.
-func NewEVPNExporter(evpn EVPNAdvertiser, sidOps SidOps, locators *locator.Manager, bindings *vrfbgp.Manager, nextHop string, logger *zap.Logger) *EVPNExporter {
+// reachable IPv6 address (its loopback); the caller resolves a bridge domain to
+// its binding and passes it to EnableBD.
+func NewEVPNExporter(evpn EVPNAdvertiser, sidOps SidOps, locators *locator.Manager, nextHop string, logger *zap.Logger) *EVPNExporter {
 	return &EVPNExporter{
 		evpn:     evpn,
 		sidOps:   sidOps,
 		locators: locators,
-		bindings: bindings,
 		nextHop:  nextHop,
 		logger:   logger.Named("bgp.export.evpn"),
 		bds:      make(map[uint16]*bdState),
 	}
+}
+
+// checkNextHop validates the BGP next hop: a non-empty IPv6 (not v4-in-6)
+// address. SRv6 VPN transport is IPv6-only; an empty / IPv4 / malformed next hop
+// serializes into an RT2 no PE can forward toward. Mirrors the L3VPN exporter's
+// Start-time validation, applied per EnableBD since the EVPN path has no Start.
+func checkNextHop(nextHop string) error {
+	if nextHop == "" {
+		return fmt.Errorf("bgp.global.next_hop is required for EVPN auto advertise")
+	}
+	a, err := netip.ParseAddr(nextHop)
+	if err != nil {
+		return fmt.Errorf("bgp.global.next_hop %q is invalid: %w", nextHop, err)
+	}
+	if !a.Is6() || a.Is4In6() {
+		return fmt.Errorf("bgp.global.next_hop %q must be an IPv6 address", nextHop)
+	}
+	return nil
 }
 
 // EnableBD makes a bridge domain's locally-learned MACs eligible for RT2
@@ -85,6 +101,9 @@ func NewEVPNExporter(evpn EVPNAdvertiser, sidOps SidOps, locators *locator.Manag
 // locator, or a non-zero BDID is rejected. It is idempotent: a BD already
 // enabled is replaced.
 func (e *EVPNExporter) EnableBD(b vrfbgp.Binding, bridgeIfindex uint32) error {
+	if err := checkNextHop(e.nextHop); err != nil {
+		return fmt.Errorf("vrf %q: %w", b.VRFName, err)
+	}
 	if b.BDID == 0 {
 		return fmt.Errorf("vrf %q: bd_id is required for EVPN auto advertise", b.VRFName)
 	}

--- a/pkg/bgp/export/evpn.go
+++ b/pkg/bgp/export/evpn.go
@@ -1,0 +1,225 @@
+package export
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"sync"
+
+	"go.uber.org/zap"
+
+	v1 "github.com/takehaya/vinbero/api/vinbero/v1"
+	"github.com/takehaya/vinbero/pkg/bgp"
+	"github.com/takehaya/vinbero/pkg/bpf"
+	"github.com/takehaya/vinbero/pkg/locator"
+	"github.com/takehaya/vinbero/pkg/vrfbgp"
+)
+
+// endpointActionDT2U is the local action for a bridge domain's unicast L2 decap
+// endpoint (End.DT2, FDB lookup). It is the EVPN RT2 service SID a remote PE
+// targets to reach a local MAC. End.DT2M (BUM flood, RT3) is a separate action.
+const endpointActionDT2U = uint8(v1.Srv6LocalAction_SRV6_LOCAL_ACTION_END_DT2)
+
+// EVPNAdvertiser is the subset of bgp.EVPNController the EVPN exporter drives:
+// the RT2 (MAC/IP) advertise direction. RT3/RT4 are future increments.
+type EVPNAdvertiser interface {
+	PushEVPNMac(ctx context.Context, r bgp.EVPNRoute) error
+	WithdrawEVPNMac(ctx context.Context, key bgp.EVPNMACKey) error
+}
+
+// bdState is the per-bridge-domain EVPN export bookkeeping: the binding, the
+// minted End.DT2U service SID, its locator base (the RX reverse-map key carried
+// as RemoteSrc), and the set of locally-learned MACs currently advertised.
+type bdState struct {
+	binding    vrfbgp.Binding
+	sid        netip.Addr
+	remoteSrc  string
+	advertised map[bgp.EVPNMACKey]struct{}
+}
+
+// EVPNExporter turns locally-learned bridge MACs into EVPN RT2 (MAC/IP)
+// advertisements, the EVPN counterpart of the L3VPN Exporter. It is a
+// netlinkwatch.MACSink: the FDBWatcher delivers local MAC changes to OnLocalMAC.
+// EnableBD mints and installs the bridge domain's End.DT2U service SID from the
+// binding's default locator (symmetric with the L3VPN Exporter's DT4/DT6), so an
+// operator only binds the BD and every RT2 follows automatically.
+//
+// Only locally-learned MACs reach this exporter: the EVPN receive path installs
+// remote MACs into the BPF fdb_map with IsRemote=1, never into the kernel bridge
+// FDB the FDBWatcher observes, so re-advertising cannot loop.
+type EVPNExporter struct {
+	mu       sync.Mutex
+	evpn     EVPNAdvertiser
+	sidOps   SidOps
+	locators *locator.Manager
+	bindings *vrfbgp.Manager
+	// nextHop is the BGP next hop stamped on every RT2: this PE's reachable IPv6
+	// address (its loopback), NOT the locator base -- same rule as the L3VPN path.
+	nextHop string
+	logger  *zap.Logger
+	bds     map[uint16]*bdState
+}
+
+// NewEVPNExporter wires an EVPN RT2 exporter. nextHop is the advertising PE's
+// reachable IPv6 address (its loopback). bindings is the shared binding registry
+// the L3VPN path also reads; an EVPN binding is one whose BDID is non-zero.
+func NewEVPNExporter(evpn EVPNAdvertiser, sidOps SidOps, locators *locator.Manager, bindings *vrfbgp.Manager, nextHop string, logger *zap.Logger) *EVPNExporter {
+	return &EVPNExporter{
+		evpn:     evpn,
+		sidOps:   sidOps,
+		locators: locators,
+		bindings: bindings,
+		nextHop:  nextHop,
+		logger:   logger.Named("bgp.export.evpn"),
+		bds:      make(map[uint16]*bdState),
+	}
+}
+
+// EnableBD makes a bridge domain's locally-learned MACs eligible for RT2
+// auto-advertise: it mints an End.DT2U service SID from the binding's default
+// locator and installs it into sid_function_map keyed to the bridge, so a remote
+// PE can decap unicast toward this node. bridgeIfindex is the BD's Linux bridge
+// device, needed for the L2 aux entry. A binding without an RD, a default
+// locator, or a non-zero BDID is rejected. It is idempotent: a BD already
+// enabled is replaced.
+func (e *EVPNExporter) EnableBD(b vrfbgp.Binding, bridgeIfindex uint32) error {
+	if b.BDID == 0 {
+		return fmt.Errorf("vrf %q: bd_id is required for EVPN auto advertise", b.VRFName)
+	}
+	if b.RD == "" {
+		return fmt.Errorf("vrf %q: rd is required for EVPN auto advertise", b.VRFName)
+	}
+	if b.DefaultLocator == "" {
+		return fmt.Errorf("vrf %q: default_locator is required for EVPN auto advertise", b.VRFName)
+	}
+	loc, ok := e.locators.Get(b.DefaultLocator)
+	if !ok {
+		return fmt.Errorf("vrf %q: unknown locator %q", b.VRFName, b.DefaultLocator)
+	}
+	remoteSrc := loc.Prefix.Masked().Addr().String()
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	// Replace any existing enablement so a re-enable updates cleanly.
+	e.disableBDLocked(b.BDID)
+
+	sid, err := e.installDT2U(b.DefaultLocator, b.BDID, bridgeIfindex)
+	if err != nil {
+		return fmt.Errorf("vrf %q: install End.DT2U SID: %w", b.VRFName, err)
+	}
+	e.bds[b.BDID] = &bdState{
+		binding:    b,
+		sid:        sid,
+		remoteSrc:  remoteSrc,
+		advertised: make(map[bgp.EVPNMACKey]struct{}),
+	}
+	e.logger.Info("bridge domain enabled for EVPN RT2 auto advertise",
+		zap.String("vrf", b.VRFName), zap.Uint16("bd_id", b.BDID),
+		zap.String("rd", b.RD), zap.String("dt2u_sid", sid.String()))
+	return nil
+}
+
+// DisableBD withdraws every RT2 advertised for the bridge domain and releases
+// its End.DT2U SID. A no-op for an unknown BD.
+func (e *EVPNExporter) DisableBD(bdID uint16) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.disableBDLocked(bdID)
+}
+
+// disableBDLocked withdraws the BD's advertised RT2s, releases its SID, and
+// drops the state. The caller holds e.mu.
+func (e *EVPNExporter) disableBDLocked(bdID uint16) {
+	st, ok := e.bds[bdID]
+	if !ok {
+		return
+	}
+	for key := range st.advertised {
+		if err := e.evpn.WithdrawEVPNMac(context.Background(), key); err != nil {
+			e.logger.Warn("withdraw RT2 on disable",
+				zap.Uint16("bd_id", bdID), zap.String("mac", key.MAC), zap.Error(err))
+		}
+	}
+	e.removeDT2U(st.sid)
+	delete(e.bds, bdID)
+	e.logger.Info("bridge domain disabled for EVPN RT2 auto advertise", zap.Uint16("bd_id", bdID))
+}
+
+// OnLocalMAC is the netlinkwatch.MACSink callback: a MAC learned (added=true) or
+// aged/removed (added=false) on a watched local bridge. For an enabled BD it
+// advertises (or withdraws) the MAC as an EVPN RT2. A MAC in an unbound BD is
+// ignored.
+func (e *EVPNExporter) OnLocalMAC(bdID uint16, mac net.HardwareAddr, added bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	st, ok := e.bds[bdID]
+	if !ok {
+		return
+	}
+	key := bgp.EVPNMACKey{RD: st.binding.RD, EthernetTag: 0, MAC: mac.String()}
+	if added {
+		if _, dup := st.advertised[key]; dup {
+			return
+		}
+		r := bgp.EVPNRoute{
+			Type: bgp.EVPNRouteTypeMACIP,
+			RD:   st.binding.RD,
+			RTs:  st.binding.ExportRTs,
+			// EthernetTag 0: VLAN-based EVI, one bridge domain = one EVI. ESI is
+			// left zero -- single-homed; multi-homing RT2 ESI is a future
+			// increment that needs the bridge's ES attribute.
+			EthernetTag: 0,
+			MAC:         mac.String(),
+			SRv6SID:     st.sid.String(),
+			NextHop:     e.nextHop,
+			RemoteSrc:   st.remoteSrc,
+		}
+		if err := e.evpn.PushEVPNMac(context.Background(), r); err != nil {
+			e.logger.Error("advertise RT2 for local MAC",
+				zap.Uint16("bd_id", bdID), zap.String("mac", r.MAC), zap.Error(err))
+			return
+		}
+		st.advertised[key] = struct{}{}
+		e.logger.Info("auto-advertised local MAC as EVPN RT2",
+			zap.Uint16("bd_id", bdID), zap.String("mac", r.MAC), zap.String("sid", r.SRv6SID))
+		return
+	}
+	if _, ok := st.advertised[key]; !ok {
+		// Never advertised (a failed push, or a MAC we did not originate): skip
+		// the withdraw so we do not touch another owner's same-NLRI path.
+		return
+	}
+	if err := e.evpn.WithdrawEVPNMac(context.Background(), key); err != nil {
+		e.logger.Error("withdraw RT2 for local MAC",
+			zap.Uint16("bd_id", bdID), zap.String("mac", key.MAC), zap.Error(err))
+		return
+	}
+	delete(st.advertised, key)
+}
+
+// installDT2U mints a function from locatorName, builds the End.DT2U SID, and
+// installs it into sid_function_map as an l2 bridge-domain endpoint owned by
+// Vinbero. On failure the function is returned to the pool. The caller holds e.mu.
+func (e *EVPNExporter) installDT2U(locatorName string, bdID uint16, bridgeIfindex uint32) (netip.Addr, error) {
+	sid, _, err := e.locators.AllocateSID(locatorName, nil)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+	entry := &bpf.SidFunctionEntry{Action: endpointActionDT2U}
+	aux := bpf.NewSidAuxL2(bdID, bridgeIfindex)
+	if err := e.sidOps.CreateSidFunction(sid.String()+"/128", entry, aux, bpf.OwnerBuiltin); err != nil {
+		e.locators.ReleaseSID(sid)
+		return netip.Addr{}, err
+	}
+	return sid, nil
+}
+
+// removeDT2U deletes the End.DT2U SID and returns its function to the pool.
+// Best-effort: a delete failure is logged, not propagated. The caller holds e.mu.
+func (e *EVPNExporter) removeDT2U(sid netip.Addr) {
+	if err := e.sidOps.DeleteSidFunction(sid.String()+"/128", bpf.OwnerBuiltin); err != nil {
+		e.logger.Warn("delete End.DT2U SID", zap.String("sid", sid.String()), zap.Error(err))
+	}
+	e.locators.ReleaseSID(sid)
+}

--- a/pkg/bgp/export/evpn.go
+++ b/pkg/bgp/export/evpn.go
@@ -97,9 +97,9 @@ func checkNextHop(nextHop string) error {
 // auto-advertise: it mints an End.DT2U service SID from the binding's default
 // locator and installs it into sid_function_map keyed to the bridge, so a remote
 // PE can decap unicast toward this node. bridgeIfindex is the BD's Linux bridge
-// device, needed for the L2 aux entry. A binding without an RD, a default
-// locator, or a non-zero BDID is rejected. It is idempotent: a BD already
-// enabled is replaced.
+// device, needed for the L2 aux entry. A binding with a zero BDID, or without an
+// RD or a default locator, is rejected. It is idempotent: a BD already enabled
+// is replaced.
 func (e *EVPNExporter) EnableBD(b vrfbgp.Binding, bridgeIfindex uint32) error {
 	if err := checkNextHop(e.nextHop); err != nil {
 		return fmt.Errorf("vrf %q: %w", b.VRFName, err)
@@ -147,6 +147,20 @@ func (e *EVPNExporter) DisableBD(bdID uint16) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.disableBDLocked(bdID)
+}
+
+// SIDForBD returns the End.DT2U SID (as a "<addr>/128" sid_function_map key) the
+// exporter installed for the bridge domain, so BridgeDelete can exclude this
+// lifecycle-owned SID from its bridge-reference check. ok=false for a BD the
+// exporter has not enabled.
+func (e *EVPNExporter) SIDForBD(bdID uint16) (string, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	st, ok := e.bds[bdID]
+	if !ok {
+		return "", false
+	}
+	return st.sidStr + "/128", true
 }
 
 // Close disables every enabled bridge domain, withdrawing its RT2s and releasing

--- a/pkg/bgp/export/evpn.go
+++ b/pkg/bgp/export/evpn.go
@@ -34,6 +34,7 @@ type EVPNAdvertiser interface {
 type bdState struct {
 	binding    vrfbgp.Binding
 	sid        netip.Addr
+	sidStr     string // sid.String(), rendered once (it is constant per BD)
 	remoteSrc  string
 	advertised map[bgp.EVPNMACKey]struct{}
 }
@@ -111,6 +112,7 @@ func (e *EVPNExporter) EnableBD(b vrfbgp.Binding, bridgeIfindex uint32) error {
 	e.bds[b.BDID] = &bdState{
 		binding:    b,
 		sid:        sid,
+		sidStr:     sid.String(),
 		remoteSrc:  remoteSrc,
 		advertised: make(map[bgp.EVPNMACKey]struct{}),
 	}
@@ -126,6 +128,17 @@ func (e *EVPNExporter) DisableBD(bdID uint16) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.disableBDLocked(bdID)
+}
+
+// Close disables every enabled bridge domain, withdrawing its RT2s and releasing
+// its End.DT2U SIDs. It is the graceful-shutdown counterpart of EnableBD; the
+// BGP session teardown is the backstop, but this withdraws explicitly first.
+func (e *EVPNExporter) Close() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for bdID := range e.bds {
+		e.disableBDLocked(bdID)
+	}
 }
 
 // disableBDLocked withdraws the BD's advertised RT2s, releases its SID, and
@@ -157,7 +170,8 @@ func (e *EVPNExporter) OnLocalMAC(bdID uint16, mac net.HardwareAddr, added bool)
 	if !ok {
 		return
 	}
-	key := bgp.EVPNMACKey{RD: st.binding.RD, EthernetTag: 0, MAC: mac.String()}
+	macStr := mac.String()
+	key := bgp.EVPNMACKey{RD: st.binding.RD, EthernetTag: 0, MAC: macStr}
 	if added {
 		if _, dup := st.advertised[key]; dup {
 			return
@@ -170,8 +184,8 @@ func (e *EVPNExporter) OnLocalMAC(bdID uint16, mac net.HardwareAddr, added bool)
 			// left zero -- single-homed; multi-homing RT2 ESI is a future
 			// increment that needs the bridge's ES attribute.
 			EthernetTag: 0,
-			MAC:         mac.String(),
-			SRv6SID:     st.sid.String(),
+			MAC:         macStr,
+			SRv6SID:     st.sidStr,
 			NextHop:     e.nextHop,
 			RemoteSrc:   st.remoteSrc,
 		}

--- a/pkg/bgp/export/evpn_test.go
+++ b/pkg/bgp/export/evpn_test.go
@@ -115,6 +115,24 @@ func TestEnableBDRejectsMissingFields(t *testing.T) {
 	}
 }
 
+func TestSIDForBD(t *testing.T) {
+	e, _, sid := newTestEVPNExporter(t)
+	if _, ok := e.SIDForBD(100); ok {
+		t.Error("SIDForBD must miss before the BD is enabled")
+	}
+	if err := e.EnableBD(evpnTestBinding(), 10); err != nil {
+		t.Fatalf("EnableBD: %v", err)
+	}
+	got, ok := e.SIDForBD(100)
+	if !ok || got != sid.created[0].prefix {
+		t.Errorf("SIDForBD(100) = %q,%v; want the installed End.DT2U key %q", got, ok, sid.created[0].prefix)
+	}
+	e.DisableBD(100)
+	if _, ok := e.SIDForBD(100); ok {
+		t.Error("SIDForBD must miss after the BD is disabled")
+	}
+}
+
 func TestOnLocalMACAdvertisesRT2(t *testing.T) {
 	e, adv, sid := newTestEVPNExporter(t)
 	if err := e.EnableBD(evpnTestBinding(), 10); err != nil {

--- a/pkg/bgp/export/evpn_test.go
+++ b/pkg/bgp/export/evpn_test.go
@@ -52,7 +52,7 @@ func newTestEVPNExporter(t *testing.T) (*EVPNExporter, *fakeEVPNAdv, *fakeSidOps
 	}
 	adv := &fakeEVPNAdv{}
 	sid := &fakeSidOps{}
-	e := NewEVPNExporter(adv, sid, locs, vrfbgp.NewManager(), "2001:db8:ff::1", zap.NewNop())
+	e := NewEVPNExporter(adv, sid, locs, "2001:db8:ff::1", zap.NewNop())
 	return e, adv, sid
 }
 
@@ -76,6 +76,23 @@ func TestEnableBDInstallsDT2U(t *testing.T) {
 	}
 	if sid.created[0].action != endpointActionDT2U {
 		t.Errorf("installed SID action = %d, want End.DT2U %d", sid.created[0].action, endpointActionDT2U)
+	}
+}
+
+func TestEnableBDRejectsInvalidNextHop(t *testing.T) {
+	locs := locator.NewManager()
+	if err := locs.Add(&locator.Locator{
+		Name: "LOC1", Prefix: netip.MustParsePrefix("fd00:1:1::/48"),
+		BlockLen: 32, NodeLen: 16, FunctionLen: 16, ArgumentLen: 64,
+		Behavior: locator.BehaviorClassic, FunctionAutoStart: 0x10, FunctionAutoEnd: 0xfffe,
+	}); err != nil {
+		t.Fatalf("add locator: %v", err)
+	}
+	for _, nh := range []string{"", "10.0.0.1", "not-an-ip"} {
+		e := NewEVPNExporter(&fakeEVPNAdv{}, &fakeSidOps{}, locs, nh, zap.NewNop())
+		if err := e.EnableBD(evpnTestBinding(), 10); err == nil {
+			t.Errorf("EnableBD with next_hop %q should fail (must be a valid IPv6)", nh)
+		}
 	}
 }
 

--- a/pkg/bgp/export/evpn_test.go
+++ b/pkg/bgp/export/evpn_test.go
@@ -1,0 +1,222 @@
+package export
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/takehaya/vinbero/pkg/bgp"
+	"github.com/takehaya/vinbero/pkg/locator"
+	"github.com/takehaya/vinbero/pkg/vrfbgp"
+)
+
+// fakeEVPNAdv records RT2 advertise / withdraw calls.
+type fakeEVPNAdv struct {
+	pushed    []bgp.EVPNRoute
+	withdrawn []bgp.EVPNMACKey
+	pushErr   error
+}
+
+func (f *fakeEVPNAdv) PushEVPNMac(_ context.Context, r bgp.EVPNRoute) error {
+	if f.pushErr != nil {
+		return f.pushErr
+	}
+	f.pushed = append(f.pushed, r)
+	return nil
+}
+
+func (f *fakeEVPNAdv) WithdrawEVPNMac(_ context.Context, key bgp.EVPNMACKey) error {
+	f.withdrawn = append(f.withdrawn, key)
+	return nil
+}
+
+func newTestEVPNExporter(t *testing.T) (*EVPNExporter, *fakeEVPNAdv, *fakeSidOps) {
+	t.Helper()
+	locs := locator.NewManager()
+	if err := locs.Add(&locator.Locator{
+		Name:              "LOC1",
+		Prefix:            netip.MustParsePrefix("fd00:1:1::/48"),
+		BlockLen:          32,
+		NodeLen:           16,
+		FunctionLen:       16,
+		ArgumentLen:       64,
+		Behavior:          locator.BehaviorClassic,
+		FunctionAutoStart: 0x10,
+		FunctionAutoEnd:   0xfffe,
+	}); err != nil {
+		t.Fatalf("add locator: %v", err)
+	}
+	adv := &fakeEVPNAdv{}
+	sid := &fakeSidOps{}
+	e := NewEVPNExporter(adv, sid, locs, vrfbgp.NewManager(), "2001:db8:ff::1", zap.NewNop())
+	return e, adv, sid
+}
+
+func evpnTestBinding() vrfbgp.Binding {
+	return vrfbgp.Binding{
+		VRFName:        "evi100",
+		RD:             "65000:100",
+		ExportRTs:      []string{"65000:100"},
+		DefaultLocator: "LOC1",
+		BDID:           100,
+	}
+}
+
+func TestEnableBDInstallsDT2U(t *testing.T) {
+	e, _, sid := newTestEVPNExporter(t)
+	if err := e.EnableBD(evpnTestBinding(), 10); err != nil {
+		t.Fatalf("EnableBD: %v", err)
+	}
+	if len(sid.created) != 1 {
+		t.Fatalf("want 1 End.DT2U SID installed, got %d: %+v", len(sid.created), sid.created)
+	}
+	if sid.created[0].action != endpointActionDT2U {
+		t.Errorf("installed SID action = %d, want End.DT2U %d", sid.created[0].action, endpointActionDT2U)
+	}
+}
+
+func TestEnableBDRejectsMissingFields(t *testing.T) {
+	e, _, _ := newTestEVPNExporter(t)
+	noBD := evpnTestBinding()
+	noBD.BDID = 0
+	if err := e.EnableBD(noBD, 10); err == nil {
+		t.Error("EnableBD without bd_id should fail")
+	}
+	noRD := evpnTestBinding()
+	noRD.RD = ""
+	if err := e.EnableBD(noRD, 10); err == nil {
+		t.Error("EnableBD without RD should fail")
+	}
+	badLoc := evpnTestBinding()
+	badLoc.DefaultLocator = "NOPE"
+	if err := e.EnableBD(badLoc, 10); err == nil {
+		t.Error("EnableBD with an unknown locator should fail")
+	}
+}
+
+func TestOnLocalMACAdvertisesRT2(t *testing.T) {
+	e, adv, sid := newTestEVPNExporter(t)
+	if err := e.EnableBD(evpnTestBinding(), 10); err != nil {
+		t.Fatalf("EnableBD: %v", err)
+	}
+	mac := net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01}
+	e.OnLocalMAC(100, mac, true)
+
+	if len(adv.pushed) != 1 {
+		t.Fatalf("want 1 RT2 advertised, got %d", len(adv.pushed))
+	}
+	r := adv.pushed[0]
+	if r.Type != bgp.EVPNRouteTypeMACIP {
+		t.Errorf("type = %d, want RT2", r.Type)
+	}
+	if r.RD != "65000:100" {
+		t.Errorf("rd = %q", r.RD)
+	}
+	if len(r.RTs) != 1 || r.RTs[0] != "65000:100" {
+		t.Errorf("rts = %v", r.RTs)
+	}
+	if r.MAC != mac.String() {
+		t.Errorf("mac = %q, want %q", r.MAC, mac.String())
+	}
+	if r.NextHop != "2001:db8:ff::1" {
+		t.Errorf("nexthop = %q, want the configured loopback", r.NextHop)
+	}
+	if r.RemoteSrc != "fd00:1:1::" {
+		t.Errorf("remote_src = %q, want the locator base fd00:1:1::", r.RemoteSrc)
+	}
+	if r.SRv6SID+"/128" != sid.created[0].prefix {
+		t.Errorf("SID = %q, want the installed End.DT2U %q", r.SRv6SID, sid.created[0].prefix)
+	}
+}
+
+func TestOnLocalMACWithdrawMirrorsAdvertise(t *testing.T) {
+	e, adv, _ := newTestEVPNExporter(t)
+	if err := e.EnableBD(evpnTestBinding(), 10); err != nil {
+		t.Fatalf("EnableBD: %v", err)
+	}
+	mac := net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01}
+	e.OnLocalMAC(100, mac, true)
+	e.OnLocalMAC(100, mac, false)
+	if len(adv.withdrawn) != 1 {
+		t.Fatalf("want 1 withdraw, got %d", len(adv.withdrawn))
+	}
+	k := adv.withdrawn[0]
+	if k.RD != "65000:100" || k.MAC != mac.String() || k.EthernetTag != 0 {
+		t.Errorf("withdraw key = %+v", k)
+	}
+}
+
+func TestOnLocalMACAddIsIdempotent(t *testing.T) {
+	e, adv, _ := newTestEVPNExporter(t)
+	if err := e.EnableBD(evpnTestBinding(), 10); err != nil {
+		t.Fatalf("EnableBD: %v", err)
+	}
+	mac := net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01}
+	e.OnLocalMAC(100, mac, true)
+	e.OnLocalMAC(100, mac, true) // duplicate learn
+	if len(adv.pushed) != 1 {
+		t.Errorf("a duplicate MAC learn should advertise once, got %d", len(adv.pushed))
+	}
+}
+
+func TestOnLocalMACIgnoresUnboundBD(t *testing.T) {
+	e, adv, _ := newTestEVPNExporter(t)
+	e.OnLocalMAC(999, net.HardwareAddr{0xaa, 0, 0, 0, 0, 1}, true)
+	if len(adv.pushed) != 0 {
+		t.Errorf("a MAC in an unbound BD must not be advertised, got %d", len(adv.pushed))
+	}
+}
+
+func TestOnLocalMACWithdrawUnadvertisedIsNoop(t *testing.T) {
+	e, adv, _ := newTestEVPNExporter(t)
+	if err := e.EnableBD(evpnTestBinding(), 10); err != nil {
+		t.Fatalf("EnableBD: %v", err)
+	}
+	// Delete a MAC we never advertised: must not issue a withdraw.
+	e.OnLocalMAC(100, net.HardwareAddr{0xaa, 0, 0, 0, 0, 9}, false)
+	if len(adv.withdrawn) != 0 {
+		t.Errorf("withdraw of an unadvertised MAC must be a no-op, got %d", len(adv.withdrawn))
+	}
+}
+
+func TestDisableBDWithdrawsAllAndReleases(t *testing.T) {
+	e, adv, sid := newTestEVPNExporter(t)
+	if err := e.EnableBD(evpnTestBinding(), 10); err != nil {
+		t.Fatalf("EnableBD: %v", err)
+	}
+	e.OnLocalMAC(100, net.HardwareAddr{0xaa, 0, 0, 0, 0, 1}, true)
+	e.OnLocalMAC(100, net.HardwareAddr{0xaa, 0, 0, 0, 0, 2}, true)
+
+	e.DisableBD(100)
+
+	if len(adv.withdrawn) != 2 {
+		t.Errorf("want 2 RT2 withdrawn on disable, got %d", len(adv.withdrawn))
+	}
+	if len(sid.deleted) != 1 {
+		t.Errorf("want the End.DT2U SID released on disable, got %d", len(sid.deleted))
+	}
+	// The BD is gone, so re-enabling must succeed.
+	if err := e.EnableBD(evpnTestBinding(), 10); err != nil {
+		t.Fatalf("re-enable after disable: %v", err)
+	}
+}
+
+func TestOnLocalMACPushFailureNotRecorded(t *testing.T) {
+	e, adv, _ := newTestEVPNExporter(t)
+	if err := e.EnableBD(evpnTestBinding(), 10); err != nil {
+		t.Fatalf("EnableBD: %v", err)
+	}
+	adv.pushErr = errors.New("push failed")
+	e.OnLocalMAC(100, net.HardwareAddr{0xaa, 0, 0, 0, 0, 1}, true)
+	// The push failed, so the MAC must not be recorded -- a later disable must
+	// not withdraw a route that was never advertised.
+	adv.pushErr = nil
+	e.DisableBD(100)
+	if len(adv.withdrawn) != 0 {
+		t.Errorf("a failed push must not be recorded, but disable withdrew %d", len(adv.withdrawn))
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -93,6 +93,11 @@ type BGPGlobalConfig struct {
 	// call. Defaults to false so the operator-explicit path stays the only
 	// behavior unless opted in.
 	AutoAdvertise bool `yaml:"auto_advertise,omitempty" default:"false"`
+	// EVPNAutoAdvertise turns on the EVPN RT2 auto advertise path
+	// (pkg/bgp/export.EVPNExporter): a locally-learned bridge MAC in a bound
+	// bridge domain is advertised as an EVPN RT2 (MAC/IP) without an explicit
+	// BgpRouteService call. Shares NextHop with the L3VPN path. Defaults to false.
+	EVPNAutoAdvertise bool `yaml:"evpn_auto_advertise,omitempty" default:"false"`
 	// NextHop is the BGP next hop the auto-advertise path stamps on routes it
 	// originates: this PE's own reachable IPv6 address (its loopback). Required
 	// when auto_advertise is on. It must NOT be a locator base -- a locator

--- a/pkg/netlinkwatch/fdb_macsink_test.go
+++ b/pkg/netlinkwatch/fdb_macsink_test.go
@@ -1,6 +1,7 @@
 package netlinkwatch
 
 import (
+	"errors"
 	"net"
 	"testing"
 
@@ -13,11 +14,15 @@ import (
 // fakeFdbMapOps records FDB writes without a live BPF map (the MAC string of
 // each create/delete).
 type fakeFdbMapOps struct {
-	created []string // mac.String() of each CreateFdb
-	deleted []string // mac.String() of each DeleteFdb
+	created   []string // mac.String() of each CreateFdb
+	deleted   []string // mac.String() of each DeleteFdb
+	createErr error    // when set, CreateFdb fails (dataplane sync failure)
 }
 
 func (f *fakeFdbMapOps) CreateFdb(bdID uint16, mac net.HardwareAddr, _ *bpf.FdbEntry) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
 	f.created = append(f.created, mac.String())
 	return nil
 }
@@ -91,6 +96,21 @@ func TestFDBWatcherSinkIgnoresUnregisteredBridge(t *testing.T) {
 	})
 	if len(sink.events) != 0 {
 		t.Errorf("a MAC on an unregistered bridge must not reach the sink, got %+v", sink.events)
+	}
+}
+
+// When the BPF fdb_map sync fails, the MAC must NOT reach the sink: advertising
+// an RT2 for a MAC the data plane cannot decap to would blackhole remote traffic.
+func TestFDBWatcherSinkSkippedWhenBPFSyncFails(t *testing.T) {
+	sink := &fakeMACSink{}
+	w, ops := newSinkTestWatcher(sink)
+	ops.createErr = errors.New("map full")
+	w.handleNeighUpdate(netlink.NeighUpdate{
+		Type:  unix.RTM_NEWNEIGH,
+		Neigh: netlink.Neigh{Family: unix.AF_BRIDGE, MasterIndex: 10, LinkIndex: 3, HardwareAddr: net.HardwareAddr{0xaa, 0, 0, 0, 0, 1}},
+	})
+	if len(sink.events) != 0 {
+		t.Errorf("a failed BPF sync must not notify the sink, got %+v", sink.events)
 	}
 }
 

--- a/pkg/netlinkwatch/fdb_macsink_test.go
+++ b/pkg/netlinkwatch/fdb_macsink_test.go
@@ -10,10 +10,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// fakeFdbMapOps records FDB writes without a live BPF map.
+// fakeFdbMapOps records FDB writes without a live BPF map (the MAC string of
+// each create/delete).
 type fakeFdbMapOps struct {
-	created []string // "bd/mac"
-	deleted []string
+	created []string // mac.String() of each CreateFdb
+	deleted []string // mac.String() of each DeleteFdb
 }
 
 func (f *fakeFdbMapOps) CreateFdb(bdID uint16, mac net.HardwareAddr, _ *bpf.FdbEntry) error {

--- a/pkg/netlinkwatch/fdb_macsink_test.go
+++ b/pkg/netlinkwatch/fdb_macsink_test.go
@@ -1,0 +1,107 @@
+package netlinkwatch
+
+import (
+	"net"
+	"testing"
+
+	"github.com/takehaya/vinbero/pkg/bpf"
+	"github.com/vishvananda/netlink"
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+)
+
+// fakeFdbMapOps records FDB writes without a live BPF map.
+type fakeFdbMapOps struct {
+	created []string // "bd/mac"
+	deleted []string
+}
+
+func (f *fakeFdbMapOps) CreateFdb(bdID uint16, mac net.HardwareAddr, _ *bpf.FdbEntry) error {
+	f.created = append(f.created, mac.String())
+	return nil
+}
+func (f *fakeFdbMapOps) DeleteFdb(bdID uint16, mac net.HardwareAddr) error {
+	f.deleted = append(f.deleted, mac.String())
+	return nil
+}
+func (f *fakeFdbMapOps) AgeFdbEntries(uint64) (int, error) { return 0, nil }
+
+type macEvent struct {
+	bdID  uint16
+	mac   string
+	added bool
+}
+
+type fakeMACSink struct {
+	events []macEvent
+}
+
+func (f *fakeMACSink) OnLocalMAC(bdID uint16, mac net.HardwareAddr, added bool) {
+	f.events = append(f.events, macEvent{bdID: bdID, mac: mac.String(), added: added})
+}
+
+func newSinkTestWatcher(sink MACSink) (*FDBWatcher, *fakeFdbMapOps) {
+	ops := &fakeFdbMapOps{}
+	w := &FDBWatcher{
+		mapOps:  ops,
+		logger:  zap.NewNop(),
+		allowed: make(map[int]uint16),
+		done:    make(chan struct{}),
+	}
+	w.RegisterBridge(10, 100) // bridge ifindex 10 -> bd_id 100
+	w.SetMACSink(sink)
+	return w, ops
+}
+
+// A local MAC add/delete on a registered bridge is forwarded to the MAC sink for
+// EVPN RT2 auto-advertise, with the right bd_id and add/delete flag.
+func TestFDBWatcherForwardsLocalMACToSink(t *testing.T) {
+	sink := &fakeMACSink{}
+	w, _ := newSinkTestWatcher(sink)
+	mac := net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01}
+
+	w.handleNeighUpdate(netlink.NeighUpdate{
+		Type:  unix.RTM_NEWNEIGH,
+		Neigh: netlink.Neigh{Family: unix.AF_BRIDGE, MasterIndex: 10, LinkIndex: 3, HardwareAddr: mac},
+	})
+	w.handleNeighUpdate(netlink.NeighUpdate{
+		Type:  unix.RTM_DELNEIGH,
+		Neigh: netlink.Neigh{Family: unix.AF_BRIDGE, MasterIndex: 10, LinkIndex: 3, HardwareAddr: mac},
+	})
+
+	if len(sink.events) != 2 {
+		t.Fatalf("want 2 sink events (add+del), got %d: %+v", len(sink.events), sink.events)
+	}
+	if e := sink.events[0]; e.bdID != 100 || e.mac != mac.String() || !e.added {
+		t.Errorf("add event = %+v, want {100, %s, true}", e, mac)
+	}
+	if e := sink.events[1]; e.bdID != 100 || e.mac != mac.String() || e.added {
+		t.Errorf("del event = %+v, want {100, %s, false}", e, mac)
+	}
+}
+
+// A MAC on a bridge that is not registered is dropped before reaching the sink.
+func TestFDBWatcherSinkIgnoresUnregisteredBridge(t *testing.T) {
+	sink := &fakeMACSink{}
+	w, _ := newSinkTestWatcher(sink)
+	w.handleNeighUpdate(netlink.NeighUpdate{
+		Type:  unix.RTM_NEWNEIGH,
+		Neigh: netlink.Neigh{Family: unix.AF_BRIDGE, MasterIndex: 99, LinkIndex: 3, HardwareAddr: net.HardwareAddr{0xaa, 0, 0, 0, 0, 1}},
+	})
+	if len(sink.events) != 0 {
+		t.Errorf("a MAC on an unregistered bridge must not reach the sink, got %+v", sink.events)
+	}
+}
+
+// A nil sink (EVPN auto-advertise off) must not panic; the BPF sync still runs.
+func TestFDBWatcherNilSinkStillSyncsBPF(t *testing.T) {
+	w, ops := newSinkTestWatcher(nil)
+	mac := net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x02}
+	w.handleNeighUpdate(netlink.NeighUpdate{
+		Type:  unix.RTM_NEWNEIGH,
+		Neigh: netlink.Neigh{Family: unix.AF_BRIDGE, MasterIndex: 10, LinkIndex: 3, HardwareAddr: mac},
+	})
+	if len(ops.created) != 1 {
+		t.Errorf("BPF sync must still run with a nil sink, got %+v", ops.created)
+	}
+}

--- a/pkg/netlinkwatch/fdb_watcher.go
+++ b/pkg/netlinkwatch/fdb_watcher.go
@@ -184,6 +184,9 @@ func (w *FDBWatcher) handleNeighUpdate(update netlink.NeighUpdate) {
 				zap.String("mac", mac.String()),
 				zap.Uint16("bd_id", bdID),
 				zap.Error(err))
+			// The dataplane FDB was not installed; do not advertise RT2 for a MAC
+			// the data plane cannot decap to, or remote traffic would blackhole.
+			return
 		}
 		w.notifyMAC(sink, bdID, mac, true)
 

--- a/pkg/netlinkwatch/fdb_watcher.go
+++ b/pkg/netlinkwatch/fdb_watcher.go
@@ -12,13 +12,31 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// MACSink consumes local bridge FDB MAC changes the FDBWatcher observes, for
+// EVPN RT2 auto-advertise. The kernel bridge FDB only holds locally-learned
+// MACs -- the EVPN receive path installs remote MACs into the BPF fdb_map with
+// IsRemote=1, never into the kernel FDB -- so every MAC delivered here is local
+// and advertising it as RT2 cannot loop. nil sink means no auto-advertise.
+type MACSink interface {
+	OnLocalMAC(bdID uint16, mac net.HardwareAddr, added bool)
+}
+
+// fdbMapOps is the subset of *bpf.MapOperations the FDBWatcher needs, narrowed
+// to an interface so the watcher is unit-testable without a live BPF map.
+type fdbMapOps interface {
+	CreateFdb(bdID uint16, mac net.HardwareAddr, entry *bpf.FdbEntry) error
+	DeleteFdb(bdID uint16, mac net.HardwareAddr) error
+	AgeFdbEntries(maxAgeNs uint64) (int, error)
+}
+
 // FDBWatcher watches Linux bridge FDB updates via Netlink and syncs them to BPF fdb_map.
 // Also runs a periodic aging timer to delete stale dynamic entries.
 type FDBWatcher struct {
-	mapOps       *bpf.MapOperations
+	mapOps       fdbMapOps
 	logger       *zap.Logger
 	mu           sync.RWMutex
 	allowed      map[int]uint16 // bridge ifindex → bd_id (for O(1) filter)
+	macSink      MACSink        // nil unless EVPN auto-advertise is on
 	done         chan struct{}
 	wg           sync.WaitGroup
 	agingSeconds int // 0=disabled
@@ -62,19 +80,15 @@ func (w *FDBWatcher) Start(ctx context.Context) error {
 		return err
 	}
 
-	w.wg.Add(1)
-	go func() {
-		defer w.wg.Done()
+	w.wg.Go(func() {
 		w.processUpdates(ctx, updates)
-	}()
+	})
 
 	// Start aging timer if configured
 	if w.agingSeconds > 0 {
-		w.wg.Add(1)
-		go func() {
-			defer w.wg.Done()
+		w.wg.Go(func() {
 			w.runAging(ctx)
-		}()
+		})
 	}
 
 	return nil
@@ -83,6 +97,14 @@ func (w *FDBWatcher) Start(ctx context.Context) error {
 // SetAgingSeconds configures the FDB aging timeout.
 func (w *FDBWatcher) SetAgingSeconds(seconds int) {
 	w.agingSeconds = seconds
+}
+
+// SetMACSink installs the sink that receives local MAC add/delete events for
+// EVPN RT2 auto-advertise. Call before Start.
+func (w *FDBWatcher) SetMACSink(sink MACSink) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.macSink = sink
 }
 
 func (w *FDBWatcher) runAging(ctx context.Context) {
@@ -134,6 +156,7 @@ func (w *FDBWatcher) handleNeighUpdate(update netlink.NeighUpdate) {
 	// Filter: only process FDB entries from registered bridges
 	w.mu.RLock()
 	bdID, ok := w.allowed[neigh.MasterIndex]
+	sink := w.macSink
 	w.mu.RUnlock()
 	if !ok {
 		return
@@ -160,6 +183,7 @@ func (w *FDBWatcher) handleNeighUpdate(update netlink.NeighUpdate) {
 				zap.Uint16("bd_id", bdID),
 				zap.Error(err))
 		}
+		w.notifyMAC(sink, bdID, mac, true)
 
 	case unix.RTM_DELNEIGH:
 		if err := w.mapOps.DeleteFdb(bdID, net.HardwareAddr(mac)); err != nil {
@@ -168,7 +192,17 @@ func (w *FDBWatcher) handleNeighUpdate(update netlink.NeighUpdate) {
 				zap.Uint16("bd_id", bdID),
 				zap.Error(err))
 		}
+		w.notifyMAC(sink, bdID, mac, false)
 	}
+}
+
+// notifyMAC forwards a local MAC change to the EVPN auto-advertise sink, if one
+// is set. It copies the MAC because the netlink-supplied slice may be reused.
+func (w *FDBWatcher) notifyMAC(sink MACSink, bdID uint16, mac net.HardwareAddr, added bool) {
+	if sink == nil {
+		return
+	}
+	sink.OnLocalMAC(bdID, append(net.HardwareAddr(nil), mac...), added)
 }
 
 // Stop stops the FDB watcher and waits for cleanup

--- a/pkg/netlinkwatch/fdb_watcher.go
+++ b/pkg/netlinkwatch/fdb_watcher.go
@@ -100,7 +100,9 @@ func (w *FDBWatcher) SetAgingSeconds(seconds int) {
 }
 
 // SetMACSink installs the sink that receives local MAC add/delete events for
-// EVPN RT2 auto-advertise. Call before Start.
+// EVPN RT2 auto-advertise. It is safe to call at any time (guarded by w.mu),
+// but setting it after Start means the boot-time ListExisting replay has already
+// run, so MACs present at that point are not delivered to the sink.
 func (w *FDBWatcher) SetMACSink(sink MACSink) {
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/pkg/server/network_resource.go
+++ b/pkg/server/network_resource.go
@@ -99,6 +99,13 @@ func (s *NetworkResourceServer) BridgeDelete(
 		// RT2s and releases its End.DT2U SID. That SID references this bridge's
 		// ifindex, so findBridgeReference below would otherwise report the bridge
 		// as still referenced and block the delete (and DisableBD would never run).
+		// On a ResourceManager cache miss (e.g. after a restart) bdID is 0 here,
+		// so recover it from the installed L2 SID's aux to still disable cleanly.
+		if s.evpn != nil && bdID == 0 && ifindex != 0 {
+			if bd, ok := s.bdIDForBridge(ifindex); ok {
+				bdID = bd
+			}
+		}
 		if s.evpn != nil && bdID != 0 {
 			s.evpn.DisableBD(bdID)
 		}
@@ -245,6 +252,38 @@ func (s *NetworkResourceServer) VrfList(
 		})
 	}
 	return connect.NewResponse(resp), nil
+}
+
+// bdIDForBridge returns the bd_id of an End.DT2/DT2M SID installed for the given
+// bridge ifindex. BridgeDelete uses it to recover the bd_id (and so disable EVPN
+// auto-advertise) when the ResourceManager cache has no record of the bridge.
+// ok=false when no L2 SID references the bridge. DisableBD is a no-op for a bd_id
+// the exporter has not enabled, so a non-exporter L2 SID match is harmless.
+func (s *NetworkResourceServer) bdIDForBridge(ifindex uint32) (uint16, bool) {
+	entries, err := s.mapOps.ListSidFunctions()
+	if err != nil {
+		return 0, false
+	}
+	for _, entry := range entries {
+		switch v1.Srv6LocalAction(entry.Action) {
+		case v1.Srv6LocalAction_SRV6_LOCAL_ACTION_END_DT2,
+			v1.Srv6LocalAction_SRV6_LOCAL_ACTION_END_DT2M:
+		default:
+			continue
+		}
+		if entry.AuxIndex == 0 {
+			continue
+		}
+		aux, err := s.mapOps.GetSidAux(uint32(entry.AuxIndex))
+		if err != nil {
+			continue
+		}
+		bdID, bridgeIfindex := bpf.SidAuxL2Data(aux)
+		if bridgeIfindex == ifindex {
+			return bdID, true
+		}
+	}
+	return 0, false
 }
 
 // findBridgeReference checks if any End.DT2/DT2M SID entry references the given bridge_ifindex.

--- a/pkg/server/network_resource.go
+++ b/pkg/server/network_resource.go
@@ -9,16 +9,29 @@ import (
 	"github.com/takehaya/vinbero/pkg/bpf"
 	"github.com/takehaya/vinbero/pkg/netlinkwatch"
 	"github.com/takehaya/vinbero/pkg/netresource"
+	"github.com/takehaya/vinbero/pkg/vrfbgp"
+	"go.uber.org/zap"
 )
+
+// EvpnBridgeHook enables or disables EVPN RT2 auto-advertise for a bridge domain
+// as its bridge is created or deleted. *pkg/bgp/export.EVPNExporter satisfies
+// it; it is nil unless EVPN auto-advertise is on.
+type EvpnBridgeHook interface {
+	EnableBD(b vrfbgp.Binding, bridgeIfindex uint32) error
+	DisableBD(bdID uint16)
+}
 
 type NetworkResourceServer struct {
 	resMgr     *netresource.ResourceManager
 	fdbWatcher *netlinkwatch.FDBWatcher
 	mapOps     *bpf.MapOperations
+	mgr        *vrfbgp.Manager // binding registry, to resolve a bd_id to its EVPN binding
+	evpn       EvpnBridgeHook  // nil unless EVPN auto-advertise is on
+	logger     *zap.Logger
 }
 
-func NewNetworkResourceServer(resMgr *netresource.ResourceManager, fdbWatcher *netlinkwatch.FDBWatcher, mapOps *bpf.MapOperations) *NetworkResourceServer {
-	return &NetworkResourceServer{resMgr: resMgr, fdbWatcher: fdbWatcher, mapOps: mapOps}
+func NewNetworkResourceServer(resMgr *netresource.ResourceManager, fdbWatcher *netlinkwatch.FDBWatcher, mapOps *bpf.MapOperations, mgr *vrfbgp.Manager, evpn EvpnBridgeHook, logger *zap.Logger) *NetworkResourceServer {
+	return &NetworkResourceServer{resMgr: resMgr, fdbWatcher: fdbWatcher, mapOps: mapOps, mgr: mgr, evpn: evpn, logger: logger}
 }
 
 func (s *NetworkResourceServer) BridgeCreate(
@@ -43,6 +56,18 @@ func (s *NetworkResourceServer) BridgeCreate(
 		// Register with FDB watcher for dynamic MAC learning
 		s.fdbWatcher.RegisterBridge(int(ifindex), uint16(br.BdId))
 
+		// If EVPN auto-advertise is on and this bd_id has a binding, enable RT2
+		// auto-advertise for the bridge. A failure here is non-fatal: the bridge
+		// is created regardless, it just won't auto-originate RT2.
+		if s.evpn != nil {
+			if b, ok := s.mgr.GetByBDID(uint16(br.BdId)); ok {
+				if err := s.evpn.EnableBD(b, ifindex); err != nil {
+					s.logger.Warn("enable EVPN RT2 auto-advertise for bridge",
+						zap.String("bridge", br.Name), zap.Uint32("bd_id", br.BdId), zap.Error(err))
+				}
+			}
+		}
+
 		resp.Created = append(resp.Created, br)
 	}
 
@@ -59,10 +84,13 @@ func (s *NetworkResourceServer) BridgeDelete(
 	}
 
 	for _, name := range req.Msg.Names {
-		// Resolve ifindex from ResourceManager cache, falling back to netlink
+		// Resolve ifindex (and bd_id) from ResourceManager cache, falling back to
+		// netlink for the ifindex.
 		var ifindex uint32
+		var bdID uint16
 		if br, ok := s.resMgr.GetBridgeByName(name); ok {
 			ifindex = br.Ifindex
+			bdID = br.BdID
 		} else if resolved, err := resolveIfindex(name); err == nil {
 			ifindex = resolved
 		}
@@ -84,6 +112,12 @@ func (s *NetworkResourceServer) BridgeDelete(
 				continue
 			}
 			s.fdbWatcher.UnregisterBridge(int(ifindex))
+		}
+
+		// Disable EVPN RT2 auto-advertise for the bridge domain before deleting:
+		// withdraws its RT2s and releases the End.DT2U SID.
+		if s.evpn != nil && bdID != 0 {
+			s.evpn.DisableBD(bdID)
 		}
 
 		if err := s.resMgr.DeleteBridge(name); err != nil {

--- a/pkg/server/network_resource.go
+++ b/pkg/server/network_resource.go
@@ -19,6 +19,10 @@ import (
 type EvpnBridgeHook interface {
 	EnableBD(b vrfbgp.Binding, bridgeIfindex uint32) error
 	DisableBD(bdID uint16)
+	// SIDForBD returns the End.DT2U SID (a sid_function_map key) the exporter
+	// installed for the bd, so BridgeDelete can exclude this lifecycle-owned SID
+	// from its reference check. ok=false for a bd that is not enabled.
+	SIDForBD(bdID uint16) (string, bool)
 }
 
 type NetworkResourceServer struct {
@@ -95,23 +99,28 @@ func (s *NetworkResourceServer) BridgeDelete(
 			ifindex = resolved
 		}
 
-		// Disable EVPN RT2 auto-advertise first: it withdraws the bridge domain's
-		// RT2s and releases its End.DT2U SID. That SID references this bridge's
-		// ifindex, so findBridgeReference below would otherwise report the bridge
-		// as still referenced and block the delete (and DisableBD would never run).
-		// On a ResourceManager cache miss (e.g. after a restart) bdID is 0 here,
-		// so recover it from the installed L2 SID's aux to still disable cleanly.
+		// The EVPN auto-advertise End.DT2U SID for this bd is lifecycle-tied to the
+		// bridge: it is released by DisableBD as part of this delete, so exclude it
+		// from the reference check below (otherwise it would always report the
+		// bridge as referenced and block the delete). On a ResourceManager cache
+		// miss (e.g. after a restart) bdID is 0, so recover it from the installed
+		// L2 SID's aux. DisableBD itself runs only AFTER the bridge is actually
+		// deleted, so a failed reference check or DeleteBridge leaves EVPN
+		// auto-advertise intact rather than tearing it down for a surviving bridge.
 		if s.evpn != nil && bdID == 0 && ifindex != 0 {
 			if bd, ok := s.bdIDForBridge(ifindex); ok {
 				bdID = bd
 			}
 		}
+		var selfSID string
 		if s.evpn != nil && bdID != 0 {
-			s.evpn.DisableBD(bdID)
+			if sid, ok := s.evpn.SIDForBD(bdID); ok {
+				selfSID = sid
+			}
 		}
 
 		if ifindex != 0 {
-			ref, err := s.findBridgeReference(ifindex)
+			ref, err := s.findBridgeReference(ifindex, selfSID)
 			if err != nil {
 				resp.Errors = append(resp.Errors, &v1.OperationError{
 					TriggerPrefix: name,
@@ -135,6 +144,13 @@ func (s *NetworkResourceServer) BridgeDelete(
 				Reason:        err.Error(),
 			})
 			continue
+		}
+
+		// The bridge is gone; now release the EVPN auto-advertise SID and withdraw
+		// its RT2s. Doing it here (not earlier) keeps EVPN intact if the delete
+		// above failed.
+		if s.evpn != nil && bdID != 0 {
+			s.evpn.DisableBD(bdID)
 		}
 
 		resp.DeletedNames = append(resp.DeletedNames, name)
@@ -286,14 +302,20 @@ func (s *NetworkResourceServer) bdIDForBridge(ifindex uint32) (uint16, bool) {
 	return 0, false
 }
 
-// findBridgeReference checks if any End.DT2/DT2M SID entry references the given bridge_ifindex.
-// Bridge ifindex is stored in the aux map (L2 variant).
-func (s *NetworkResourceServer) findBridgeReference(ifindex uint32) (string, error) {
+// findBridgeReference checks if any End.DT2/DT2M SID entry references the given
+// bridge_ifindex, returning the first such SID prefix. The exclude prefix (the
+// EVPN auto-advertise SID for this bridge, which the delete itself releases) is
+// skipped so it does not block the delete. Bridge ifindex is stored in the aux
+// map (L2 variant).
+func (s *NetworkResourceServer) findBridgeReference(ifindex uint32, exclude string) (string, error) {
 	entries, err := s.mapOps.ListSidFunctions()
 	if err != nil {
 		return "", fmt.Errorf("list SID functions: %w", err)
 	}
 	for prefix, entry := range entries {
+		if exclude != "" && prefix == exclude {
+			continue
+		}
 		switch v1.Srv6LocalAction(entry.Action) {
 		case v1.Srv6LocalAction_SRV6_LOCAL_ACTION_END_DT2,
 			v1.Srv6LocalAction_SRV6_LOCAL_ACTION_END_DT2M:

--- a/pkg/server/network_resource.go
+++ b/pkg/server/network_resource.go
@@ -95,6 +95,14 @@ func (s *NetworkResourceServer) BridgeDelete(
 			ifindex = resolved
 		}
 
+		// Disable EVPN RT2 auto-advertise first: it withdraws the bridge domain's
+		// RT2s and releases its End.DT2U SID. That SID references this bridge's
+		// ifindex, so findBridgeReference below would otherwise report the bridge
+		// as still referenced and block the delete (and DisableBD would never run).
+		if s.evpn != nil && bdID != 0 {
+			s.evpn.DisableBD(bdID)
+		}
+
 		if ifindex != 0 {
 			ref, err := s.findBridgeReference(ifindex)
 			if err != nil {
@@ -112,12 +120,6 @@ func (s *NetworkResourceServer) BridgeDelete(
 				continue
 			}
 			s.fdbWatcher.UnregisterBridge(int(ifindex))
-		}
-
-		// Disable EVPN RT2 auto-advertise for the bridge domain before deleting:
-		// withdraws its RT2s and releases the End.DT2U SID.
-		if s.evpn != nil && bdID != 0 {
-			s.evpn.DisableBD(bdID)
 		}
 
 		if err := s.resMgr.DeleteBridge(name); err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -34,6 +34,7 @@ type Server struct {
 	mupAdv       bgp.MUPController
 	srPolicyCtrl srPolicyController
 	vrfExporter  VrfExporter                // runtime auto-advertise hook; nil when off
+	evpnBridge   EvpnBridgeHook             // EVPN RT2 auto-advertise BD hook; nil when off
 	esReElectDF  func(esi [bpf.ESILen]byte) // applier DF re-election; nil when BGP is off
 	logger       *zap.Logger
 	mux          *http.ServeMux
@@ -50,7 +51,7 @@ type Server struct {
 // enabled, or nil otherwise. Taking the concrete type (not the interface)
 // keeps a typed-nil from leaking into srPolicyCtrl, so the FailedPrecondition
 // guard in SrPolicyServer works.
-func NewServer(cfg *config.Config, mapOps *bpf.MapOperations, resMgr *netresource.ResourceManager, fdbWatcher *netlinkwatch.FDBWatcher, locatorMgr *locator.Manager, vrfBgpMgr *vrfbgp.Manager, advertiser bgp.RouteAdvertiser, srPolicyAdv bgp.SRPolicyController, evpnAdv bgp.EVPNController, mupAdv bgp.MUPController, srPolicyApplier *apply.Applier, vrfExporter VrfExporter, logger *zap.Logger) *Server {
+func NewServer(cfg *config.Config, mapOps *bpf.MapOperations, resMgr *netresource.ResourceManager, fdbWatcher *netlinkwatch.FDBWatcher, locatorMgr *locator.Manager, vrfBgpMgr *vrfbgp.Manager, advertiser bgp.RouteAdvertiser, srPolicyAdv bgp.SRPolicyController, evpnAdv bgp.EVPNController, mupAdv bgp.MUPController, srPolicyApplier *apply.Applier, vrfExporter VrfExporter, evpnBridge EvpnBridgeHook, logger *zap.Logger) *Server {
 	s := &Server{
 		cfg:         cfg,
 		mapOps:      mapOps,
@@ -63,6 +64,7 @@ func NewServer(cfg *config.Config, mapOps *bpf.MapOperations, resMgr *netresourc
 		evpnAdv:     evpnAdv,
 		mupAdv:      mupAdv,
 		vrfExporter: vrfExporter,
+		evpnBridge:  evpnBridge,
 		logger:      logger,
 		mux:         http.NewServeMux(),
 	}
@@ -161,7 +163,7 @@ func (s *Server) Setup() {
 	s.logger.Info("Registered EthernetSegmentService", zap.String("path", path))
 
 	// NetworkResource service (VRF/Bridge management)
-	netResourceServer := NewNetworkResourceServer(s.resMgr, s.fdbWatcher, s.mapOps)
+	netResourceServer := NewNetworkResourceServer(s.resMgr, s.fdbWatcher, s.mapOps, s.vrfBgpMgr, s.evpnBridge, s.logger)
 	path, handler = vinberov1connect.NewNetworkResourceServiceHandler(netResourceServer)
 	s.mux.Handle(path, handler)
 	s.logger.Info("Registered NetworkResourceService", zap.String("path", path))

--- a/pkg/vrfbgp/manager.go
+++ b/pkg/vrfbgp/manager.go
@@ -83,6 +83,23 @@ func (m *Manager) Get(vrfName string) (Binding, bool) {
 	return b, ok
 }
 
+// GetByBDID returns the binding whose BDID matches bdID, for the EVPN
+// auto-advertise path to resolve a bridge domain back to its binding. bdID 0
+// (L3VPN-only bindings) never matches.
+func (m *Manager) GetByBDID(bdID uint16) (Binding, bool) {
+	if bdID == 0 {
+		return Binding{}, false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, b := range m.bindings {
+		if b.BDID == bdID {
+			return b, true
+		}
+	}
+	return Binding{}, false
+}
+
 // List returns a snapshot of every binding.
 func (m *Manager) List() []Binding {
 	m.mu.RLock()

--- a/pkg/vrfbgp/manager.go
+++ b/pkg/vrfbgp/manager.go
@@ -85,19 +85,27 @@ func (m *Manager) Get(vrfName string) (Binding, bool) {
 
 // GetByBDID returns the binding whose BDID matches bdID, for the EVPN
 // auto-advertise path to resolve a bridge domain back to its binding. bdID 0
-// (L3VPN-only bindings) never matches.
+// (L3VPN-only bindings) never matches. If more than one binding claims the same
+// bd_id it is ambiguous, so ok=false: refusing to guess is safer than
+// originating RT2 with a map-iteration-order-dependent VRF/RD/RT.
 func (m *Manager) GetByBDID(bdID uint16) (Binding, bool) {
 	if bdID == 0 {
 		return Binding{}, false
 	}
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+	var found Binding
+	n := 0
 	for _, b := range m.bindings {
 		if b.BDID == bdID {
-			return b, true
+			found = b
+			n++
 		}
 	}
-	return Binding{}, false
+	if n != 1 {
+		return Binding{}, false
+	}
+	return found, true
 }
 
 // List returns a snapshot of every binding.

--- a/pkg/vrfbgp/manager_test.go
+++ b/pkg/vrfbgp/manager_test.go
@@ -84,6 +84,14 @@ func TestManager_GetByBDID(t *testing.T) {
 	if _, ok := m.GetByBDID(0); ok {
 		t.Error("GetByBDID(0) must never match an L3VPN-only binding")
 	}
+	// Two bindings claiming the same bd_id is ambiguous: GetByBDID must refuse
+	// rather than return a map-order-dependent result.
+	if err := m.Bind(Binding{VRFName: "evi100-dup", RD: "65000:101", BDID: 100}); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	if _, ok := m.GetByBDID(100); ok {
+		t.Error("GetByBDID(100) must be ambiguous (ok=false) when two bindings share the bd_id")
+	}
 }
 
 func TestManager_MatchImport(t *testing.T) {

--- a/pkg/vrfbgp/manager_test.go
+++ b/pkg/vrfbgp/manager_test.go
@@ -66,6 +66,26 @@ func TestManager_BindReplaces(t *testing.T) {
 	}
 }
 
+func TestManager_GetByBDID(t *testing.T) {
+	m := NewManager()
+	if err := m.Bind(Binding{VRFName: "evi100", RD: "65000:100", BDID: 100}); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	if err := m.Bind(Binding{VRFName: "l3vrf", RD: "65000:1"}); err != nil { // BDID 0
+		t.Fatalf("Bind: %v", err)
+	}
+	b, ok := m.GetByBDID(100)
+	if !ok || b.VRFName != "evi100" {
+		t.Errorf("GetByBDID(100) = %+v, %v; want the evi100 binding", b, ok)
+	}
+	if _, ok := m.GetByBDID(200); ok {
+		t.Error("GetByBDID(200) should miss when no binding has that bd_id")
+	}
+	if _, ok := m.GetByBDID(0); ok {
+		t.Error("GetByBDID(0) must never match an L3VPN-only binding")
+	}
+}
+
 func TestManager_MatchImport(t *testing.T) {
 	m := NewManager()
 	if err := m.Bind(Binding{VRFName: "vrf-a", ImportRTs: []string{"65000:100", "65000:101"}}); err != nil {


### PR DESCRIPTION
## 概要

auto-advertise を EVPN に横展開する第一弾。local の bridge で学習した MAC を、operator の明示 RPC 無しで EVPN RT2 (MAC/IP) として自動 advertise する。L3VPN auto-advertise (PR #48 / #49) の EVPN 版で、`bgp.global.evpn_auto_advertise` で opt-in する。control plane の `EVPNController` は実装済みのため、本 PR は local state を trigger に Push を自動で呼ぶ engine と配線を足す。

## 変更点

- `pkg/netlinkwatch.FDBWatcher` に `MACSink` を追加。kernel bridge FDB の local MAC 変化を sink に転送する。kernel FDB は local MAC のみ (受信側の remote MAC は bpf fdb_map に IsRemote=1 で入り kernel FDB には入らない) なので、ここから RT2 を出しても loop しない。mapOps を narrow interface 化して live BPF 無しで test 可能にした
- `pkg/bgp/export.EVPNExporter`。MACSink として `OnLocalMAC` で RT2 を組み立て `PushEVPNMac`。BD ごとに binding の default_locator から End.DT2U SID を mint (action End.DT2 + `NewSidAuxL2`)、L3VPN の DT4/DT6 払い出しと対称。nexthop は loopback (locator base ではない、同じ理由)、RemoteSrc は locator base、EthernetTag 0、ESI 0 (single-home)
- 配線。`bgp.global.evpn_auto_advertise` で opt-in。BD の enable/disable を `BridgeCreate` / `BridgeDelete` に hook し、bd_id から binding を引いて `EnableBD` / `DisableBD`。graceful shutdown で RT2 を withdraw し SID を解放
- `vrfbgp.Manager.GetByBDID` (bd_id → binding 逆引き) を追加
- `NewServer` / `NetworkResourceServer` に `EvpnBridgeHook` を typed-nil-safe で配線 (server→export 依存を避ける `VrfExporter` と同じ interface 方針)

## テスト

- `go build ./...` / `go vet ./...` 通過
- `go test -race ./pkg/bgp/export/... ./pkg/server/... ./pkg/vrfbgp/...` 通過。FDBWatcher sink (3)、EVPNExporter (9)、GetByBDID を追加。fake advertiser / SidOps / sink で検証
- pre-commit golangci-lint 0 issues
- netlink/eBPF を伴う FDB dump や containerlab E2E は sudo/Docker 必須のためローカル unit 範囲外

## /simplify 実施

cleanup レビューを 4 観点で回し、hot path の `mac.String()` / `sid.String()` の重複計算を OnLocalMAC で一度だけに集約。SID install/release の L3VPN exporter との共通化や locator base helper の抽出は、just-merged の L3VPN exporter を触るため別 PR の cleanup とした (両 exporter は意図的に parallel)。

## スコープと既知の制約 (後続)

本 PR は EVPN RT2 のみ。

- 起動時に既に学習済みの MAC は取りこぼす。FDBWatcher の ListExisting replay 後に sink を set するため。`RouteWatcher.DumpTable` と対称な FDB dump seam を enable 時に呼ぶのが後続の修正
- enable の trigger が bridge device 側のみ。bridge 作成後に `VrfBgpBind` で EVPN binding を足しても `EnableBD` は走らない (L3VPN の binding 駆動と非対称)。後続で binding 側からも駆動して両軸にする
- RT2 に MaxPrefixes admission cap が無い (L3VPN にはある)
- RT3 (BUM, End.DT2M) と RT4 (ES) は未実装

設計の全体像と family ごとの feasibility は docs/dev/bgp_auto_advertise_multifamily.md を参照 (SR Policy は CRUD hook、MUP は local 定義機構が無く後回し)。