### PR TITLE
feat(bgp): replay a bridge's existing FDB on enable for EVPN RT2

### DIFF
--- a/pkg/netlinkwatch/fdb_macsink_test.go
+++ b/pkg/netlinkwatch/fdb_macsink_test.go
@@ -126,3 +126,36 @@ func TestFDBWatcherNilSinkStillSyncsBPF(t *testing.T) {
 		t.Errorf("BPF sync must still run with a nil sink, got %+v", ops.created)
 	}
 }
+
+func TestIsUnicastMAC(t *testing.T) {
+	cases := []struct {
+		name string
+		mac  net.HardwareAddr
+		want bool
+	}{
+		{"unicast", net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01}, true},
+		{"multicast", net.HardwareAddr{0x01, 0x00, 0x5e, 0, 0, 1}, false},
+		{"broadcast", net.HardwareAddr{0xff, 0xff, 0xff, 0xff, 0xff, 0xff}, false},
+		{"too short", net.HardwareAddr{0xaa, 0xbb, 0xcc}, false},
+		{"nil", nil, false},
+	}
+	for _, c := range cases {
+		if got := isUnicastMAC(c.mac); got != c.want {
+			t.Errorf("isUnicastMAC(%v) = %v, want %v", c.mac, got, c.want)
+		}
+	}
+}
+
+func TestDumpBridgeUnregisteredReturnsError(t *testing.T) {
+	w, _ := newSinkTestWatcher(&fakeMACSink{})
+	if err := w.DumpBridge(99); err == nil { // only ifindex 10 is registered
+		t.Error("DumpBridge of an unregistered bridge should return an error")
+	}
+}
+
+func TestDumpBridgeNilSinkIsNoop(t *testing.T) {
+	w, _ := newSinkTestWatcher(nil) // registers bridge ifindex 10, no sink
+	if err := w.DumpBridge(10); err != nil {
+		t.Errorf("DumpBridge with no sink must be a no-op, got %v", err)
+	}
+}

--- a/pkg/netlinkwatch/fdb_watcher.go
+++ b/pkg/netlinkwatch/fdb_watcher.go
@@ -2,6 +2,7 @@ package netlinkwatch
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"sync"
 	"time"
@@ -165,12 +166,7 @@ func (w *FDBWatcher) handleNeighUpdate(update netlink.NeighUpdate) {
 	}
 
 	mac := neigh.HardwareAddr
-	if mac == nil || len(mac) != 6 {
-		return
-	}
-
-	// Skip broadcast/multicast MACs
-	if mac[0]&0x01 != 0 {
+	if !isUnicastMAC(mac) {
 		return
 	}
 
@@ -208,6 +204,46 @@ func (w *FDBWatcher) notifyMAC(sink MACSink, bdID uint16, mac net.HardwareAddr, 
 		return
 	}
 	sink.OnLocalMAC(bdID, append(net.HardwareAddr(nil), mac...), added)
+}
+
+// isUnicastMAC reports whether mac is a 6-byte unicast address (the only FDB
+// entries the watcher forwards: broadcast/multicast are skipped).
+func isUnicastMAC(mac net.HardwareAddr) bool {
+	return len(mac) == 6 && mac[0]&0x01 == 0
+}
+
+// DumpBridge replays a registered bridge's existing kernel FDB to the MAC sink
+// as adds, for EVPN RT2 auto-advertise. The boot-time ListExisting replay in
+// Start only reaches the sink if it was set before Start; a bridge registered
+// later (or whose sink is wired after Start) needs this to pick up MACs already
+// learned. It does not touch the BPF fdb_map (Start's sync already covers that);
+// it only feeds the sink, which dedups, so a replay is idempotent. A no-op when
+// no sink is set.
+func (w *FDBWatcher) DumpBridge(ifindex int) error {
+	w.mu.RLock()
+	bdID, ok := w.allowed[ifindex]
+	sink := w.macSink
+	w.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("bridge ifindex %d is not registered", ifindex)
+	}
+	if sink == nil {
+		return nil
+	}
+	// NeighList(0, AF_BRIDGE) lists every bridge FDB entry; filter by MasterIndex
+	// to this bridge, mirroring the live handleNeighUpdate path.
+	neighs, err := netlink.NeighList(0, unix.AF_BRIDGE)
+	if err != nil {
+		return fmt.Errorf("list bridge FDB: %w", err)
+	}
+	for i := range neighs {
+		n := &neighs[i]
+		if n.MasterIndex != ifindex || !isUnicastMAC(n.HardwareAddr) {
+			continue
+		}
+		sink.OnLocalMAC(bdID, append(net.HardwareAddr(nil), n.HardwareAddr...), true)
+	}
+	return nil
 }
 
 // Stop stops the FDB watcher and waits for cleanup

