### PR TITLE
feat(bgp): EVPN auto-advertise binding-axis + exporter hardening

### DIFF
--- a/cmd/vinberod/main.go
+++ b/cmd/vinberod/main.go
@@ -140,8 +140,9 @@ func run(cliCtx *cli.Context) error {
 	// exporter / routeWatcher drive the auto-advertise path (VRF export).
 	// They stay nil unless BGP is enabled with bgp.global.auto_advertise.
 	var exporter *export.Exporter
-	// evpnExporter drives EVPN RT2 auto-advertise (local MAC -> RT2). nil unless
-	// BGP is enabled with bgp.global.evpn_auto_advertise.
+	// evpnExporter drives EVPN auto-advertise: RT2 (local bridge MAC), RT3 (BUM
+	// flood for a bound bridge domain), and RT4 (local Ethernet Segment). nil
+	// unless BGP is enabled with bgp.global.evpn_auto_advertise.
 	var evpnExporter *export.EVPNExporter
 	if cliCtx.Bool("bgp-enabled") {
 		// Load config-time VRF <-> route-target bindings before the BGP
@@ -202,10 +203,11 @@ func run(cliCtx *cli.Context) error {
 				lg,
 			)
 		}
-		// EVPN RT2 auto-advertise (local MAC -> RT2) is opt-in via
+		// EVPN auto-advertise (RT2/RT3/RT4) is opt-in via
 		// bgp.global.evpn_auto_advertise. It shares the locator manager, VRF
-		// bindings, and BGP advertiser; the FDBWatcher feeds it local MACs and
-		// BridgeCreate/BridgeDelete enable/disable each bound bridge domain.
+		// bindings, and BGP advertiser; the FDBWatcher feeds it local MACs and both
+		// the bridge-device (BridgeCreate/Delete) and binding (VrfBgpBind/Unbind)
+		// lifecycles enable/disable each bound bridge domain.
 		if cfg.BGP.Global.EVPNAutoAdvertise {
 			evpnExporter = export.NewEVPNExporter(
 				bgpSession,
@@ -223,16 +225,23 @@ func run(cliCtx *cli.Context) error {
 	if exporter != nil {
 		vrfExp = exporter
 	}
-	// evpnExporter implements server.EvpnBridgeHook (RT2/RT3) and
-	// server.EvpnEsHook (RT4); same typed-nil avoidance so the handlers' nil
-	// checks hold when EVPN auto-advertise is off.
-	var evpnBridge server.EvpnBridgeHook
+	// The EVPN coordinator drives RT2/RT3 across both the bridge-device axis
+	// (BridgeCreate/Delete) and the binding axis (VrfBgpBind/Unbind), resolving a
+	// bridge domain to its bridge ifindex and replaying its FDB on enable. evpnES
+	// is the RT4 (Ethernet Segment) hook. Both stay nil unless EVPN auto-advertise
+	// is on, so the handlers' nil checks hold.
+	var evpnCoord *server.EvpnCoordinator
 	var evpnES server.EvpnEsHook
 	if evpnExporter != nil {
-		evpnBridge = evpnExporter
+		evpnCoord = server.NewEvpnCoordinator(
+			evpnExporter,
+			vin.GetResourceManager().BridgeIfindexByBDID,
+			vin.GetFDBWatcher().DumpBridge,
+			lg,
+		)
 		evpnES = evpnExporter
 	}
-	srv := server.NewServer(cfg, vin.GetMapOperations(), vin.GetResourceManager(), vin.GetFDBWatcher(), locatorMgr, vrfBgpMgr, advertiser, srPolicyAdvertiser, evpnAdvertiser, mupAdvertiser, applier, vrfExp, evpnBridge, evpnES, lg)
+	srv := server.NewServer(cfg, vin.GetMapOperations(), vin.GetResourceManager(), vin.GetFDBWatcher(), locatorMgr, vrfBgpMgr, advertiser, srPolicyAdvertiser, evpnAdvertiser, mupAdvertiser, applier, vrfExp, evpnCoord, evpnES, lg)
 
 	if bgpSession != nil {
 		// Registered before the Start attempt so a partial failure
@@ -277,13 +286,21 @@ func run(cliCtx *cli.Context) error {
 		// EVPN exporter. The sink is set here, after the FDBWatcher has already
 		// started (StartFDBWatcher, above), so MACs present at that boot
 		// ListExisting replay are NOT captured; a MAC learned after a BridgeCreate
-		// enables its bridge domain is. Replaying a bridge's existing FDB on enable
-		// (an FDB dump seam symmetric with RouteWatcher.DumpTable) is a follow-up.
-		// Close (withdraw RT2s + release SIDs) runs before the BGP session drops,
-		// like exporter.Stop above.
+		// enables its bridge domain is. BridgeCreate / VrfBgpBind replay a bridge's
+		// existing FDB via the coordinator, so a bridge that predates the bind is
+		// still picked up.
 		if evpnExporter != nil {
 			vin.GetFDBWatcher().SetMACSink(evpnExporter)
-			defer evpnExporter.Close()
+			// Teardown ordering: detach the sink BEFORE Close so an in-flight FDB
+			// event cannot re-advertise a MAC after Close has withdrawn it. Close
+			// also empties the BD table, so any OnLocalMAC that still races in is a
+			// no-op (unknown BD); the detach makes that the common case rather than
+			// relying on it. Close (withdraw RT2s/RT3 + release SIDs) runs before the
+			// BGP session drops, like exporter.Stop above (LIFO defers).
+			defer func() {
+				vin.GetFDBWatcher().SetMACSink(nil)
+				evpnExporter.Close()
+			}()
 		}
 	}
 

--- a/docs/loadmap.md
+++ b/docs/loadmap.md
@@ -103,5 +103,5 @@ status.
 | VRF <-> route-target binding | Supported | Import-RT filter for received VPN routes               | RFC 9252 |
 | SR Policy (SAFI 73)        | Supported | Color-based steering (control + data plane)              | RFC 9256 |
 | BGP MUP (SAFI 85)          | Supported | MUP route exchange (ISD/DSD/T1ST/T2ST, IPv4/IPv6) + apply: GTP4/GTP6 downlink H.Encaps + uplink F-TEID (H.M.GTP4.D_TEID / H.M.GTP6.D_TEID) | draft-mpmz-bess-mup-safi |
-| Automatic advertise        | Partial   | VRF-export driven (config-time bindings and runtime VrfBgpBind RPC): connected/static prefixes auto-advertised as VPNv4/v6. EVPN / SR Policy / MUP auto-advertise deferred | RFC 9252 |
+| Automatic advertise        | Partial   | VRF-export driven (config-time bindings and runtime VrfBgpBind RPC): connected/static prefixes auto-advertised as VPNv4/v6, and EVPN RT2/RT3 (local bridge MAC/BUM) and RT4 (local Ethernet Segment) driven by the bridge-device and binding lifecycles. SR Policy / MUP auto-advertise deferred | RFC 9252 / 7432 |
 | EVPN (RT2/3/4)             | Supported | L2VPN over BGP EVPN: RT2 MAC/IP, RT3 Inclusive Multicast, RT4 Ethernet Segment + RFC 8584 DF election / Local-Bias split-horizon (multi-homing). IRB (RT2 L3) and RT5 not yet supported | RFC 9252 / 7432 / 8584 |

--- a/pkg/bgp/export/evpn.go
+++ b/pkg/bgp/export/evpn.go
@@ -50,6 +50,9 @@ type bdState struct {
 	remoteSrc     string
 	rt3Advertised bool
 	advertised    map[bgp.EVPNMACKey]struct{}
+	// atLimit is set once the BD crosses into the MaxPrefixes-capped state, so the
+	// cap-reached warning fires once per crossing rather than per flooded MAC.
+	atLimit bool
 }
 
 // EVPNExporter turns local bridge-domain state into EVPN advertisements, the
@@ -78,7 +81,8 @@ type EVPNExporter struct {
 	es map[[bpf.ESILen]byte]string
 }
 
-// NewEVPNExporter wires an EVPN exporter (RT2 + RT3). nextHop is the advertising
+// NewEVPNExporter wires an EVPN exporter (RT2 + RT3 per bridge domain, RT4 per
+// Ethernet Segment). nextHop is the advertising
 // PE's reachable IPv6 address (its loopback); the caller resolves a bridge domain
 // to its binding and passes it to EnableBD.
 func NewEVPNExporter(evpn EVPNAdvertiser, sidOps SidOps, locators *locator.Manager, nextHop string, logger *zap.Logger) *EVPNExporter {
@@ -111,7 +115,7 @@ func (e *EVPNExporter) EnableES(esi [bpf.ESILen]byte, rd string) error {
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	e.disableESLocked(esi) // replace any existing advertisement
+	prevRD, hadPrev := e.es[esi]
 	r := bgp.EVPNRoute{
 		Type:       bgp.EVPNRouteTypeEthernetSegment,
 		RD:         rd,
@@ -119,8 +123,22 @@ func (e *EVPNExporter) EnableES(esi [bpf.ESILen]byte, rd string) error {
 		ESImportRT: esImportRT,
 		NextHop:    e.nextHop,
 	}
+	// Push the new RT4 FIRST. gobgp AddPath supersedes a same-NLRI path, so for an
+	// unchanged RD this replaces the prior advertisement in place; for a changed RD
+	// the old NLRI survives and is withdrawn below. Pushing first means a push
+	// failure returns with the prior advertisement still intact rather than having
+	// withdrawn it for a replacement that never landed.
 	if err := e.evpn.PushEVPNEthernetSegment(context.Background(), r); err != nil {
 		return fmt.Errorf("advertise RT4 for esi %s: %w", bpf.FormatESI(esi), err)
+	}
+	if hadPrev && prevRD != rd {
+		// The RD changed, so the new push created a different NLRI (RD+ESI) and did
+		// not supersede the old one; withdraw it explicitly. Non-fatal: the new RT4
+		// is already up.
+		if err := e.evpn.WithdrawEVPNEthernetSegment(context.Background(), bgp.EVPNESKey{RD: prevRD, ESI: esi}); err != nil {
+			e.logger.Warn("withdraw superseded RT4 after RD change",
+				zap.String("esi", bpf.FormatESI(esi)), zap.String("old_rd", prevRD), zap.Error(err))
+		}
 	}
 	e.es[esi] = rd
 	e.logger.Info("ethernet segment enabled for EVPN RT4 auto advertise",
@@ -135,6 +153,17 @@ func (e *EVPNExporter) DisableES(esi [bpf.ESILen]byte) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.disableESLocked(esi)
+}
+
+// RDForESI returns the route distinguisher the ES's RT4 is currently advertised
+// with, so EsList can echo the operator-supplied RD that lives only in this
+// control-plane state (the BPF esi_map carries no RD). ok=false for an ES that
+// is not auto-advertised.
+func (e *EVPNExporter) RDForESI(esi [bpf.ESILen]byte) (string, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	rd, ok := e.es[esi]
+	return rd, ok
 }
 
 // disableESLocked withdraws the ES's RT4 and drops its state. The caller holds e.mu.
@@ -326,6 +355,20 @@ func (e *EVPNExporter) OnLocalMAC(bdID uint16, mac net.HardwareAddr, added bool)
 		if _, dup := st.advertised[key]; dup {
 			return
 		}
+		if st.binding.MaxPrefixes > 0 && uint32(len(st.advertised)) >= st.binding.MaxPrefixes {
+			// Per-BD MAC cap reached: stop originating RT2 so a local-MAC flood into
+			// a bound bridge cannot amplify into unbounded off-box advertisements
+			// (the same blast-radius bound the L3VPN path applies). Which MACs land
+			// under the cap follows FDB event/dump order, not a deterministic
+			// selection. Warn once per crossing so the flood does not also flood the
+			// log; atLimit clears when a withdraw frees headroom.
+			if !st.atLimit {
+				e.logger.Warn("bridge domain MAC limit reached; capping EVPN RT2 auto-advertise",
+					zap.Uint16("bd_id", bdID), zap.Uint32("max", st.binding.MaxPrefixes))
+				st.atLimit = true
+			}
+			return
+		}
 		r := bgp.EVPNRoute{
 			Type: bgp.EVPNRouteTypeMACIP,
 			RD:   st.binding.RD,
@@ -360,6 +403,8 @@ func (e *EVPNExporter) OnLocalMAC(bdID uint16, mac net.HardwareAddr, added bool)
 		return
 	}
 	delete(st.advertised, key)
+	// Headroom freed: let the cap-reached warning fire again if it refills.
+	st.atLimit = false
 }
 
 // installL2SID mints a function from locatorName and installs an L2 bridge-domain

--- a/pkg/bgp/export/evpn_test.go
+++ b/pkg/bgp/export/evpn_test.go
@@ -429,7 +429,8 @@ func TestEnableESReplaces(t *testing.T) {
 	if err := e.EnableES(testESI, "65000:200"); err != nil {
 		t.Fatalf("EnableES: %v", err)
 	}
-	// Re-enable with a different RD: the old RT4 is withdrawn and a new one pushed.
+	// Re-enable with a different RD: the new RT4 is pushed (push-first) and the old
+	// one, a different NLRI key, is withdrawn.
 	if err := e.EnableES(testESI, "65000:201"); err != nil {
 		t.Fatalf("re-EnableES: %v", err)
 	}
@@ -438,5 +439,86 @@ func TestEnableESReplaces(t *testing.T) {
 	}
 	if len(adv.pushedES) != 2 || adv.pushedES[1].RD != "65000:201" {
 		t.Errorf("re-enable must push the new RT4 (RD 65000:201), got %+v", adv.pushedES)
+	}
+}
+
+// Re-enabling an ES with the SAME RD relies on gobgp AddPath superseding the
+// same-NLRI path, so no explicit withdraw is issued (an explicit withdraw would
+// race the re-push and could blackhole the ES).
+func TestEnableESSameRDDoesNotWithdraw(t *testing.T) {
+	e, adv, _ := newTestEVPNExporter(t)
+	if err := e.EnableES(testESI, "65000:200"); err != nil {
+		t.Fatalf("EnableES: %v", err)
+	}
+	if err := e.EnableES(testESI, "65000:200"); err != nil {
+		t.Fatalf("re-EnableES same RD: %v", err)
+	}
+	if len(adv.withdrawnES) != 0 {
+		t.Errorf("same-RD re-enable must not withdraw (AddPath supersedes), got %d", len(adv.withdrawnES))
+	}
+	if len(adv.pushedES) != 2 {
+		t.Errorf("each EnableES re-pushes the RT4, got %d", len(adv.pushedES))
+	}
+}
+
+// A failed re-EnableES push must leave the prior RT4 intact (push-first): the
+// withdraw of the old advertisement only runs after the new push lands.
+func TestEnableESPushFailureKeepsPrior(t *testing.T) {
+	e, adv, _ := newTestEVPNExporter(t)
+	if err := e.EnableES(testESI, "65000:200"); err != nil {
+		t.Fatalf("EnableES: %v", err)
+	}
+	adv.pushErr = errors.New("push failed")
+	if err := e.EnableES(testESI, "65000:201"); err == nil {
+		t.Fatal("EnableES should return the push error")
+	}
+	if len(adv.withdrawnES) != 0 {
+		t.Errorf("a failed re-EnableES must not withdraw the prior RT4, got %d", len(adv.withdrawnES))
+	}
+	if rd, ok := e.RDForESI(testESI); !ok || rd != "65000:200" {
+		t.Errorf("the prior RD must remain advertised after a failed re-enable; RDForESI=%q,%v", rd, ok)
+	}
+}
+
+func TestRDForESI(t *testing.T) {
+	e, _, _ := newTestEVPNExporter(t)
+	if _, ok := e.RDForESI(testESI); ok {
+		t.Error("RDForESI must report not-advertised before EnableES")
+	}
+	if err := e.EnableES(testESI, "65000:200"); err != nil {
+		t.Fatalf("EnableES: %v", err)
+	}
+	if rd, ok := e.RDForESI(testESI); !ok || rd != "65000:200" {
+		t.Errorf("RDForESI = %q,%v want 65000:200,true", rd, ok)
+	}
+	e.DisableES(testESI)
+	if _, ok := e.RDForESI(testESI); ok {
+		t.Error("RDForESI must report not-advertised after DisableES")
+	}
+}
+
+// MaxPrefixes bounds how many local MACs a bridge domain originates as RT2; a
+// withdraw frees headroom for a later MAC.
+func TestOnLocalMACMaxPrefixesCap(t *testing.T) {
+	e, adv, _ := newTestEVPNExporter(t)
+	b := evpnTestBinding()
+	b.MaxPrefixes = 2
+	if err := e.EnableBD(b, 10); err != nil {
+		t.Fatalf("EnableBD: %v", err)
+	}
+	macs := []net.HardwareAddr{
+		{0xaa, 0, 0, 0, 0, 1}, {0xaa, 0, 0, 0, 0, 2}, {0xaa, 0, 0, 0, 0, 3},
+	}
+	for _, m := range macs {
+		e.OnLocalMAC(100, m, true)
+	}
+	if len(adv.pushed) != 2 {
+		t.Fatalf("MaxPrefixes=2 must cap RT2 at 2, got %d", len(adv.pushed))
+	}
+	// Withdraw one (frees headroom), then a new MAC advertises again.
+	e.OnLocalMAC(100, macs[0], false)
+	e.OnLocalMAC(100, net.HardwareAddr{0xaa, 0, 0, 0, 0, 4}, true)
+	if len(adv.pushed) != 3 {
+		t.Errorf("freeing headroom must let a new MAC advertise; total pushed=%d, want 3", len(adv.pushed))
 	}
 }

--- a/pkg/bpf/maps.go
+++ b/pkg/bpf/maps.go
@@ -1744,16 +1744,31 @@ func (m *MapOperations) ListDx2vVlan() (map[Dx2vKey]*Dx2vEntry, error) {
 	return result, nil
 }
 
+// AgedFdbEntry identifies an FDB entry the ager removed, so the EVPN
+// auto-advertise path can withdraw its RT2. IsRemote distinguishes a
+// locally-learned MAC (advertised as RT2) from an EVPN-received one (never
+// advertised), so the caller only withdraws what it originated.
+type AgedFdbEntry struct {
+	BDID     uint16
+	MAC      net.HardwareAddr
+	IsRemote bool
+}
+
 // AgeFdbEntries deletes dynamic FDB entries older than maxAgeNs nanoseconds.
 // Static entries (is_static=1) and entries with last_seen=0 are never aged out.
-// Returns the number of entries deleted.
-func (m *MapOperations) AgeFdbEntries(maxAgeNs uint64) (int, error) {
+// It returns the entries actually deleted so the caller can withdraw their RT2
+// advertisements; len() is the number deleted.
+func (m *MapOperations) AgeFdbEntries(maxAgeNs uint64) ([]AgedFdbEntry, error) {
 	var key FdbKey
 	var entry FdbEntry
 	iter := m.objs.FdbMap.Iterate()
 
 	now := currentKtimeNs()
-	var toDelete []FdbKey
+	type candidate struct {
+		key      FdbKey
+		isRemote bool
+	}
+	var toDelete []candidate
 	for iter.Next(&key, &entry) {
 		if entry.IsStatic != 0 || entry.LastSeen == 0 {
 			continue
@@ -1763,18 +1778,22 @@ func (m *MapOperations) AgeFdbEntries(maxAgeNs uint64) (int, error) {
 		}
 		age := now - entry.LastSeen
 		if age > maxAgeNs {
-			keyCopy := key
-			toDelete = append(toDelete, keyCopy)
+			toDelete = append(toDelete, candidate{key: key, isRemote: entry.IsRemote != 0})
 		}
 	}
 	if err := iter.Err(); err != nil {
-		return 0, fmt.Errorf("failed to iterate fdb map: %w", err)
+		return nil, fmt.Errorf("failed to iterate fdb map: %w", err)
 	}
 
-	deleted := 0
-	for _, k := range toDelete {
+	deleted := make([]AgedFdbEntry, 0, len(toDelete))
+	for _, c := range toDelete {
+		k := c.key
 		if err := m.objs.FdbMap.Delete(&k); err == nil {
-			deleted++
+			deleted = append(deleted, AgedFdbEntry{
+				BDID:     k.BdId,
+				MAC:      net.HardwareAddr(append([]byte(nil), k.Mac[:]...)),
+				IsRemote: c.isRemote,
+			})
 		}
 	}
 	return deleted, nil

--- a/pkg/bpf/maps_test.go
+++ b/pkg/bpf/maps_test.go
@@ -529,12 +529,15 @@ func TestFdbAging(t *testing.T) {
 
 	// Age with 1s timeout — should delete the old entry (last_seen=1ns is ancient)
 	// Use short timeout because CI VMs may have small CLOCK_MONOTONIC after boot.
-	deleted, err := h.mapOps.AgeFdbEntries(1e9) // 1 second in ns
+	aged, err := h.mapOps.AgeFdbEntries(1e9) // 1 second in ns
 	if err != nil {
 		t.Fatalf("AgeFdbEntries: %v", err)
 	}
-	if deleted != 1 {
-		t.Errorf("expected 1 deleted, got %d", deleted)
+	if len(aged) != 1 {
+		t.Errorf("expected 1 deleted, got %d", len(aged))
+	} else if aged[0].BDID != bdID || aged[0].MAC.String() != dynamicMAC.String() {
+		t.Errorf("aged entry = bd %d mac %s, want bd %d mac %s",
+			aged[0].BDID, aged[0].MAC, bdID, dynamicMAC)
 	}
 
 	// Verify: old dynamic entry gone

--- a/pkg/cli/cmd_es.go
+++ b/pkg/cli/cmd_es.go
@@ -80,7 +80,7 @@ func esCommand() *cli.Command {
 					if useJSON(c) {
 						return printJSON(resp.Msg.Entries)
 					}
-					headers := []string{"ESI", "LOCAL_ATTACHED", "LOCAL_PE", "DF_PE", "MODE"}
+					headers := []string{"ESI", "LOCAL_ATTACHED", "LOCAL_PE", "DF_PE", "MODE", "RD"}
 					var rows [][]string
 					for _, e := range resp.Msg.Entries {
 						rows = append(rows, []string{
@@ -89,6 +89,7 @@ func esCommand() *cli.Command {
 							e.LocalPeSrcAddr,
 							e.DfPeSrcAddr,
 							formatEsiMode(e.RedundancyMode),
+							e.Rd,
 						})
 					}
 					printTable(headers, rows)

--- a/pkg/netlinkwatch/fdb_macsink_test.go
+++ b/pkg/netlinkwatch/fdb_macsink_test.go
@@ -14,9 +14,10 @@ import (
 // fakeFdbMapOps records FDB writes without a live BPF map (the MAC string of
 // each create/delete).
 type fakeFdbMapOps struct {
-	created   []string // mac.String() of each CreateFdb
-	deleted   []string // mac.String() of each DeleteFdb
-	createErr error    // when set, CreateFdb fails (dataplane sync failure)
+	created   []string           // mac.String() of each CreateFdb
+	deleted   []string           // mac.String() of each DeleteFdb
+	createErr error              // when set, CreateFdb fails (dataplane sync failure)
+	aged      []bpf.AgedFdbEntry // returned by AgeFdbEntries (the entries it removed)
 }
 
 func (f *fakeFdbMapOps) CreateFdb(bdID uint16, mac net.HardwareAddr, _ *bpf.FdbEntry) error {
@@ -30,7 +31,7 @@ func (f *fakeFdbMapOps) DeleteFdb(bdID uint16, mac net.HardwareAddr) error {
 	f.deleted = append(f.deleted, mac.String())
 	return nil
 }
-func (f *fakeFdbMapOps) AgeFdbEntries(uint64) (int, error) { return 0, nil }
+func (f *fakeFdbMapOps) AgeFdbEntries(uint64) ([]bpf.AgedFdbEntry, error) { return f.aged, nil }
 
 type macEvent struct {
 	bdID  uint16
@@ -52,7 +53,9 @@ func newSinkTestWatcher(sink MACSink) (*FDBWatcher, *fakeFdbMapOps) {
 		mapOps:  ops,
 		logger:  zap.NewNop(),
 		allowed: make(map[int]uint16),
-		done:    make(chan struct{}),
+		// Default to an empty bridge FDB; DumpBridge tests override this.
+		neighList: func(int, int) ([]netlink.Neigh, error) { return nil, nil },
+		done:      make(chan struct{}),
 	}
 	w.RegisterBridge(10, 100) // bridge ifindex 10 -> bd_id 100
 	w.SetMACSink(sink)
@@ -140,9 +143,11 @@ func TestIsUnicastMAC(t *testing.T) {
 		{"nil", nil, false},
 	}
 	for _, c := range cases {
-		if got := isUnicastMAC(c.mac); got != c.want {
-			t.Errorf("isUnicastMAC(%v) = %v, want %v", c.mac, got, c.want)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			if got := isUnicastMAC(c.mac); got != c.want {
+				t.Errorf("isUnicastMAC(%v) = %v, want %v", c.mac, got, c.want)
+			}
+		})
 	}
 }
 
@@ -157,5 +162,80 @@ func TestDumpBridgeNilSinkIsNoop(t *testing.T) {
 	w, _ := newSinkTestWatcher(nil) // registers bridge ifindex 10, no sink
 	if err := w.DumpBridge(10); err != nil {
 		t.Errorf("DumpBridge with no sink must be a no-op, got %v", err)
+	}
+}
+
+// DumpBridge replays only the registered bridge's unicast MACs (MasterIndex
+// filter), and syncs each into the BPF fdb_map before advertising it (the
+// gating that prevents advertising a MAC the data plane cannot decap).
+func TestDumpBridgeFiltersAndSyncsBeforeAdvertise(t *testing.T) {
+	onBridge := net.HardwareAddr{0xaa, 0, 0, 0, 0, 1}     // ifindex 10 (registered) -> replayed
+	otherBridge := net.HardwareAddr{0xaa, 0, 0, 0, 0, 2}  // ifindex 20 -> filtered out
+	multicast := net.HardwareAddr{0x01, 0, 0x5e, 0, 0, 9} // ifindex 10 but multicast -> skipped
+
+	sink := &fakeMACSink{}
+	w, ops := newSinkTestWatcher(sink)
+	w.neighList = func(int, int) ([]netlink.Neigh, error) {
+		return []netlink.Neigh{
+			{Family: unix.AF_BRIDGE, MasterIndex: 10, LinkIndex: 3, HardwareAddr: onBridge},
+			{Family: unix.AF_BRIDGE, MasterIndex: 20, LinkIndex: 4, HardwareAddr: otherBridge},
+			{Family: unix.AF_BRIDGE, MasterIndex: 10, LinkIndex: 3, HardwareAddr: multicast},
+		}, nil
+	}
+	if err := w.DumpBridge(10); err != nil {
+		t.Fatalf("DumpBridge: %v", err)
+	}
+
+	// Only the registered bridge's unicast MAC is synced + advertised.
+	if len(ops.created) != 1 || ops.created[0] != onBridge.String() {
+		t.Errorf("only the registered bridge's unicast MAC should sync to BPF, got %v", ops.created)
+	}
+	if len(sink.events) != 1 {
+		t.Fatalf("only the registered bridge's unicast MAC should advertise, got %+v", sink.events)
+	}
+	ev := sink.events[0]
+	if ev.bdID != 100 || ev.mac != onBridge.String() || !ev.added {
+		t.Errorf("replayed event = %+v, want bd 100 add of %s", ev, onBridge)
+	}
+}
+
+// DumpBridge must not advertise a MAC whose BPF fdb_map sync fails (the data
+// plane cannot decap it), the same gating the live path applies.
+func TestDumpBridgeSkipsAdvertiseWhenSyncFails(t *testing.T) {
+	sink := &fakeMACSink{}
+	w, ops := newSinkTestWatcher(sink)
+	ops.createErr = errors.New("map full")
+	w.neighList = func(int, int) ([]netlink.Neigh, error) {
+		return []netlink.Neigh{
+			{Family: unix.AF_BRIDGE, MasterIndex: 10, LinkIndex: 3, HardwareAddr: net.HardwareAddr{0xaa, 0, 0, 0, 0, 1}},
+		}, nil
+	}
+	if err := w.DumpBridge(10); err != nil {
+		t.Fatalf("DumpBridge: %v", err)
+	}
+	if len(sink.events) != 0 {
+		t.Errorf("a MAC whose BPF sync fails must not advertise, got %+v", sink.events)
+	}
+}
+
+// The aging pass withdraws RT2 for each aged locally-learned MAC (so an
+// aging-removed entry does not stay advertised with no data-plane entry), but
+// not for EVPN-received (remote) entries, which were never advertised.
+func TestAgeAndWithdrawWithdrawsLocalNotRemote(t *testing.T) {
+	local := net.HardwareAddr{0xaa, 0, 0, 0, 0, 1}
+	remote := net.HardwareAddr{0xaa, 0, 0, 0, 0, 2}
+	sink := &fakeMACSink{}
+	w, ops := newSinkTestWatcher(sink)
+	ops.aged = []bpf.AgedFdbEntry{
+		{BDID: 100, MAC: local, IsRemote: false},
+		{BDID: 100, MAC: remote, IsRemote: true},
+	}
+	w.ageAndWithdraw(1e9)
+	if len(sink.events) != 1 {
+		t.Fatalf("only the local aged MAC should be withdrawn, got %+v", sink.events)
+	}
+	ev := sink.events[0]
+	if ev.bdID != 100 || ev.mac != local.String() || ev.added {
+		t.Errorf("withdraw event = %+v, want bd 100 delete of %s", ev, local)
 	}
 }

--- a/pkg/netlinkwatch/fdb_watcher.go
+++ b/pkg/netlinkwatch/fdb_watcher.go
@@ -27,17 +27,20 @@ type MACSink interface {
 type fdbMapOps interface {
 	CreateFdb(bdID uint16, mac net.HardwareAddr, entry *bpf.FdbEntry) error
 	DeleteFdb(bdID uint16, mac net.HardwareAddr) error
-	AgeFdbEntries(maxAgeNs uint64) (int, error)
+	AgeFdbEntries(maxAgeNs uint64) ([]bpf.AgedFdbEntry, error)
 }
 
 // FDBWatcher watches Linux bridge FDB updates via Netlink and syncs them to BPF fdb_map.
 // Also runs a periodic aging timer to delete stale dynamic entries.
 type FDBWatcher struct {
-	mapOps       fdbMapOps
-	logger       *zap.Logger
-	mu           sync.RWMutex
-	allowed      map[int]uint16 // bridge ifindex → bd_id (for O(1) filter)
-	macSink      MACSink        // nil unless EVPN auto-advertise is on
+	mapOps  fdbMapOps
+	logger  *zap.Logger
+	mu      sync.RWMutex
+	allowed map[int]uint16 // bridge ifindex → bd_id (for O(1) filter)
+	macSink MACSink        // nil unless EVPN auto-advertise is on
+	// neighList lists kernel neighbor entries (defaults to netlink.NeighList);
+	// overridable in tests so DumpBridge's filter + sync path needs no live bridge.
+	neighList    func(linkIndex, family int) ([]netlink.Neigh, error)
 	done         chan struct{}
 	wg           sync.WaitGroup
 	agingSeconds int // 0=disabled
@@ -46,10 +49,11 @@ type FDBWatcher struct {
 // NewFDBWatcher creates a new FDB watcher
 func NewFDBWatcher(mapOps *bpf.MapOperations, logger *zap.Logger) *FDBWatcher {
 	return &FDBWatcher{
-		mapOps:  mapOps,
-		logger:  logger,
-		allowed: make(map[int]uint16),
-		done:    make(chan struct{}),
+		mapOps:    mapOps,
+		logger:    logger,
+		allowed:   make(map[int]uint16),
+		neighList: netlink.NeighList,
+		done:      make(chan struct{}),
 	}
 }
 
@@ -122,15 +126,36 @@ func (w *FDBWatcher) runAging(ctx context.Context) {
 		case <-w.done:
 			return
 		case <-ticker.C:
-			maxAgeNs := uint64(w.agingSeconds) * 1e9
-			deleted, err := w.mapOps.AgeFdbEntries(maxAgeNs)
-			if err != nil {
-				w.logger.Warn("FDB aging error", zap.Error(err))
-			} else if deleted > 0 {
-				w.logger.Info("FDB aging: deleted stale entries", zap.Int("count", deleted))
-			}
+			w.ageAndWithdraw(uint64(w.agingSeconds) * 1e9)
 		}
 	}
+}
+
+// ageAndWithdraw runs one BPF aging pass and withdraws the RT2 for each aged
+// locally-learned MAC. Vinbero's BPF ager may remove an fdb_map entry the kernel
+// FDB still holds (the kernel runs its own aging and would emit RTM_DELNEIGH), so
+// without this the route stays advertised with no data-plane entry behind it --
+// an aging-induced blackhole. Remote entries (IsRemote) were never advertised as
+// RT2, so they are skipped.
+func (w *FDBWatcher) ageAndWithdraw(maxAgeNs uint64) {
+	aged, err := w.mapOps.AgeFdbEntries(maxAgeNs)
+	if err != nil {
+		w.logger.Warn("FDB aging error", zap.Error(err))
+		return
+	}
+	if len(aged) == 0 {
+		return
+	}
+	w.mu.RLock()
+	sink := w.macSink
+	w.mu.RUnlock()
+	for _, a := range aged {
+		if a.IsRemote {
+			continue
+		}
+		w.notifyMAC(sink, a.BDID, a.MAC, false)
+	}
+	w.logger.Info("FDB aging: deleted stale entries", zap.Int("count", len(aged)))
 }
 
 func (w *FDBWatcher) processUpdates(ctx context.Context, updates <-chan netlink.NeighUpdate) {
@@ -236,9 +261,9 @@ func (w *FDBWatcher) DumpBridge(ifindex int) error {
 	if sink == nil {
 		return nil
 	}
-	// NeighList(0, AF_BRIDGE) lists every bridge FDB entry; filter by MasterIndex
+	// neighList(0, AF_BRIDGE) lists every bridge FDB entry; filter by MasterIndex
 	// to this bridge, mirroring the live handleNeighUpdate path.
-	neighs, err := netlink.NeighList(0, unix.AF_BRIDGE)
+	neighs, err := w.neighList(0, unix.AF_BRIDGE)
 	if err != nil {
 		return fmt.Errorf("list bridge FDB: %w", err)
 	}

--- a/pkg/netresource/manager.go
+++ b/pkg/netresource/manager.go
@@ -89,21 +89,31 @@ func (m *ResourceManager) GetBridgeByName(name string) (ManagedBridge, bool) {
 // whose bridge domain id is bdID. The EVPN auto-advertise binding axis
 // (VrfBgpBind) uses it to enable a bridge domain whose bridge already exists.
 // ok=false when no managed bridge claims bdID (bind arrived before the bridge,
-// so BridgeCreate will enable it instead) or when bdID is 0. A duplicate bd_id
-// returns the first match; GetByBDID already refuses an ambiguous binding before
-// this is reached, so the duplicate cannot originate a route here.
+// so BridgeCreate will enable it instead) or when bdID is 0.
+//
+// It REFUSES an ambiguous bd_id (more than one bridge claims it) with ok=false,
+// mirroring vrfbgp.Manager.GetByBDID: CreateBridge does not enforce bd_id
+// uniqueness, and resolving a duplicate by first match would let the bridge that
+// happens to sort first steer which device's FDB/decap target a route advertises.
+// Fail closed instead so an ambiguous bd_id originates nothing on either axis.
 func (m *ResourceManager) BridgeIfindexByBDID(bdID uint16) (uint32, bool) {
 	if bdID == 0 {
 		return 0, false
 	}
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+	var ifindex uint32
+	n := 0
 	for _, b := range m.state.Bridges {
 		if b.BdID == bdID {
-			return b.Ifindex, true
+			ifindex = b.Ifindex
+			n++
 		}
 	}
-	return 0, false
+	if n != 1 {
+		return 0, false
+	}
+	return ifindex, true
 }
 
 // GetVrfByName returns the managed VRF info by name.

--- a/pkg/netresource/manager.go
+++ b/pkg/netresource/manager.go
@@ -85,6 +85,27 @@ func (m *ResourceManager) GetBridgeByName(name string) (ManagedBridge, bool) {
 	return ManagedBridge{}, false
 }
 
+// BridgeIfindexByBDID returns the Linux bridge ifindex of the managed bridge
+// whose bridge domain id is bdID. The EVPN auto-advertise binding axis
+// (VrfBgpBind) uses it to enable a bridge domain whose bridge already exists.
+// ok=false when no managed bridge claims bdID (bind arrived before the bridge,
+// so BridgeCreate will enable it instead) or when bdID is 0. A duplicate bd_id
+// returns the first match; GetByBDID already refuses an ambiguous binding before
+// this is reached, so the duplicate cannot originate a route here.
+func (m *ResourceManager) BridgeIfindexByBDID(bdID uint16) (uint32, bool) {
+	if bdID == 0 {
+		return 0, false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, b := range m.state.Bridges {
+		if b.BdID == bdID {
+			return b.Ifindex, true
+		}
+	}
+	return 0, false
+}
+
 // GetVrfByName returns the managed VRF info by name.
 func (m *ResourceManager) GetVrfByName(name string) (ManagedVrf, bool) {
 	m.mu.RLock()

--- a/pkg/netresource/manager_test.go
+++ b/pkg/netresource/manager_test.go
@@ -1,0 +1,37 @@
+package netresource
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// BridgeIfindexByBDID resolves a unique bd_id to its bridge ifindex, but fails
+// closed for an absent bd_id, bd_id 0, and -- critically -- a duplicate bd_id
+// (CreateBridge does not enforce uniqueness), so the EVPN binding axis never
+// steers to an arbitrarily-chosen bridge.
+func TestBridgeIfindexByBDID(t *testing.T) {
+	m := &ResourceManager{
+		logger: zap.NewNop(),
+		state: &ManagedState{
+			Bridges: []ManagedBridge{
+				{Name: "br10", BdID: 10, Ifindex: 100},
+				{Name: "br20", BdID: 20, Ifindex: 200},
+				{Name: "br20-dup", BdID: 20, Ifindex: 201}, // duplicate bd_id 20
+			},
+		},
+	}
+
+	if ifindex, ok := m.BridgeIfindexByBDID(10); !ok || ifindex != 100 {
+		t.Errorf("unique bd_id 10 should resolve to ifindex 100; got %d,%v", ifindex, ok)
+	}
+	if _, ok := m.BridgeIfindexByBDID(20); ok {
+		t.Error("ambiguous bd_id 20 (two bridges) must fail closed, not pick a first match")
+	}
+	if _, ok := m.BridgeIfindexByBDID(99); ok {
+		t.Error("absent bd_id must return ok=false")
+	}
+	if _, ok := m.BridgeIfindexByBDID(0); ok {
+		t.Error("bd_id 0 (L3VPN-only) must return ok=false")
+	}
+}

--- a/pkg/server/ethernet_segment.go
+++ b/pkg/server/ethernet_segment.go
@@ -18,6 +18,9 @@ import (
 type EvpnEsHook interface {
 	EnableES(esi [bpf.ESILen]byte, rd string) error
 	DisableES(esi [bpf.ESILen]byte)
+	// RDForESI returns the RD the ES's RT4 is advertised with so EsList can echo
+	// it; the BPF esi_map does not store the RD. ok=false when not advertised.
+	RDForESI(esi [bpf.ESILen]byte) (string, bool)
 }
 
 type EthernetSegmentServer struct {
@@ -68,6 +71,14 @@ func (s *EthernetSegmentServer) entryToProto(esi [bpf.ESILen]byte, entry *bpf.Es
 	}
 	if entry.DfPeSrcAddr != zero {
 		out.DfPeSrcAddr = bpf.FormatIPv6(entry.DfPeSrcAddr)
+	}
+	// The RD lives only in the auto-advertise exporter's state (the BPF esi_map
+	// carries no RD), so echo it from there when EVPN auto-advertise is on and this
+	// ES is advertised. Off / not-advertised leaves rd empty.
+	if s.evpn != nil {
+		if rd, ok := s.evpn.RDForESI(esi); ok {
+			out.Rd = rd
+		}
 	}
 	return out
 }

--- a/pkg/server/evpn_coordinator.go
+++ b/pkg/server/evpn_coordinator.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"github.com/takehaya/vinbero/pkg/vrfbgp"
+	"go.uber.org/zap"
+)
+
+// EvpnCoordinator drives EVPN auto-advertise (RT2 + RT3) across the two
+// lifecycles that gate a bridge domain: the bridge device (BridgeCreate /
+// BridgeDelete) and the VRF<->BGP binding (VrfBgpBind / VrfBgpUnbind). A bridge
+// domain may auto-advertise only when BOTH its bridge exists and its binding is
+// present, so whichever arrives second enables it and whichever leaves first
+// disables it. Centralizing both axes here keeps the enable (EnableBD + FDB
+// replay) sequence in one place and closes the asymmetry where an unbind left
+// the device-axis enablement originating routes under a removed RD/RT.
+//
+// It is nil unless EVPN auto-advertise is on; callers nil-check before use.
+type EvpnCoordinator struct {
+	exporter EvpnBridgeHook
+	// bridgeIfindex resolves a bridge domain id to its Linux bridge ifindex
+	// (ResourceManager.BridgeIfindexByBDID); ok=false when no bridge exists yet.
+	bridgeIfindex func(bdID uint16) (uint32, bool)
+	// replayFDB re-runs a bridge's existing kernel FDB through the RT2 path
+	// (FDBWatcher.DumpBridge), so a bridge already holding MACs advertises them.
+	replayFDB func(ifindex int) error
+	logger    *zap.Logger
+}
+
+// NewEvpnCoordinator wires the coordinator. exporter is the EVPNExporter,
+// bridgeIfindex is ResourceManager.BridgeIfindexByBDID, replayFDB is
+// FDBWatcher.DumpBridge.
+func NewEvpnCoordinator(exporter EvpnBridgeHook, bridgeIfindex func(bdID uint16) (uint32, bool), replayFDB func(ifindex int) error, logger *zap.Logger) *EvpnCoordinator {
+	return &EvpnCoordinator{
+		exporter:      exporter,
+		bridgeIfindex: bridgeIfindex,
+		replayFDB:     replayFDB,
+		logger:        logger.Named("evpn.coordinator"),
+	}
+}
+
+// EnableForBridge is the device axis: a bridge was just created (or already
+// existed) for a binding, so enable EVPN auto-advertise and replay the bridge's
+// existing FDB as RT2. Both steps are non-fatal -- the bridge is usable
+// regardless; it just won't auto-originate -- so failures are logged, not
+// returned.
+func (c *EvpnCoordinator) EnableForBridge(b vrfbgp.Binding, ifindex uint32, bridgeName string) {
+	if err := c.exporter.EnableBD(b, ifindex); err != nil {
+		c.logger.Warn("enable EVPN auto-advertise for bridge",
+			zap.String("bridge", bridgeName), zap.Uint16("bd_id", b.BDID), zap.Error(err))
+		return
+	}
+	if err := c.replayFDB(int(ifindex)); err != nil {
+		// Replay MACs already in the bridge's FDB (e.g. a pre-existing bridge) so
+		// they advertise as RT2. Non-fatal: live events still cover anything
+		// learned after this.
+		c.logger.Warn("replay bridge FDB for EVPN RT2 auto-advertise",
+			zap.String("bridge", bridgeName), zap.Uint16("bd_id", b.BDID), zap.Error(err))
+	}
+}
+
+// EnableForBinding is the binding axis: a VRF was just bound, so enable EVPN
+// auto-advertise for its bridge domain if the bridge already exists. When the
+// bridge has not been created yet it is a no-op -- BridgeCreate enables it via
+// EnableForBridge when it arrives. A binding without a bridge domain (BDID 0,
+// i.e. L3VPN-only) is ignored.
+func (c *EvpnCoordinator) EnableForBinding(b vrfbgp.Binding) {
+	if b.BDID == 0 {
+		return
+	}
+	ifindex, ok := c.bridgeIfindex(b.BDID)
+	if !ok {
+		c.logger.Debug("EVPN binding has no bridge yet; BridgeCreate will enable it",
+			zap.String("vrf", b.VRFName), zap.Uint16("bd_id", b.BDID))
+		return
+	}
+	c.EnableForBridge(b, ifindex, b.VRFName)
+}
+
+// Disable tears down a bridge domain's EVPN auto-advertise (withdraw RT2/RT3,
+// release SIDs). Driven by BridgeDelete (device gone) and VrfBgpUnbind (binding
+// gone); a no-op for a BD the exporter has not enabled, so calling it from both
+// axes is safe.
+func (c *EvpnCoordinator) Disable(bdID uint16) {
+	if bdID == 0 {
+		return
+	}
+	c.exporter.DisableBD(bdID)
+}
+
+// SIDsForBD returns the sid_function_map keys the exporter installed for the
+// bridge domain, so BridgeDelete can exclude them from its reference check.
+func (c *EvpnCoordinator) SIDsForBD(bdID uint16) []string {
+	return c.exporter.SIDsForBD(bdID)
+}

--- a/pkg/server/evpn_coordinator.go
+++ b/pkg/server/evpn_coordinator.go
@@ -82,7 +82,11 @@ func (c *EvpnCoordinator) EnableForBinding(b vrfbgp.Binding) {
 	}
 	ifindex, ok := c.bridgeIfindex(b.BDID)
 	if !ok {
-		c.logger.Debug("EVPN binding has no bridge yet; BridgeCreate will enable it",
+		// bridgeIfindex fails closed for an absent OR ambiguous bd_id (more than one
+		// bridge claims it); either way nothing is enabled here. For the absent case
+		// BridgeCreate enables it when the bridge arrives; an ambiguous bd_id
+		// originates nothing on either axis (the device axis refuses it too).
+		c.logger.Debug("EVPN binding has no unique bridge yet (absent or ambiguous bd_id)",
 			zap.String("vrf", b.VRFName), zap.Uint16("bd_id", b.BDID))
 		return
 	}

--- a/pkg/server/evpn_coordinator.go
+++ b/pkg/server/evpn_coordinator.go
@@ -38,15 +38,17 @@ func NewEvpnCoordinator(exporter EvpnBridgeHook, bridgeIfindex func(bdID uint16)
 	}
 }
 
-// EnableForBridge is the device axis: a bridge was just created (or already
-// existed) for a binding, so enable EVPN auto-advertise and replay the bridge's
-// existing FDB as RT2. Both steps are non-fatal -- the bridge is usable
-// regardless; it just won't auto-originate -- so failures are logged, not
-// returned.
+// EnableForBridge enables EVPN auto-advertise for a binding whose bridge is at
+// ifindex, and replays the bridge's existing FDB as RT2. Both steps are
+// non-fatal -- the bridge is usable regardless; it just won't auto-originate --
+// so failures are logged, not returned. bridgeName is the Linux bridge device
+// name when the caller knows it (the device axis, BridgeCreate); the binding
+// axis passes "" since it resolves only the ifindex, so the log omits the
+// bridge field rather than mislabelling another value as the bridge name.
 func (c *EvpnCoordinator) EnableForBridge(b vrfbgp.Binding, ifindex uint32, bridgeName string) {
 	if err := c.exporter.EnableBD(b, ifindex); err != nil {
-		c.logger.Warn("enable EVPN auto-advertise for bridge",
-			zap.String("bridge", bridgeName), zap.Uint16("bd_id", b.BDID), zap.Error(err))
+		c.logger.Warn("enable EVPN auto-advertise for bridge domain",
+			c.bdFields(b, bridgeName, zap.Error(err))...)
 		return
 	}
 	if err := c.replayFDB(int(ifindex)); err != nil {
@@ -54,8 +56,19 @@ func (c *EvpnCoordinator) EnableForBridge(b vrfbgp.Binding, ifindex uint32, brid
 		// they advertise as RT2. Non-fatal: live events still cover anything
 		// learned after this.
 		c.logger.Warn("replay bridge FDB for EVPN RT2 auto-advertise",
-			zap.String("bridge", bridgeName), zap.Uint16("bd_id", b.BDID), zap.Error(err))
+			c.bdFields(b, bridgeName, zap.Error(err))...)
 	}
+}
+
+// bdFields builds the common log fields for a bridge domain: vrf and bd_id
+// always, bridge only when its name is known, plus any extra fields.
+func (c *EvpnCoordinator) bdFields(b vrfbgp.Binding, bridgeName string, extra ...zap.Field) []zap.Field {
+	f := make([]zap.Field, 0, 3+len(extra))
+	f = append(f, zap.String("vrf", b.VRFName), zap.Uint16("bd_id", b.BDID))
+	if bridgeName != "" {
+		f = append(f, zap.String("bridge", bridgeName))
+	}
+	return append(f, extra...)
 }
 
 // EnableForBinding is the binding axis: a VRF was just bound, so enable EVPN
@@ -73,7 +86,9 @@ func (c *EvpnCoordinator) EnableForBinding(b vrfbgp.Binding) {
 			zap.String("vrf", b.VRFName), zap.Uint16("bd_id", b.BDID))
 		return
 	}
-	c.EnableForBridge(b, ifindex, b.VRFName)
+	// The binding axis resolves only the ifindex, not the bridge device name, so
+	// pass "" -- EnableForBridge omits the bridge log field rather than mislabel.
+	c.EnableForBridge(b, ifindex, "")
 }
 
 // Disable tears down a bridge domain's EVPN auto-advertise (withdraw RT2/RT3,

--- a/pkg/server/network_resource.go
+++ b/pkg/server/network_resource.go
@@ -30,12 +30,12 @@ type NetworkResourceServer struct {
 	resMgr     *netresource.ResourceManager
 	fdbWatcher *netlinkwatch.FDBWatcher
 	mapOps     *bpf.MapOperations
-	mgr        *vrfbgp.Manager // binding registry, to resolve a bd_id to its EVPN binding
-	evpn       EvpnBridgeHook  // nil unless EVPN auto-advertise is on
+	mgr        *vrfbgp.Manager  // binding registry, to resolve a bd_id to its EVPN binding
+	evpn       *EvpnCoordinator // EVPN BD lifecycle (device axis); nil unless auto-advertise is on
 	logger     *zap.Logger
 }
 
-func NewNetworkResourceServer(resMgr *netresource.ResourceManager, fdbWatcher *netlinkwatch.FDBWatcher, mapOps *bpf.MapOperations, mgr *vrfbgp.Manager, evpn EvpnBridgeHook, logger *zap.Logger) *NetworkResourceServer {
+func NewNetworkResourceServer(resMgr *netresource.ResourceManager, fdbWatcher *netlinkwatch.FDBWatcher, mapOps *bpf.MapOperations, mgr *vrfbgp.Manager, evpn *EvpnCoordinator, logger *zap.Logger) *NetworkResourceServer {
 	return &NetworkResourceServer{resMgr: resMgr, fdbWatcher: fdbWatcher, mapOps: mapOps, mgr: mgr, evpn: evpn, logger: logger}
 }
 
@@ -62,20 +62,12 @@ func (s *NetworkResourceServer) BridgeCreate(
 		s.fdbWatcher.RegisterBridge(int(ifindex), uint16(br.BdId))
 
 		// If EVPN auto-advertise is on and this bd_id has a binding, enable
-		// auto-advertise (RT2 + RT3) for the bridge. A failure here is non-fatal:
-		// the bridge is created regardless, it just won't auto-originate.
+		// auto-advertise (RT2 + RT3) for the bridge (the device axis). The
+		// coordinator's EnableForBridge handles the EnableBD + FDB replay; failures
+		// are non-fatal (logged, not returned) so the bridge is created regardless.
 		if s.evpn != nil {
 			if b, ok := s.mgr.GetByBDID(uint16(br.BdId)); ok {
-				if err := s.evpn.EnableBD(b, ifindex); err != nil {
-					s.logger.Warn("enable EVPN auto-advertise for bridge",
-						zap.String("bridge", br.Name), zap.Uint32("bd_id", br.BdId), zap.Error(err))
-				} else if err := s.fdbWatcher.DumpBridge(int(ifindex)); err != nil {
-					// Replay MACs already in the bridge's FDB (e.g. a pre-existing
-					// bridge) so they advertise as RT2. Non-fatal: live events still
-					// cover anything learned after this.
-					s.logger.Warn("replay bridge FDB for EVPN RT2 auto-advertise",
-						zap.String("bridge", br.Name), zap.Uint32("bd_id", br.BdId), zap.Error(err))
-				}
+				s.evpn.EnableForBridge(b, ifindex, br.Name)
 			}
 		}
 
@@ -154,9 +146,10 @@ func (s *NetworkResourceServer) BridgeDelete(
 
 		// The bridge is gone; now release the EVPN auto-advertise SID and withdraw
 		// its RT2s. Doing it here (not earlier) keeps EVPN intact if the delete
-		// above failed.
+		// above failed. The binding may still exist (only the device left); a later
+		// VrfBgpUnbind is a no-op for an already-disabled BD.
 		if s.evpn != nil && bdID != 0 {
-			s.evpn.DisableBD(bdID)
+			s.evpn.Disable(bdID)
 		}
 
 		resp.DeletedNames = append(resp.DeletedNames, name)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -34,7 +34,7 @@ type Server struct {
 	mupAdv       bgp.MUPController
 	srPolicyCtrl srPolicyController
 	vrfExporter  VrfExporter                // runtime auto-advertise hook; nil when off
-	evpnBridge   EvpnBridgeHook             // EVPN RT2/RT3 auto-advertise BD hook; nil when off
+	evpnCoord    *EvpnCoordinator           // EVPN RT2/RT3 BD lifecycle (device + binding axes); nil when off
 	evpnES       EvpnEsHook                 // EVPN RT4 auto-advertise ES hook; nil when off
 	esReElectDF  func(esi [bpf.ESILen]byte) // applier DF re-election; nil when BGP is off
 	logger       *zap.Logger
@@ -52,7 +52,7 @@ type Server struct {
 // enabled, or nil otherwise. Taking the concrete type (not the interface)
 // keeps a typed-nil from leaking into srPolicyCtrl, so the FailedPrecondition
 // guard in SrPolicyServer works.
-func NewServer(cfg *config.Config, mapOps *bpf.MapOperations, resMgr *netresource.ResourceManager, fdbWatcher *netlinkwatch.FDBWatcher, locatorMgr *locator.Manager, vrfBgpMgr *vrfbgp.Manager, advertiser bgp.RouteAdvertiser, srPolicyAdv bgp.SRPolicyController, evpnAdv bgp.EVPNController, mupAdv bgp.MUPController, srPolicyApplier *apply.Applier, vrfExporter VrfExporter, evpnBridge EvpnBridgeHook, evpnES EvpnEsHook, logger *zap.Logger) *Server {
+func NewServer(cfg *config.Config, mapOps *bpf.MapOperations, resMgr *netresource.ResourceManager, fdbWatcher *netlinkwatch.FDBWatcher, locatorMgr *locator.Manager, vrfBgpMgr *vrfbgp.Manager, advertiser bgp.RouteAdvertiser, srPolicyAdv bgp.SRPolicyController, evpnAdv bgp.EVPNController, mupAdv bgp.MUPController, srPolicyApplier *apply.Applier, vrfExporter VrfExporter, evpnCoord *EvpnCoordinator, evpnES EvpnEsHook, logger *zap.Logger) *Server {
 	s := &Server{
 		cfg:         cfg,
 		mapOps:      mapOps,
@@ -65,7 +65,7 @@ func NewServer(cfg *config.Config, mapOps *bpf.MapOperations, resMgr *netresourc
 		evpnAdv:     evpnAdv,
 		mupAdv:      mupAdv,
 		vrfExporter: vrfExporter,
-		evpnBridge:  evpnBridge,
+		evpnCoord:   evpnCoord,
 		evpnES:      evpnES,
 		logger:      logger,
 		mux:         http.NewServeMux(),
@@ -101,7 +101,7 @@ func (s *Server) Setup() {
 	pluginServer := NewPluginServer(s.mapOps, s.cfg.BpfConstants(), roEnforce, s.logger)
 
 	// VrfBgp service (VRF <-> BGP route-target bindings).
-	vrfBgpServer := NewVrfBgpServer(s.vrfBgpMgr, s.vrfExporter)
+	vrfBgpServer := NewVrfBgpServer(s.vrfBgpMgr, s.vrfExporter, s.evpnCoord)
 	vrfBgpPath, vrfBgpHandler := vinberov1connect.NewVrfBgpServiceHandler(vrfBgpServer)
 	s.mux.Handle(vrfBgpPath, vrfBgpHandler)
 	s.logger.Info("Registered VrfBgpService", zap.String("path", vrfBgpPath))
@@ -165,7 +165,7 @@ func (s *Server) Setup() {
 	s.logger.Info("Registered EthernetSegmentService", zap.String("path", path))
 
 	// NetworkResource service (VRF/Bridge management)
-	netResourceServer := NewNetworkResourceServer(s.resMgr, s.fdbWatcher, s.mapOps, s.vrfBgpMgr, s.evpnBridge, s.logger)
+	netResourceServer := NewNetworkResourceServer(s.resMgr, s.fdbWatcher, s.mapOps, s.vrfBgpMgr, s.evpnCoord, s.logger)
 	path, handler = vinberov1connect.NewNetworkResourceServiceHandler(netResourceServer)
 	s.mux.Handle(path, handler)
 	s.logger.Info("Registered NetworkResourceService", zap.String("path", path))

--- a/pkg/server/vrf_bgp.go
+++ b/pkg/server/vrf_bgp.go
@@ -20,11 +20,14 @@ type VrfExporter interface {
 }
 
 // VrfBgpServer is the Connect RPC handler for VrfBgpService, a thin
-// adapter over vrfbgp.Manager. When auto-advertise is on it also drives a
-// VrfExporter so a runtime bind/unbind enables/disables auto advertise.
+// adapter over vrfbgp.Manager. When auto-advertise is on it also drives the
+// L3VPN VrfExporter and the EVPN coordinator so a runtime bind/unbind
+// enables/disables auto advertise on both families: L3VPN (DT4/DT6) and EVPN
+// (RT2/RT3) for a binding with a bridge domain.
 type VrfBgpServer struct {
 	mgr      *vrfbgp.Manager
-	exporter VrfExporter // nil when auto-advertise is off
+	exporter VrfExporter      // L3VPN auto-advertise hook; nil when off
+	evpn     *EvpnCoordinator // EVPN BD lifecycle (binding axis); nil when off
 	// mu serializes a bind/unbind's manager + exporter mutations per call so two
 	// concurrent same-VRF RPCs cannot interleave (the manager Bind/Unbind and the
 	// exporter AddVRF/RemoveVRF are separate registries; the exporter's own opMu
@@ -32,8 +35,8 @@ type VrfBgpServer struct {
 	mu sync.Mutex
 }
 
-func NewVrfBgpServer(mgr *vrfbgp.Manager, exporter VrfExporter) *VrfBgpServer {
-	return &VrfBgpServer{mgr: mgr, exporter: exporter}
+func NewVrfBgpServer(mgr *vrfbgp.Manager, exporter VrfExporter, evpn *EvpnCoordinator) *VrfBgpServer {
+	return &VrfBgpServer{mgr: mgr, exporter: exporter, evpn: evpn}
 }
 
 // protoToBinding converts a wire VrfBgpBinding into the runtime Binding. The
@@ -90,10 +93,12 @@ func (s *VrfBgpServer) bindOne(b *v1.VrfBgpBinding) (*v1.VrfBgpBinding, *v1.Oper
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	binding := protoToBinding(b)
+	// Capture the prior binding once: the L3VPN restore path needs it to undo a
+	// failed re-bind, and the EVPN axis needs it to disable a bridge domain a
+	// re-bind moved off of.
+	prev, existed := s.mgr.Get(binding.VRFName)
 	if s.exporter != nil {
-		// AddVRF removes any prior enablement before re-enabling, so capture the
-		// prior binding to restore it if the re-bind fails.
-		prev, existed := s.mgr.Get(binding.VRFName)
+		// AddVRF removes any prior enablement before re-enabling.
 		if err := s.exporter.AddVRF(binding); err != nil {
 			reason := fmt.Sprintf("auto advertise: %v", err)
 			if existed {
@@ -118,6 +123,16 @@ func (s *VrfBgpServer) bindOne(b *v1.VrfBgpBinding) (*v1.VrfBgpBinding, *v1.Oper
 		}
 		return nil, &v1.OperationError{TriggerPrefix: b.GetVrfName(), Reason: err.Error()}
 	}
+	// EVPN binding axis: enable auto-advertise for the committed binding's bridge
+	// domain if its bridge is already up (a no-op otherwise; BridgeCreate enables
+	// it when the bridge arrives). A re-bind that moved the VRF to a different BD
+	// (or dropped it) disables the old BD first so it stops advertising.
+	if s.evpn != nil {
+		if existed && prev.BDID != 0 && prev.BDID != binding.BDID {
+			s.evpn.Disable(prev.BDID)
+		}
+		s.evpn.EnableForBinding(binding)
+	}
 	return b, nil
 }
 
@@ -130,12 +145,23 @@ func (s *VrfBgpServer) VrfBgpUnbind(
 		Errors:          make([]*v1.OperationError, 0),
 	}
 	for _, name := range req.Msg.VrfNames {
-		// Hold s.mu across the manager Unbind + exporter RemoveVRF so an unbind
-		// and a concurrent same-VRF bind cannot interleave.
+		// Hold s.mu across the manager Unbind + exporter/EVPN teardown so an unbind
+		// and a concurrent same-VRF bind cannot interleave. Capture the binding
+		// before Unbind so the EVPN axis knows which bridge domain to disable.
 		s.mu.Lock()
+		prev, existed := s.mgr.Get(name)
 		err := s.mgr.Unbind(name)
-		if err == nil && s.exporter != nil {
-			s.exporter.RemoveVRF(name)
+		if err == nil {
+			if s.exporter != nil {
+				s.exporter.RemoveVRF(name)
+			}
+			// EVPN: stop advertising RT2/RT3 for the unbound binding's bridge domain.
+			// Without this the exporter would keep originating under the removed
+			// RD/RT even though the binding is gone (the bridge device may still be
+			// up; a later re-bind re-enables it via the binding axis).
+			if s.evpn != nil && existed && prev.BDID != 0 {
+				s.evpn.Disable(prev.BDID)
+			}
 		}
 		s.mu.Unlock()
 		if err != nil {

--- a/pkg/server/vrf_bgp_test.go
+++ b/pkg/server/vrf_bgp_test.go
@@ -3,18 +3,54 @@ package server
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 	"testing"
 
 	"connectrpc.com/connect"
 	v1 "github.com/takehaya/vinbero/api/vinbero/v1"
 	"github.com/takehaya/vinbero/pkg/vrfbgp"
+	"go.uber.org/zap"
 )
+
+// fakeEvpnBridge records the EVPN coordinator's exporter calls so the
+// binding-axis tests can assert which bridge domains were enabled / disabled.
+type fakeEvpnBridge struct {
+	enabled  map[uint16]bool // bd_ids currently enabled
+	disabled []uint16        // each DisableBD's bd_id, in order
+}
+
+func (f *fakeEvpnBridge) EnableBD(b vrfbgp.Binding, _ uint32) error {
+	if f.enabled == nil {
+		f.enabled = make(map[uint16]bool)
+	}
+	f.enabled[b.BDID] = true
+	return nil
+}
+
+func (f *fakeEvpnBridge) DisableBD(bdID uint16) {
+	delete(f.enabled, bdID)
+	f.disabled = append(f.disabled, bdID)
+}
+
+func (f *fakeEvpnBridge) SIDsForBD(uint16) []string { return nil }
+
+// newEvpnCoordForTest builds a coordinator over hook, treating the bd_id ->
+// ifindex entries in bridges as the bridges that already exist; replayFDB is a
+// no-op.
+func newEvpnCoordForTest(hook EvpnBridgeHook, bridges map[uint16]uint32) *EvpnCoordinator {
+	return NewEvpnCoordinator(
+		hook,
+		func(bdID uint16) (uint32, bool) { ifindex, ok := bridges[bdID]; return ifindex, ok },
+		func(int) error { return nil },
+		zap.NewNop(),
+	)
+}
 
 // An out-of-range bd_id (> uint16) is rejected as a per-item error rather than
 // silently truncated into a different bridge domain.
 func TestVrfBgpBind_BdIdOutOfRange(t *testing.T) {
-	s := NewVrfBgpServer(vrfbgp.NewManager(), nil)
+	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil)
 	resp, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
 		Bindings: []*v1.VrfBgpBinding{
 			{VrfName: "evi-ok", ImportRts: []string{"65000:100"}, BdId: 100},
@@ -70,7 +106,7 @@ func (f *fakeVrfExporter) RemoveVRF(name string) {
 // A successful bind drives the exporter's AddVRF, and an unbind its RemoveVRF.
 func TestVrfBgpBind_DrivesExporter(t *testing.T) {
 	exp := &fakeVrfExporter{}
-	s := NewVrfBgpServer(vrfbgp.NewManager(), exp)
+	s := NewVrfBgpServer(vrfbgp.NewManager(), exp, nil)
 	resp, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
 		Bindings: []*v1.VrfBgpBinding{
 			{VrfName: "vrf1", Rd: "65100:200", ExportRts: []string{"65000:200"}, DefaultLocator: "LOC1", Redistribute: []string{"static"}},
@@ -97,7 +133,7 @@ func TestVrfBgpBind_DrivesExporter(t *testing.T) {
 // registry and the exporter stay consistent.
 func TestVrfBgpBind_AddVRFFailureRollsBack(t *testing.T) {
 	mgr := vrfbgp.NewManager()
-	s := NewVrfBgpServer(mgr, &fakeVrfExporter{addErr: errors.New("boom")})
+	s := NewVrfBgpServer(mgr, &fakeVrfExporter{addErr: errors.New("boom")}, nil)
 	resp, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
 		Bindings: []*v1.VrfBgpBinding{
 			{VrfName: "vrf1", Rd: "65100:200", DefaultLocator: "LOC1", Redistribute: []string{"static"}},
@@ -119,7 +155,7 @@ func TestVrfBgpBind_AddVRFFailureRollsBack(t *testing.T) {
 func TestVrfBgpBind_RebindFailureRestoresPrior(t *testing.T) {
 	mgr := vrfbgp.NewManager()
 	exp := &fakeVrfExporter{failOnRD: "65100:999"}
-	s := NewVrfBgpServer(mgr, exp)
+	s := NewVrfBgpServer(mgr, exp, nil)
 
 	// Initial bind succeeds.
 	if _, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
@@ -162,7 +198,7 @@ func TestVrfBgpBind_ConcurrentSameVRFStaysConsistent(t *testing.T) {
 	for i := range 300 {
 		mgr := vrfbgp.NewManager()
 		exp := &fakeVrfExporter{failOnRD: "fail"}
-		s := NewVrfBgpServer(mgr, exp)
+		s := NewVrfBgpServer(mgr, exp, nil)
 		var wg sync.WaitGroup
 		wg.Add(2)
 		go func() {
@@ -189,7 +225,7 @@ func TestVrfBgpBind_ConcurrentSameVRFStaysConsistent(t *testing.T) {
 // The new rd / redistribute / max_prefixes fields survive a bind -> list round
 // trip through protoToBinding and back, and import/export RTs are not swapped.
 func TestVrfBgpList_RoundTripsNewFields(t *testing.T) {
-	s := NewVrfBgpServer(vrfbgp.NewManager(), nil)
+	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil)
 	if _, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
 		Bindings: []*v1.VrfBgpBinding{
 			{
@@ -231,5 +267,88 @@ func TestVrfBgpList_RoundTripsNewFields(t *testing.T) {
 	}
 	if got := b.GetExportRts(); len(got) != 1 || got[0] != "65000:201" {
 		t.Errorf("export_rts = %v, want [65000:201] (import/export must not be swapped)", got)
+	}
+}
+
+// Binding a VRF whose bridge domain already has a bridge enables EVPN
+// auto-advertise on the binding axis; binding one whose bridge has not been
+// created yet is a no-op (BridgeCreate enables it when the bridge arrives).
+func TestVrfBgpBind_EnablesEvpnOnlyWhenBridgeUp(t *testing.T) {
+	hook := &fakeEvpnBridge{}
+	// bd_id 100's bridge exists; bd_id 200's does not.
+	coord := newEvpnCoordForTest(hook, map[uint16]uint32{100: 5})
+	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, coord)
+
+	if _, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
+		Bindings: []*v1.VrfBgpBinding{
+			{VrfName: "evi-up", Rd: "65100:100", BdId: 100},
+			{VrfName: "evi-down", Rd: "65100:200", BdId: 200},
+			{VrfName: "l3-only", Rd: "65100:300"}, // BDID 0: never EVPN
+		},
+	})); err != nil {
+		t.Fatalf("VrfBgpBind: %v", err)
+	}
+	if !hook.enabled[100] {
+		t.Errorf("bd_id 100 (bridge up) must be EVPN-enabled on bind; enabled=%v", hook.enabled)
+	}
+	if hook.enabled[200] {
+		t.Errorf("bd_id 200 (no bridge yet) must NOT be enabled on bind; enabled=%v", hook.enabled)
+	}
+	if hook.enabled[0] {
+		t.Errorf("an L3VPN-only binding (bd_id 0) must never touch EVPN; enabled=%v", hook.enabled)
+	}
+}
+
+// Unbinding a VRF disables its bridge domain's EVPN auto-advertise even though
+// the bridge device is still up — closing the gap where the exporter kept
+// originating RT2/RT3 under a removed RD/RT.
+func TestVrfBgpUnbind_DisablesEvpn(t *testing.T) {
+	hook := &fakeEvpnBridge{}
+	coord := newEvpnCoordForTest(hook, map[uint16]uint32{100: 5})
+	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, coord)
+
+	if _, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
+		Bindings: []*v1.VrfBgpBinding{{VrfName: "evi", Rd: "65100:100", BdId: 100}},
+	})); err != nil {
+		t.Fatalf("VrfBgpBind: %v", err)
+	}
+	if !hook.enabled[100] {
+		t.Fatalf("precondition: bd_id 100 should be enabled after bind; enabled=%v", hook.enabled)
+	}
+	if _, err := s.VrfBgpUnbind(context.Background(), connect.NewRequest(&v1.VrfBgpUnbindRequest{VrfNames: []string{"evi"}})); err != nil {
+		t.Fatalf("VrfBgpUnbind: %v", err)
+	}
+	if len(hook.disabled) != 1 || hook.disabled[0] != 100 {
+		t.Errorf("VrfBgpUnbind must DisableBD(100); disabled=%v", hook.disabled)
+	}
+	if hook.enabled[100] {
+		t.Errorf("bd_id 100 must be disabled after unbind; enabled=%v", hook.enabled)
+	}
+}
+
+// Re-binding a VRF onto a different bridge domain disables the old BD before
+// enabling the new one, so the vacated BD stops advertising.
+func TestVrfBgpBind_RebindMovingBridgeDomainDisablesOld(t *testing.T) {
+	hook := &fakeEvpnBridge{}
+	coord := newEvpnCoordForTest(hook, map[uint16]uint32{100: 5, 200: 6})
+	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, coord)
+
+	bind := func(bdID uint32) {
+		if _, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
+			Bindings: []*v1.VrfBgpBinding{{VrfName: "evi", Rd: "65100:100", BdId: bdID}},
+		})); err != nil {
+			t.Fatalf("VrfBgpBind bd_id %d: %v", bdID, err)
+		}
+	}
+	bind(100)
+	bind(200) // move the VRF to a different bridge domain
+	if !slices.Contains(hook.disabled, uint16(100)) {
+		t.Errorf("re-bind moving bd_id 100 -> 200 must DisableBD(100); disabled=%v", hook.disabled)
+	}
+	if !hook.enabled[200] {
+		t.Errorf("bd_id 200 must be enabled after the move; enabled=%v", hook.enabled)
+	}
+	if hook.enabled[100] {
+		t.Errorf("bd_id 100 must be disabled after the move; enabled=%v", hook.enabled)
 	}
 }


### PR DESCRIPTION
EVPN auto-advertise (RT2/RT3/RT4) のマージ後レビュー (OCR REQUEST CHANGES + Copilot 残) を clean main 上で対応する follow-up です。

## Blocker: binding-axis から EVPN を駆動

これまで EVPN auto-advertise は bridge device (`BridgeCreate`/`BridgeDelete`) でしか enable/disable せず、binding lifecycle (`VrfBgpBind`/`VrfBgpUnbind`) は L3VPN exporter しか駆動していませんでした。このため bridge が稼働したまま VRF を unbind すると、削除済みの RD/RT で RT2/RT3 を出し続けます (L3VPN の round-2 で潰したのと同じ registry vs exporter desync)。

新しい `EvpnCoordinator` を両軸 (device + binding) で共有し、enable (EnableBD + FDB replay) のシーケンスを 1 箇所に集約しました。

- `VrfBgpUnbind` が bridge domain の EVPN を disable します (bridge device はまだ生きていても止める。再 bind で binding axis から再 enable)。
- `VrfBgpBind` は bridge が既に存在すれば enable、未作成なら no-op (`BridgeCreate` が後で enable)。
- VRF を別の bd_id へ re-bind したら旧 bd_id を disable します。
- `ResourceManager.BridgeIfindexByBDID` を追加し binding axis から bridge ifindex を解決します。

## Should Fix / Copilot 残

- RT2 に per-bridge-domain `MaxPrefixes` cap を追加 (local MAC flood の blast radius を L3VPN と同様に制限)。
- FDB aging が aged local MAC の RT2 を withdraw します。`AgeFdbEntries` が削除したエントリ (`[]AgedFdbEntry`) を返すようにし、aging で消えた MAC が advertise されたまま残る blackhole を解消。remote (IsRemote) はもともと未 advertise なので skip。
- `EnableES` を push-first 化。新 RT4 を push してから旧を withdraw するので、push 失敗時に旧 advertise が残ります。同一 RD は gobgp AddPath supersede に任せます。
- RT4 の RD を `EsList` で echo。BPF esi_map は RD を持たないので、exporter state (`RDForESI`) から返します。BPF struct 変更なし。
- teardown 時に Close の前で MAC sink を detach し、withdraw 後の re-advertise を防止。
- `DumpBridge` の filter + sync-before-advertise を unit test 可能にし (neighList 注入)、テストを追加。
- test nit (`TestIsUnicastMAC` を `t.Run` 化)、docs/loadmap.md とコメントの naming 更新。

## テスト

- `go build ./...` / `go vet` / `gofmt` クリーン。
- `go test -race ./pkg/server/... ./pkg/bgp/export/... ./pkg/netresource/...` パス。binding-axis (enable-when-bridge-up / unbind-disables / rebind-moves-bd)、RT2 cap、push-first、RDForESI、aging-withdraw、DumpBridge filter/sync のテストを追加。
- `go test -exec sudo ./pkg/netlinkwatch/ ./pkg/bpf/ -run TestFdbAging` で live BPF map に対しても aging の戻り値変更を検証。