### PR TITLE
feat(bgp): EVPN RT3 (Inclusive Multicast / BUM) auto-advertise

### DIFF
--- a/pkg/bgp/export/evpn.go
+++ b/pkg/bgp/export/evpn.go
@@ -310,10 +310,15 @@ func (e *EVPNExporter) installL2SID(locatorName string, bdID uint16, bridgeIfind
 }
 
 // removeL2SID deletes an L2 endpoint SID and returns its function to the pool.
-// Best-effort: a delete failure is logged, not propagated. The caller holds e.mu.
+// The caller holds e.mu. On a delete failure the SID is NOT released: the
+// sid_function_map entry may still be present, and releasing the SID would let a
+// later AllocateSID hand out the same SID, whose CreateSidFunction would then hit
+// an owner conflict on the stuck entry. Leaking the SID is the safer outcome.
 func (e *EVPNExporter) removeL2SID(sid netip.Addr) {
 	if err := e.sidOps.DeleteSidFunction(sid.String()+"/128", bpf.OwnerBuiltin); err != nil {
-		e.logger.Warn("delete L2 endpoint SID", zap.String("sid", sid.String()), zap.Error(err))
+		e.logger.Warn("delete L2 endpoint SID; keeping it allocated to avoid reuse",
+			zap.String("sid", sid.String()), zap.Error(err))
+		return
 	}
 	e.locators.ReleaseSID(sid)
 }

--- a/pkg/bgp/export/evpn.go
+++ b/pkg/bgp/export/evpn.go
@@ -184,8 +184,8 @@ func (e *EVPNExporter) EnableBD(b vrfbgp.Binding, bridgeIfindex uint32) error {
 	return nil
 }
 