--- a/pkg/netlinkwatch/fdb_watcher.go
+++ b/pkg/netlinkwatch/fdb_watcher.go
@@ -172,19 +172,7 @@ func (w *FDBWatcher) handleNeighUpdate(update netlink.NeighUpdate) {
 
 	switch update.Type {
 	case unix.RTM_NEWNEIGH:
-		entry := &bpf.FdbEntry{
-			Oif: uint32(neigh.LinkIndex),
-		}
-		if err := w.mapOps.CreateFdb(bdID, net.HardwareAddr(mac), entry); err != nil {
-			w.logger.Debug("Failed to sync FDB entry to BPF map",
-				zap.String("mac", mac.String()),
-				zap.Uint16("bd_id", bdID),
-				zap.Error(err))
-			// The dataplane FDB was not installed; do not advertise RT2 for a MAC
-			// the data plane cannot decap to, or remote traffic would blackhole.
-			return
-		}
-		w.notifyMAC(sink, bdID, mac, true)
+		w.syncAndNotify(sink, bdID, mac, neigh.LinkIndex)
 
 	case unix.RTM_DELNEIGH:
 		if err := w.mapOps.DeleteFdb(bdID, net.HardwareAddr(mac)); err != nil {
@@ -195,6 +183,23 @@ func (w *FDBWatcher) handleNeighUpdate(update netlink.NeighUpdate) {
 		}
 		w.notifyMAC(sink, bdID, mac, false)
 	}
+}
+
+// syncAndNotify installs a locally-learned MAC into the BPF fdb_map and, only on
+// success, forwards it to the EVPN auto-advertise sink as an add. Gating the
+// sink on the data-plane write means RT2 is never advertised for a MAC the data
+// plane cannot decap to (which would blackhole remote traffic). Shared by the
+// live update path (handleNeighUpdate) and the replay path (DumpBridge), so the
+// two cannot drift on this safety rule. The caller has already filtered to a
+// registered bridge and a unicast MAC.
+func (w *FDBWatcher) syncAndNotify(sink MACSink, bdID uint16, mac net.HardwareAddr, linkIndex int) {
+	entry := &bpf.FdbEntry{Oif: uint32(linkIndex)}
+	if err := w.mapOps.CreateFdb(bdID, mac, entry); err != nil {
+		w.logger.Debug("Failed to sync FDB entry to BPF map",
+			zap.String("mac", mac.String()), zap.Uint16("bd_id", bdID), zap.Error(err))
+		return
+	}
+	w.notifyMAC(sink, bdID, mac, true)
 }
 
 // notifyMAC forwards a local MAC change to the EVPN auto-advertise sink, if one
@@ -212,13 +217,14 @@ func isUnicastMAC(mac net.HardwareAddr) bool {
 	return len(mac) == 6 && mac[0]&0x01 == 0
 }
 
-// DumpBridge replays a registered bridge's existing kernel FDB to the MAC sink
-// as adds, for EVPN RT2 auto-advertise. The boot-time ListExisting replay in
-// Start only reaches the sink if it was set before Start; a bridge registered
-// later (or whose sink is wired after Start) needs this to pick up MACs already
-// learned. It does not touch the BPF fdb_map (Start's sync already covers that);
-// it only feeds the sink, which dedups, so a replay is idempotent. A no-op when
-// no sink is set.
+// DumpBridge replays a registered bridge's existing kernel FDB through the same
+// sync-then-advertise path as a live add, for EVPN RT2 auto-advertise. The
+// boot-time ListExisting replay in Start only reaches the sink if it was set
+// before Start; a bridge registered later (or whose sink is wired after Start)
+// needs this to pick up MACs already learned. Each MAC is re-synced into the BPF
+// fdb_map (idempotent, and a backstop for a failed Start-time Put) and advertised
+// only on success; the sink dedups, so a replay is idempotent. A no-op when no
+// sink is set.
 func (w *FDBWatcher) DumpBridge(ifindex int) error {
 	w.mu.RLock()
 	bdID, ok := w.allowed[ifindex]
@@ -241,7 +247,10 @@ func (w *FDBWatcher) DumpBridge(ifindex int) error {
 		if n.MasterIndex != ifindex || !isUnicastMAC(n.HardwareAddr) {
 			continue
 		}
-		sink.OnLocalMAC(bdID, append(net.HardwareAddr(nil), n.HardwareAddr...), true)
+		// Same path as a live add: re-sync the BPF fdb_map (idempotent for entries
+		// already present, and a backstop if a Start-time Put had failed) and only
+		// then advertise RT2, so a MAC missing from the data plane is not advertised.
+		w.syncAndNotify(sink, bdID, n.HardwareAddr, n.LinkIndex)
 	}
 	return nil
 }

--- a/pkg/server/network_resource.go
+++ b/pkg/server/network_resource.go
@@ -69,6 +69,12 @@ func (s *NetworkResourceServer) BridgeCreate(
 				if err := s.evpn.EnableBD(b, ifindex); err != nil {
 					s.logger.Warn("enable EVPN auto-advertise for bridge",
 						zap.String("bridge", br.Name), zap.Uint32("bd_id", br.BdId), zap.Error(err))
+				} else if err := s.fdbWatcher.DumpBridge(int(ifindex)); err != nil {
+					// Replay MACs already in the bridge's FDB (e.g. a pre-existing
+					// bridge) so they advertise as RT2. Non-fatal: live events still
+					// cover anything learned after this.
+					s.logger.Warn("replay bridge FDB for EVPN RT2 auto-advertise",
+						zap.String("bridge", br.Name), zap.Uint32("bd_id", br.BdId), zap.Error(err))
 				}
 			}
 		}


### PR DESCRIPTION
## 概要

EVPN RT2 auto-advertise の起動時 MAC 取りこぼしを塞ぐ。FDBWatcher の MAC sink は Start の後に配線されるため、kernel FDB に既にある MAC (例: 既存 bridge を後から BridgeCreate で登録) が RT2 にならなかった。PR #52 (RT4) に stack。

## 変更点

- `FDBWatcher.DumpBridge(ifindex)`: bridge の kernel FDB を `NeighList(0, AF_BRIDGE)` + MasterIndex フィルタ (live path と同じ) で列挙し、各 unicast MAC を sink に add として replay する。sink のみ駆動 (BPF fdb_map は Start の同期で既にカバー)、sink は dedup するので replay は idempotent。未登録 bridge はエラー、sink 未設定なら no-op
- `BridgeCreate` が EnableBD 成功後に DumpBridge を呼ぶ (非 fatal)
- `isUnicastMAC` を抽出し handleNeighUpdate と DumpBridge で共有
- テスト: isUnicastMAC、DumpBridge の未登録エラー / nil-sink no-op。完全な netlink dump は sudo 範囲 (RouteWatcher.DumpTable と同様)

## テスト

build/vet/`-race`/golangci-lint すべて green。

## 後続

binding 駆動 enable の両軸化 (VrfBgpBind からも EVPN を enable)、RT2 の MaxPrefixes cap は別 increment。