-// DisableBD withdraws every RT2 advertised for the bridge domain and releases
-// its End.DT2U SID. A no-op for an unknown BD.
+// DisableBD withdraws the bridge domain's RT3 and every advertised RT2, and
+// releases its End.DT2U and End.DT2M SIDs. A no-op for an unknown BD.
 func (e *EVPNExporter) DisableBD(bdID uint16) {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/pkg/bgp/export/evpn.go
+++ b/pkg/bgp/export/evpn.go
@@ -16,35 +16,46 @@ import (
 	"github.com/takehaya/vinbero/pkg/vrfbgp"
 )
 
-// endpointActionDT2U is the local action for a bridge domain's unicast L2 decap
-// endpoint (End.DT2, FDB lookup). It is the EVPN RT2 service SID a remote PE
-// targets to reach a local MAC. End.DT2M (BUM flood, RT3) is a separate action.
-const endpointActionDT2U = uint8(v1.Srv6LocalAction_SRV6_LOCAL_ACTION_END_DT2)
+// endpointActionDT2U / endpointActionDT2M are the L2 bridge-domain endpoint
+// actions: End.DT2 (FDB lookup) is the RT2 unicast service SID a remote PE
+// targets to reach a local MAC; End.DT2M (BUM flood) is the RT3 service SID a
+// remote PE targets to flood BUM traffic toward this node.
+const (
+	endpointActionDT2U = uint8(v1.Srv6LocalAction_SRV6_LOCAL_ACTION_END_DT2)
+	endpointActionDT2M = uint8(v1.Srv6LocalAction_SRV6_LOCAL_ACTION_END_DT2M)
+)
 
 // EVPNAdvertiser is the subset of bgp.EVPNController the EVPN exporter drives:
-// the RT2 (MAC/IP) advertise direction. RT3/RT4 are future increments.
+// RT2 (MAC/IP) for local MACs and RT3 (Inclusive Multicast) for the bridge
+// domain's BUM flood endpoint. RT4 (Ethernet Segment) is a future increment.
 type EVPNAdvertiser interface {
 	PushEVPNMac(ctx context.Context, r bgp.EVPNRoute) error
 	WithdrawEVPNMac(ctx context.Context, key bgp.EVPNMACKey) error
+	PushEVPNInclusiveMulticast(ctx context.Context, r bgp.EVPNRoute) error
+	WithdrawEVPNInclusiveMulticast(ctx context.Context, key bgp.EVPNMcastKey) error
 }
 
 // bdState is the per-bridge-domain EVPN export bookkeeping: the binding, the
-// minted End.DT2U service SID, its locator base (the RX reverse-map key carried
-// as RemoteSrc), and the set of locally-learned MACs currently advertised.
+// minted End.DT2U (RT2 unicast) and End.DT2M (RT3 BUM flood) service SIDs, the
+// locator base (the RX reverse-map key carried as RemoteSrc), whether RT3 is
+// advertised, and the set of locally-learned MACs currently advertised as RT2.
 type bdState struct {
-	binding    vrfbgp.Binding
-	sid        netip.Addr
-	sidStr     string // sid.String(), rendered once (it is constant per BD)
-	remoteSrc  string
-	advertised map[bgp.EVPNMACKey]struct{}
+	binding       vrfbgp.Binding
+	sid           netip.Addr // End.DT2U (RT2 unicast)
+	sidStr        string     // sid.String(), rendered once (constant per BD)
+	dt2mSID       netip.Addr // End.DT2M (RT3 BUM flood)
+	dt2mSIDStr    string
+	remoteSrc     string
+	rt3Advertised bool
+	advertised    map[bgp.EVPNMACKey]struct{}
 }
 
-// EVPNExporter turns locally-learned bridge MACs into EVPN RT2 (MAC/IP)
-// advertisements, the EVPN counterpart of the L3VPN Exporter. It is a
-// netlinkwatch.MACSink: the FDBWatcher delivers local MAC changes to OnLocalMAC.
-// EnableBD mints and installs the bridge domain's End.DT2U service SID from the
-// binding's default locator (symmetric with the L3VPN Exporter's DT4/DT6), so an
-// operator only binds the BD and every RT2 follows automatically.
+// EVPNExporter turns local bridge-domain state into EVPN advertisements, the
+// EVPN counterpart of the L3VPN Exporter. EnableBD mints the bridge domain's
+// End.DT2U (RT2 unicast) and End.DT2M (RT3 BUM flood) service SIDs from the
+// binding's default locator (symmetric with the L3VPN Exporter's DT4/DT6) and
+// advertises RT3; locally-learned MACs then advertise as RT2 through OnLocalMAC
+// (the netlinkwatch.MACSink the FDBWatcher feeds). An operator only binds the BD.
 //
 // Only locally-learned MACs reach this exporter: the EVPN receive path installs
 // remote MACs into the BPF fdb_map with IsRemote=1, never into the kernel bridge
@@ -61,9 +72,9 @@ type EVPNExporter struct {
 	bds     map[uint16]*bdState
 }
 
-// NewEVPNExporter wires an EVPN RT2 exporter. nextHop is the advertising PE's
-// reachable IPv6 address (its loopback); the caller resolves a bridge domain to
-// its binding and passes it to EnableBD.
+// NewEVPNExporter wires an EVPN exporter (RT2 + RT3). nextHop is the advertising
+// PE's reachable IPv6 address (its loopback); the caller resolves a bridge domain
+// to its binding and passes it to EnableBD.
 func NewEVPNExporter(evpn EVPNAdvertiser, sidOps SidOps, locators *locator.Manager, nextHop string, logger *zap.Logger) *EVPNExporter {
 	return &EVPNExporter{
 		evpn:     evpn,
@@ -93,10 +104,11 @@ func checkNextHop(nextHop string) error {
 	return nil
 }
 
-// EnableBD makes a bridge domain's locally-learned MACs eligible for RT2
-// auto-advertise: it mints an End.DT2U service SID from the binding's default
-// locator and installs it into sid_function_map keyed to the bridge, so a remote
-// PE can decap unicast toward this node. bridgeIfindex is the BD's Linux bridge
+// EnableBD makes a bridge domain eligible for EVPN auto-advertise: it mints the
+// End.DT2U (RT2 unicast) and End.DT2M (RT3 BUM flood) service SIDs from the
+// binding's default locator, installs them into sid_function_map keyed to the
+// bridge, and advertises RT3 so remote PEs flood BUM toward this node; local MACs
+// then advertise as RT2 via OnLocalMAC. bridgeIfindex is the BD's Linux bridge
 // device, needed for the L2 aux entry. A binding with a zero BDID, or without an
 // RD or a default locator, is rejected. It is idempotent: a BD already enabled
 // is replaced.
@@ -124,20 +136,47 @@ func (e *EVPNExporter) EnableBD(b vrfbgp.Binding, bridgeIfindex uint32) error {
 	// Replace any existing enablement so a re-enable updates cleanly.
 	e.disableBDLocked(b.BDID)
 
-	sid, err := e.installDT2U(b.DefaultLocator, b.BDID, bridgeIfindex)
+	dt2uSID, err := e.installL2SID(b.DefaultLocator, b.BDID, bridgeIfindex, endpointActionDT2U)
 	if err != nil {
 		return fmt.Errorf("vrf %q: install End.DT2U SID: %w", b.VRFName, err)
 	}
-	e.bds[b.BDID] = &bdState{
+	dt2mSID, err := e.installL2SID(b.DefaultLocator, b.BDID, bridgeIfindex, endpointActionDT2M)
+	if err != nil {
+		// Roll the DT2U SID back so a half-enabled BD leaves no orphan.
+		e.removeL2SID(dt2uSID)
+		return fmt.Errorf("vrf %q: install End.DT2M SID: %w", b.VRFName, err)
+	}
+	st := &bdState{
 		binding:    b,
-		sid:        sid,
-		sidStr:     sid.String(),
+		sid:        dt2uSID,
+		sidStr:     dt2uSID.String(),
+		dt2mSID:    dt2mSID,
+		dt2mSIDStr: dt2mSID.String(),
 		remoteSrc:  remoteSrc,
 		advertised: make(map[bgp.EVPNMACKey]struct{}),
 	}
-	e.logger.Info("bridge domain enabled for EVPN RT2 auto advertise",
-		zap.String("vrf", b.VRFName), zap.Uint16("bd_id", b.BDID),
-		zap.String("rd", b.RD), zap.String("dt2u_sid", sid.String()))
+	e.bds[b.BDID] = st
+	// Advertise RT3 (Inclusive Multicast) so remote PEs flood BUM traffic toward
+	// this node's End.DT2M. A failure is non-fatal: RT2 unicast still works, so
+	// log it and leave the BD enabled rather than failing the whole bridge.
+	r3 := bgp.EVPNRoute{
+		Type:        bgp.EVPNRouteTypeInclusiveMulticast,
+		RD:          b.RD,
+		RTs:         b.ExportRTs,
+		EthernetTag: 0,
+		SRv6SID:     st.dt2mSIDStr,
+		NextHop:     e.nextHop,
+		RemoteSrc:   remoteSrc,
+	}
+	if err := e.evpn.PushEVPNInclusiveMulticast(context.Background(), r3); err != nil {
+		e.logger.Error("advertise RT3 inclusive multicast",
+			zap.String("vrf", b.VRFName), zap.Uint16("bd_id", b.BDID), zap.Error(err))
+	} else {
+		st.rt3Advertised = true
+	}
+	e.logger.Info("bridge domain enabled for EVPN auto advertise",
+		zap.String("vrf", b.VRFName), zap.Uint16("bd_id", b.BDID), zap.String("rd", b.RD),
+		zap.String("dt2u_sid", dt2uSID.String()), zap.String("dt2m_sid", dt2mSID.String()))
 	return nil
 }
 
@@ -149,23 +188,23 @@ func (e *EVPNExporter) DisableBD(bdID uint16) {
 	e.disableBDLocked(bdID)
 }
 
-// SIDForBD returns the End.DT2U SID (as a "<addr>/128" sid_function_map key) the
-// exporter installed for the bridge domain, so BridgeDelete can exclude this
-// lifecycle-owned SID from its bridge-reference check. ok=false for a BD the
-// exporter has not enabled.
-func (e *EVPNExporter) SIDForBD(bdID uint16) (string, bool) {
+// SIDsForBD returns the sid_function_map keys ("<addr>/128") of the End.DT2U and
+// End.DT2M SIDs the exporter installed for the bridge domain, so BridgeDelete can
+// exclude these lifecycle-owned SIDs from its bridge-reference check. nil for a
+// BD the exporter has not enabled.
+func (e *EVPNExporter) SIDsForBD(bdID uint16) []string {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	st, ok := e.bds[bdID]
 	if !ok {
-		return "", false
+		return nil
 	}
-	return st.sidStr + "/128", true
+	return []string{st.sidStr + "/128", st.dt2mSIDStr + "/128"}
 }
 
-// Close disables every enabled bridge domain, withdrawing its RT2s and releasing
-// its End.DT2U SIDs. It is the graceful-shutdown counterpart of EnableBD; the
-// BGP session teardown is the backstop, but this withdraws explicitly first.
+// Close disables every enabled bridge domain, withdrawing its RT2s/RT3 and
+// releasing its End.DT2U/DT2M SIDs. It is the graceful-shutdown counterpart of
+// EnableBD; the BGP session teardown is the backstop, but this withdraws first.
 func (e *EVPNExporter) Close() {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -174,12 +213,18 @@ func (e *EVPNExporter) Close() {
 	}
 }
 
-// disableBDLocked withdraws the BD's advertised RT2s, releases its SID, and
-// drops the state. The caller holds e.mu.
+// disableBDLocked withdraws the BD's RT3 and advertised RT2s, releases its
+// End.DT2U/DT2M SIDs, and drops the state. The caller holds e.mu.
 func (e *EVPNExporter) disableBDLocked(bdID uint16) {
 	st, ok := e.bds[bdID]
 	if !ok {
 		return
+	}
+	if st.rt3Advertised {
+		if err := e.evpn.WithdrawEVPNInclusiveMulticast(context.Background(),
+			bgp.EVPNMcastKey{RD: st.binding.RD, EthernetTag: 0}); err != nil {
+			e.logger.Warn("withdraw RT3 on disable", zap.Uint16("bd_id", bdID), zap.Error(err))
+		}
 	}
 	for key := range st.advertised {
 		if err := e.evpn.WithdrawEVPNMac(context.Background(), key); err != nil {
@@ -187,9 +232,10 @@ func (e *EVPNExporter) disableBDLocked(bdID uint16) {
 				zap.Uint16("bd_id", bdID), zap.String("mac", key.MAC), zap.Error(err))
 		}
 	}
-	e.removeDT2U(st.sid)
+	e.removeL2SID(st.sid)
+	e.removeL2SID(st.dt2mSID)
 	delete(e.bds, bdID)
-	e.logger.Info("bridge domain disabled for EVPN RT2 auto advertise", zap.Uint16("bd_id", bdID))
+	e.logger.Info("bridge domain disabled for EVPN auto advertise", zap.Uint16("bd_id", bdID))
 }
 
 // OnLocalMAC is the netlinkwatch.MACSink callback: a MAC learned (added=true) or
@@ -245,15 +291,16 @@ func (e *EVPNExporter) OnLocalMAC(bdID uint16, mac net.HardwareAddr, added bool)
 	delete(st.advertised, key)
 }
 
-// installDT2U mints a function from locatorName, builds the End.DT2U SID, and
-// installs it into sid_function_map as an l2 bridge-domain endpoint owned by
-// Vinbero. On failure the function is returned to the pool. The caller holds e.mu.
-func (e *EVPNExporter) installDT2U(locatorName string, bdID uint16, bridgeIfindex uint32) (netip.Addr, error) {
+// installL2SID mints a function from locatorName and installs an L2 bridge-domain
+// endpoint SID for the given action (End.DT2U for RT2, End.DT2M for RT3) into
+// sid_function_map, owned by Vinbero. On failure the function is returned to the
+// pool. The caller holds e.mu.
+func (e *EVPNExporter) installL2SID(locatorName string, bdID uint16, bridgeIfindex uint32, action uint8) (netip.Addr, error) {
 	sid, _, err := e.locators.AllocateSID(locatorName, nil)
 	if err != nil {
 		return netip.Addr{}, err
 	}
-	entry := &bpf.SidFunctionEntry{Action: endpointActionDT2U}
+	entry := &bpf.SidFunctionEntry{Action: action}
 	aux := bpf.NewSidAuxL2(bdID, bridgeIfindex)
 	if err := e.sidOps.CreateSidFunction(sid.String()+"/128", entry, aux, bpf.OwnerBuiltin); err != nil {
 		e.locators.ReleaseSID(sid)
@@ -262,11 +309,11 @@ func (e *EVPNExporter) installDT2U(locatorName string, bdID uint16, bridgeIfinde
 	return sid, nil
 }
 
-// removeDT2U deletes the End.DT2U SID and returns its function to the pool.
+// removeL2SID deletes an L2 endpoint SID and returns its function to the pool.
 // Best-effort: a delete failure is logged, not propagated. The caller holds e.mu.
-func (e *EVPNExporter) removeDT2U(sid netip.Addr) {
+func (e *EVPNExporter) removeL2SID(sid netip.Addr) {
 	if err := e.sidOps.DeleteSidFunction(sid.String()+"/128", bpf.OwnerBuiltin); err != nil {
-		e.logger.Warn("delete End.DT2U SID", zap.String("sid", sid.String()), zap.Error(err))
+		e.logger.Warn("delete L2 endpoint SID", zap.String("sid", sid.String()), zap.Error(err))
 	}
 	e.locators.ReleaseSID(sid)
 }

--- a/pkg/bgp/export/evpn.go
+++ b/pkg/bgp/export/evpn.go
@@ -176,7 +176,7 @@ func (e *EVPNExporter) EnableBD(b vrfbgp.Binding, bridgeIfindex uint32) error {
 	}
 	e.logger.Info("bridge domain enabled for EVPN auto advertise",
 		zap.String("vrf", b.VRFName), zap.Uint16("bd_id", b.BDID), zap.String("rd", b.RD),
-		zap.String("dt2u_sid", dt2uSID.String()), zap.String("dt2m_sid", dt2mSID.String()))
+		zap.String("dt2u_sid", st.sidStr), zap.String("dt2m_sid", st.dt2mSIDStr))
 	return nil
 }
 

--- a/pkg/bgp/export/evpn.go
+++ b/pkg/bgp/export/evpn.go
@@ -142,8 +142,12 @@ func (e *EVPNExporter) EnableBD(b vrfbgp.Binding, bridgeIfindex uint32) error {
 	}
 	dt2mSID, err := e.installL2SID(b.DefaultLocator, b.BDID, bridgeIfindex, endpointActionDT2M)
 	if err != nil {
-		// Roll the DT2U SID back so a half-enabled BD leaves no orphan.
-		e.removeL2SID(dt2uSID)
+		// Roll the DT2U SID back so a half-enabled BD leaves no orphan. If the
+		// rollback delete itself fails, surface it: the DT2U SID is then stranded
+		// in sid_function_map and would block a later BridgeDelete reference check.
+		if rbErr := e.removeL2SID(dt2uSID); rbErr != nil {
+			return fmt.Errorf("vrf %q: install End.DT2M SID: %w; rolling back the End.DT2U SID failed (%v): it may be stranded in sid_function_map", b.VRFName, err, rbErr)
+		}
 		return fmt.Errorf("vrf %q: install End.DT2M SID: %w", b.VRFName, err)
 	}
 	st := &bdState{
@@ -232,8 +236,9 @@ func (e *EVPNExporter) disableBDLocked(bdID uint16) {
 				zap.Uint16("bd_id", bdID), zap.String("mac", key.MAC), zap.Error(err))
 		}
 	}
-	e.removeL2SID(st.sid)
-	e.removeL2SID(st.dt2mSID)
+	// Teardown is best-effort; removeL2SID logs a delete failure internally.
+	_ = e.removeL2SID(st.sid)
+	_ = e.removeL2SID(st.dt2mSID)
 	delete(e.bds, bdID)
 	e.logger.Info("bridge domain disabled for EVPN auto advertise", zap.Uint16("bd_id", bdID))
 }
@@ -309,16 +314,18 @@ func (e *EVPNExporter) installL2SID(locatorName string, bdID uint16, bridgeIfind
 	return sid, nil
 }
 
-// removeL2SID deletes an L2 endpoint SID and returns its function to the pool.
-// The caller holds e.mu. On a delete failure the SID is NOT released: the
+// removeL2SID deletes an L2 endpoint SID and returns its function to the pool,
+// returning the delete error so a caller doing a rollback can surface a stranded
+// SID. The caller holds e.mu. On a delete failure the SID is NOT released: the
 // sid_function_map entry may still be present, and releasing the SID would let a
 // later AllocateSID hand out the same SID, whose CreateSidFunction would then hit
 // an owner conflict on the stuck entry. Leaking the SID is the safer outcome.
-func (e *EVPNExporter) removeL2SID(sid netip.Addr) {
+func (e *EVPNExporter) removeL2SID(sid netip.Addr) error {
 	if err := e.sidOps.DeleteSidFunction(sid.String()+"/128", bpf.OwnerBuiltin); err != nil {
 		e.logger.Warn("delete L2 endpoint SID; keeping it allocated to avoid reuse",
 			zap.String("sid", sid.String()), zap.Error(err))
-		return
+		return err
 	}
 	e.locators.ReleaseSID(sid)
+	return nil
 }

--- a/pkg/bgp/export/evpn_test.go
+++ b/pkg/bgp/export/evpn_test.go
@@ -17,7 +17,7 @@ import (
 // fakeEVPNAdv records RT2 (MAC/IP) and RT3 (Inclusive Multicast) advertise /
 // withdraw calls.
 type fakeEVPNAdv struct {
-	pushed    []bgp.EVPNRoute
+	pushed         []bgp.EVPNRoute
 	withdrawn      []bgp.EVPNMACKey
 	pushedMcast    []bgp.EVPNRoute
 	withdrawnMcast []bgp.EVPNMcastKey

--- a/pkg/bgp/export/evpn_test.go
+++ b/pkg/bgp/export/evpn_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"net/netip"
+	"strings"
 	"testing"
 
 	"go.uber.org/zap"
@@ -133,6 +134,19 @@ func TestEnableBDRollsBackDT2UWhenDT2MFails(t *testing.T) {
 	sid.failOnCall = 0
 	if err := e.EnableBD(evpnTestBinding(), 10); err != nil {
 		t.Fatalf("re-enable after rollback: %v", err)
+	}
+}
+
+func TestEnableBDRollbackFailureSurfacesStrandedSID(t *testing.T) {
+	e, _, sid := newTestEVPNExporter(t)
+	sid.failOnCall = 2                       // DT2M install fails
+	sid.deleteErr = errors.New("map locked") // the DT2U rollback delete also fails
+	err := e.EnableBD(evpnTestBinding(), 10)
+	if err == nil {
+		t.Fatal("EnableBD should fail when both the DT2M install and the DT2U rollback fail")
+	}
+	if !strings.Contains(err.Error(), "stranded") {
+		t.Errorf("error should surface the stranded DT2U SID, got: %v", err)
 	}
 }
 

--- a/pkg/bgp/export/evpn_test.go
+++ b/pkg/bgp/export/evpn_test.go
@@ -14,7 +14,8 @@ import (
 	"github.com/takehaya/vinbero/pkg/vrfbgp"
 )
 
-// fakeEVPNAdv records RT2 advertise / withdraw calls.
+// fakeEVPNAdv records RT2 (MAC/IP) and RT3 (Inclusive Multicast) advertise /
+// withdraw calls.
 type fakeEVPNAdv struct {
 	pushed    []bgp.EVPNRoute
 	withdrawn      []bgp.EVPNMACKey

--- a/pkg/bgp/export/evpn_test.go
+++ b/pkg/bgp/export/evpn_test.go
@@ -17,8 +17,10 @@ import (
 // fakeEVPNAdv records RT2 advertise / withdraw calls.
 type fakeEVPNAdv struct {
 	pushed    []bgp.EVPNRoute
-	withdrawn []bgp.EVPNMACKey
-	pushErr   error
+	withdrawn      []bgp.EVPNMACKey
+	pushedMcast    []bgp.EVPNRoute
+	withdrawnMcast []bgp.EVPNMcastKey
+	pushErr        error
 }
 
 func (f *fakeEVPNAdv) PushEVPNMac(_ context.Context, r bgp.EVPNRoute) error {
@@ -31,6 +33,19 @@ func (f *fakeEVPNAdv) PushEVPNMac(_ context.Context, r bgp.EVPNRoute) error {
 
 func (f *fakeEVPNAdv) WithdrawEVPNMac(_ context.Context, key bgp.EVPNMACKey) error {
 	f.withdrawn = append(f.withdrawn, key)
+	return nil
+}
+
+func (f *fakeEVPNAdv) PushEVPNInclusiveMulticast(_ context.Context, r bgp.EVPNRoute) error {
+	if f.pushErr != nil {
+		return f.pushErr
+	}
+	f.pushedMcast = append(f.pushedMcast, r)
+	return nil
+}
+
+func (f *fakeEVPNAdv) WithdrawEVPNInclusiveMulticast(_ context.Context, key bgp.EVPNMcastKey) error {
+	f.withdrawnMcast = append(f.withdrawnMcast, key)
 	return nil
 }
 
@@ -66,16 +81,57 @@ func evpnTestBinding() vrfbgp.Binding {
 	}
 }
 
-func TestEnableBDInstallsDT2U(t *testing.T) {
-	e, _, sid := newTestEVPNExporter(t)
+func TestEnableBDInstallsBothL2SIDs(t *testing.T) {
+	e, adv, sid := newTestEVPNExporter(t)
 	if err := e.EnableBD(evpnTestBinding(), 10); err != nil {
 		t.Fatalf("EnableBD: %v", err)
 	}
-	if len(sid.created) != 1 {
-		t.Fatalf("want 1 End.DT2U SID installed, got %d: %+v", len(sid.created), sid.created)
+	if len(sid.created) != 2 {
+		t.Fatalf("want 2 L2 SIDs installed (DT2U + DT2M), got %d: %+v", len(sid.created), sid.created)
 	}
-	if sid.created[0].action != endpointActionDT2U {
-		t.Errorf("installed SID action = %d, want End.DT2U %d", sid.created[0].action, endpointActionDT2U)
+	if _, ok := sidForAction(sid.created, endpointActionDT2U); !ok {
+		t.Errorf("no End.DT2U SID installed: %+v", sid.created)
+	}
+	if _, ok := sidForAction(sid.created, endpointActionDT2M); !ok {
+		t.Errorf("no End.DT2M SID installed: %+v", sid.created)
+	}
+	// RT3 (Inclusive Multicast) is advertised once at enable, carrying the DT2M SID.
+	if len(adv.pushedMcast) != 1 {
+		t.Fatalf("want 1 RT3 advertised at enable, got %d", len(adv.pushedMcast))
+	}
+	r3 := adv.pushedMcast[0]
+	if r3.Type != bgp.EVPNRouteTypeInclusiveMulticast {
+		t.Errorf("type = %d, want RT3 inclusive multicast", r3.Type)
+	}
+	dt2m, _ := sidForAction(sid.created, endpointActionDT2M)
+	if r3.SRv6SID+"/128" != dt2m {
+		t.Errorf("RT3 SID = %q, want the installed End.DT2M %q", r3.SRv6SID, dt2m)
+	}
+	if r3.RD != "65000:100" || r3.NextHop != "2001:db8:ff::1" || r3.RemoteSrc != "fd00:1:1::" {
+		t.Errorf("RT3 fields wrong: %+v", r3)
+	}
+}
+
+func TestEnableBDRollsBackDT2UWhenDT2MFails(t *testing.T) {
+	e, _, sid := newTestEVPNExporter(t)
+	// DT2U installs (call 1), DT2M (call 2) fails -> the DT2U rollback path runs.
+	sid.failOnCall = 2
+	if err := e.EnableBD(evpnTestBinding(), 10); err == nil {
+		t.Fatal("EnableBD should fail when the End.DT2M SID install fails")
+	}
+	if len(sid.created) != 1 {
+		t.Fatalf("want only the DT2U SID created before the failure, got %d", len(sid.created))
+	}
+	if len(sid.deleted) != 1 {
+		t.Fatalf("want the DT2U SID rolled back, got %d deletes", len(sid.deleted))
+	}
+	if sid.created[0].prefix != sid.deleted[0] {
+		t.Errorf("rolled-back SID %q != installed DT2U %q", sid.deleted[0], sid.created[0].prefix)
+	}
+	// Re-enable must work (the DT2U function was returned to the pool).
+	sid.failOnCall = 0
+	if err := e.EnableBD(evpnTestBinding(), 10); err != nil {
+		t.Fatalf("re-enable after rollback: %v", err)
 	}
 }
 
@@ -115,21 +171,30 @@ func TestEnableBDRejectsMissingFields(t *testing.T) {
 	}
 }
 
-func TestSIDForBD(t *testing.T) {
-	e, _, sid := newTestEVPNExporter(t)
-	if _, ok := e.SIDForBD(100); ok {
-		t.Error("SIDForBD must miss before the BD is enabled")
+func TestSIDsForBD(t *testing.T) {
+	e, _, _ := newTestEVPNExporter(t)
+	if got := e.SIDsForBD(100); got != nil {
+		t.Errorf("SIDsForBD must be nil before the BD is enabled, got %v", got)
 	}
 	if err := e.EnableBD(evpnTestBinding(), 10); err != nil {
 		t.Fatalf("EnableBD: %v", err)
 	}
-	got, ok := e.SIDForBD(100)
-	if !ok || got != sid.created[0].prefix {
-		t.Errorf("SIDForBD(100) = %q,%v; want the installed End.DT2U key %q", got, ok, sid.created[0].prefix)
+	got := e.SIDsForBD(100)
+	if len(got) != 2 {
+		t.Fatalf("SIDsForBD(100) should return both the DT2U and DT2M keys, got %v", got)
+	}
+	// Both must be valid "<addr>/128" sid_function_map keys and distinct.
+	if got[0] == got[1] {
+		t.Errorf("the DT2U and DT2M keys must differ, got %v", got)
+	}
+	for _, k := range got {
+		if _, _, err := net.ParseCIDR(k); err != nil {
+			t.Errorf("SID key %q is not a valid prefix: %v", k, err)
+		}
 	}
 	e.DisableBD(100)
-	if _, ok := e.SIDForBD(100); ok {
-		t.Error("SIDForBD must miss after the BD is disabled")
+	if got := e.SIDsForBD(100); got != nil {
+		t.Errorf("SIDsForBD must be nil after the BD is disabled, got %v", got)
 	}
 }
 
@@ -163,8 +228,9 @@ func TestOnLocalMACAdvertisesRT2(t *testing.T) {
 	if r.RemoteSrc != "fd00:1:1::" {
 		t.Errorf("remote_src = %q, want the locator base fd00:1:1::", r.RemoteSrc)
 	}
-	if r.SRv6SID+"/128" != sid.created[0].prefix {
-		t.Errorf("SID = %q, want the installed End.DT2U %q", r.SRv6SID, sid.created[0].prefix)
+	dt2u, _ := sidForAction(sid.created, endpointActionDT2U)
+	if r.SRv6SID+"/128" != dt2u {
+		t.Errorf("SID = %q, want the installed End.DT2U %q", r.SRv6SID, dt2u)
 	}
 }
 
@@ -231,8 +297,11 @@ func TestDisableBDWithdrawsAllAndReleases(t *testing.T) {
 	if len(adv.withdrawn) != 2 {
 		t.Errorf("want 2 RT2 withdrawn on disable, got %d", len(adv.withdrawn))
 	}
-	if len(sid.deleted) != 1 {
-		t.Errorf("want the End.DT2U SID released on disable, got %d", len(sid.deleted))
+	if len(adv.withdrawnMcast) != 1 {
+		t.Errorf("want the RT3 withdrawn on disable, got %d", len(adv.withdrawnMcast))
+	}
+	if len(sid.deleted) != 2 {
+		t.Errorf("want both L2 SIDs (DT2U + DT2M) released on disable, got %d", len(sid.deleted))
 	}
 	// The BD is gone, so re-enabling must succeed.
 	if err := e.EnableBD(evpnTestBinding(), 10); err != nil {

--- a/pkg/bgp/export/exporter_test.go
+++ b/pkg/bgp/export/exporter_test.go
@@ -54,7 +54,8 @@ type sidCreate struct {
 type fakeSidOps struct {
 	created    []sidCreate
 	deleted    []string
-	failOnCall int // 0 = never; N = fail the Nth CreateSidFunction call
+	failOnCall int   // 0 = never; N = fail the Nth CreateSidFunction call
+	deleteErr  error // when set, DeleteSidFunction fails (e.g. to test rollback)
 	calls      int
 }
 
@@ -68,6 +69,9 @@ func (f *fakeSidOps) CreateSidFunction(triggerPrefix string, entry *bpf.SidFunct
 }
 
 func (f *fakeSidOps) DeleteSidFunction(triggerPrefix string, _ bpf.OwnerTag) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
 	f.deleted = append(f.deleted, triggerPrefix)
 	return nil
 }

--- a/pkg/server/network_resource.go
+++ b/pkg/server/network_resource.go
@@ -100,10 +100,11 @@ func (s *NetworkResourceServer) BridgeDelete(
 			ifindex = resolved
 		}
 
-		// The EVPN auto-advertise End.DT2U SID for this bd is lifecycle-tied to the
-		// bridge: it is released by DisableBD as part of this delete, so exclude it
-		// from the reference check below (otherwise it would always report the
-		// bridge as referenced and block the delete). On a ResourceManager cache
+		// The EVPN auto-advertise SIDs for this bd (End.DT2U for RT2, End.DT2M for
+		// RT3) are lifecycle-tied to the bridge: they are released by DisableBD as
+		// part of this delete, so exclude them (selfSIDs) from the reference check
+		// below (otherwise they would always report the bridge as referenced and
+		// block the delete). On a ResourceManager cache
 		// miss (e.g. after a restart) bdID is 0, so recover it from the installed
 		// L2 SID's aux. DisableBD itself runs only AFTER the bridge is actually
 		// deleted, so a failed reference check or DeleteBridge leaves EVPN

--- a/pkg/server/network_resource.go
+++ b/pkg/server/network_resource.go
@@ -19,10 +19,10 @@ import (
 type EvpnBridgeHook interface {
 	EnableBD(b vrfbgp.Binding, bridgeIfindex uint32) error
 	DisableBD(bdID uint16)
-	// SIDForBD returns the End.DT2U SID (a sid_function_map key) the exporter
-	// installed for the bd, so BridgeDelete can exclude this lifecycle-owned SID
-	// from its reference check. ok=false for a bd that is not enabled.
-	SIDForBD(bdID uint16) (string, bool)
+	// SIDsForBD returns the sid_function_map keys the exporter installed for the
+	// bd (End.DT2U + End.DT2M), so BridgeDelete can exclude these lifecycle-owned
+	// SIDs from its reference check. nil for a bd that is not enabled.
+	SIDsForBD(bdID uint16) []string
 }
 
 type NetworkResourceServer struct {
@@ -112,15 +112,13 @@ func (s *NetworkResourceServer) BridgeDelete(
 				bdID = bd
 			}
 		}
-		var selfSID string
+		var selfSIDs []string
 		if s.evpn != nil && bdID != 0 {
-			if sid, ok := s.evpn.SIDForBD(bdID); ok {
-				selfSID = sid
-			}
+			selfSIDs = s.evpn.SIDsForBD(bdID)
 		}
 
 		if ifindex != 0 {
-			ref, err := s.findBridgeReference(ifindex, selfSID)
+			ref, err := s.findBridgeReference(ifindex, selfSIDs)
 			if err != nil {
 				resp.Errors = append(resp.Errors, &v1.OperationError{
 					TriggerPrefix: name,
@@ -303,17 +301,21 @@ func (s *NetworkResourceServer) bdIDForBridge(ifindex uint32) (uint16, bool) {
 }
 
 // findBridgeReference checks if any End.DT2/DT2M SID entry references the given
-// bridge_ifindex, returning the first such SID prefix. The exclude prefix (the
-// EVPN auto-advertise SID for this bridge, which the delete itself releases) is
-// skipped so it does not block the delete. Bridge ifindex is stored in the aux
+// bridge_ifindex, returning the first such SID prefix. The exclude prefixes (the
+// EVPN auto-advertise SIDs for this bridge, which the delete itself releases) are
+// skipped so they do not block the delete. Bridge ifindex is stored in the aux
 // map (L2 variant).
-func (s *NetworkResourceServer) findBridgeReference(ifindex uint32, exclude string) (string, error) {
+func (s *NetworkResourceServer) findBridgeReference(ifindex uint32, exclude []string) (string, error) {
+	excluded := make(map[string]struct{}, len(exclude))
+	for _, e := range exclude {
+		excluded[e] = struct{}{}
+	}
 	entries, err := s.mapOps.ListSidFunctions()
 	if err != nil {
 		return "", fmt.Errorf("list SID functions: %w", err)
 	}
 	for prefix, entry := range entries {
-		if exclude != "" && prefix == exclude {
+		if _, skip := excluded[prefix]; skip {
 			continue
 		}
 		switch v1.Srv6LocalAction(entry.Action) {

--- a/pkg/server/network_resource.go
+++ b/pkg/server/network_resource.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"connectrpc.com/connect"
 	v1 "github.com/takehaya/vinbero/api/vinbero/v1"
@@ -13,9 +14,9 @@ import (
 	"go.uber.org/zap"
 )
 
-// EvpnBridgeHook enables or disables EVPN RT2 auto-advertise for a bridge domain
-// as its bridge is created or deleted. *pkg/bgp/export.EVPNExporter satisfies
-// it; it is nil unless EVPN auto-advertise is on.
+// EvpnBridgeHook enables or disables EVPN auto-advertise (RT2 + RT3) for a bridge
+// domain as its bridge is created or deleted. *pkg/bgp/export.EVPNExporter
+// satisfies it; it is nil unless EVPN auto-advertise is on.
 type EvpnBridgeHook interface {
 	EnableBD(b vrfbgp.Binding, bridgeIfindex uint32) error
 	DisableBD(bdID uint16)
@@ -60,13 +61,13 @@ func (s *NetworkResourceServer) BridgeCreate(
 		// Register with FDB watcher for dynamic MAC learning
 		s.fdbWatcher.RegisterBridge(int(ifindex), uint16(br.BdId))
 
-		// If EVPN auto-advertise is on and this bd_id has a binding, enable RT2
-		// auto-advertise for the bridge. A failure here is non-fatal: the bridge
-		// is created regardless, it just won't auto-originate RT2.
+		// If EVPN auto-advertise is on and this bd_id has a binding, enable
+		// auto-advertise (RT2 + RT3) for the bridge. A failure here is non-fatal:
+		// the bridge is created regardless, it just won't auto-originate.
 		if s.evpn != nil {
 			if b, ok := s.mgr.GetByBDID(uint16(br.BdId)); ok {
 				if err := s.evpn.EnableBD(b, ifindex); err != nil {
-					s.logger.Warn("enable EVPN RT2 auto-advertise for bridge",
+					s.logger.Warn("enable EVPN auto-advertise for bridge",
 						zap.String("bridge", br.Name), zap.Uint32("bd_id", br.BdId), zap.Error(err))
 				}
 			}
@@ -306,16 +307,12 @@ func (s *NetworkResourceServer) bdIDForBridge(ifindex uint32) (uint16, bool) {
 // skipped so they do not block the delete. Bridge ifindex is stored in the aux
 // map (L2 variant).
 func (s *NetworkResourceServer) findBridgeReference(ifindex uint32, exclude []string) (string, error) {
-	excluded := make(map[string]struct{}, len(exclude))
-	for _, e := range exclude {
-		excluded[e] = struct{}{}
-	}
 	entries, err := s.mapOps.ListSidFunctions()
 	if err != nil {
 		return "", fmt.Errorf("list SID functions: %w", err)
 	}
 	for prefix, entry := range entries {
-		if _, skip := excluded[prefix]; skip {
+		if slices.Contains(exclude, prefix) {
 			continue
 		}
 		switch v1.Srv6LocalAction(entry.Action) {


### PR DESCRIPTION
EVPN auto-advertise を RT3 (Inclusive Multicast) に拡張。#50 (RT2) merge 後の rebase により base を main に。元 PR #51 は #50 のブランチ削除で自動 close されたため再作成。内容は #51 と同一 (RT3 の 6 commits)。EnableBD が BD ごとに End.DT2M も mint し RT3 を advertise、DisableBD で withdraw。Copilot 収束済み・CI green。