### PR TITLE
refactor(bgp): idempotent EVPN EnableBD + shared next-hop validation

### DIFF
--- a/pkg/bgp/export/evpn.go
+++ b/pkg/bgp/export/evpn.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"slices"
 	"sync"
 
 	"go.uber.org/zap"
@@ -43,6 +44,7 @@ type EVPNAdvertiser interface {
 // advertised, and the set of locally-learned MACs currently advertised as RT2.
 type bdState struct {
 	binding       vrfbgp.Binding
+	bridgeIfindex uint32     // the BD's Linux bridge device, for the re-enable idempotency check
 	sid           netip.Addr // End.DT2U (RT2 unicast)
 	sidStr        string     // sid.String(), rendered once (constant per BD)
 	dt2mSID       netip.Addr // End.DT2M (RT3 BUM flood)
@@ -104,7 +106,7 @@ func NewEVPNExporter(evpn EVPNAdvertiser, sidOps SidOps, locators *locator.Manag
 // idempotent: an ES already advertised is replaced. A push failure is returned
 // (the caller logs it; the ES data-plane entry is unaffected).
 func (e *EVPNExporter) EnableES(esi [bpf.ESILen]byte, rd string) error {
-	if err := checkNextHop(e.nextHop); err != nil {
+	if err := validateIPv6NextHop(e.nextHop); err != nil {
 		return err
 	}
 	if rd == "" {
@@ -178,22 +180,20 @@ func (e *EVPNExporter) disableESLocked(esi [bpf.ESILen]byte) {
 	delete(e.es, esi)
 }
 
-// checkNextHop validates the BGP next hop: a non-empty IPv6 (not v4-in-6)
-// address. SRv6 VPN transport is IPv6-only; an empty / IPv4 / malformed next hop
-// serializes into an RT2 no PE can forward toward. Mirrors the L3VPN exporter's
-// Start-time validation, applied per EnableBD since the EVPN path has no Start.
-func checkNextHop(nextHop string) error {
-	if nextHop == "" {
-		return fmt.Errorf("bgp.global.next_hop is required for EVPN auto advertise")
-	}
-	a, err := netip.ParseAddr(nextHop)
-	if err != nil {
-		return fmt.Errorf("bgp.global.next_hop %q is invalid: %w", nextHop, err)
-	}
-	if !a.Is6() || a.Is4In6() {
-		return fmt.Errorf("bgp.global.next_hop %q must be an IPv6 address", nextHop)
-	}
-	return nil
+// bdAdvertiseUnchanged reports whether re-enabling the bridge domain with binding
+// b and bridgeIfindex would produce the same advertisements and SIDs as the
+// current state st, so EnableBD can skip a needless disable + SID re-mint + RT3
+// re-advertise. It compares only the fields that shape what this exporter
+// originates: the RD and export RTs (RT2/RT3 keys + attributes), the default
+// locator (SID minting + RemoteSrc), the bridge ifindex (the End.DT2 L2 aux), and
+// the RT2 MaxPrefixes cap. Receive-only fields (import RTs, redistribute) do not
+// affect origination, so changing them alone is a no-op here.
+func bdAdvertiseUnchanged(st *bdState, b vrfbgp.Binding, bridgeIfindex uint32) bool {
+	return st.bridgeIfindex == bridgeIfindex &&
+		st.binding.RD == b.RD &&
+		st.binding.DefaultLocator == b.DefaultLocator &&
+		st.binding.MaxPrefixes == b.MaxPrefixes &&
+		slices.Equal(st.binding.ExportRTs, b.ExportRTs)
 }
 
 // EnableBD makes a bridge domain eligible for EVPN auto-advertise: it mints the
@@ -202,10 +202,11 @@ func checkNextHop(nextHop string) error {
 // bridge, and advertises RT3 so remote PEs flood BUM toward this node; local MACs
 // then advertise as RT2 via OnLocalMAC. bridgeIfindex is the BD's Linux bridge
 // device, needed for the L2 aux entry. A binding with a zero BDID, or without an
-// RD or a default locator, is rejected. It is idempotent: a BD already enabled
-// is replaced.
+// RD or a default locator, is rejected. It is idempotent: a re-enable whose
+// advertisement-affecting fields are unchanged is a no-op (no RT3/SID flap); any
+// real change re-enables cleanly (the prior enablement is torn down first).
 func (e *EVPNExporter) EnableBD(b vrfbgp.Binding, bridgeIfindex uint32) error {
-	if err := checkNextHop(e.nextHop); err != nil {
+	if err := validateIPv6NextHop(e.nextHop); err != nil {
 		return fmt.Errorf("vrf %q: %w", b.VRFName, err)
 	}
 	if b.BDID == 0 {
@@ -225,6 +226,15 @@ func (e *EVPNExporter) EnableBD(b vrfbgp.Binding, bridgeIfindex uint32) error {
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	// Idempotent re-enable: if the BD is already enabled and nothing that affects
+	// its advertisements changed, skip the disable + SID re-mint + RT3 re-advertise
+	// that would otherwise flap the bridge domain's routes for no change. A
+	// VrfBgpBind re-binds the same VRF on every call, so without this an unchanged
+	// re-bind would withdraw and re-originate RT3 + every RT2 and rewrite
+	// sid_function_map each time.
+	if st, ok := e.bds[b.BDID]; ok && bdAdvertiseUnchanged(st, b, bridgeIfindex) {
+		return nil
+	}
 	// Replace any existing enablement so a re-enable updates cleanly.
 	e.disableBDLocked(b.BDID)
 
@@ -243,13 +253,14 @@ func (e *EVPNExporter) EnableBD(b vrfbgp.Binding, bridgeIfindex uint32) error {
 		return fmt.Errorf("vrf %q: install End.DT2M SID: %w", b.VRFName, err)
 	}
 	st := &bdState{
-		binding:    b,
-		sid:        dt2uSID,
-		sidStr:     dt2uSID.String(),
-		dt2mSID:    dt2mSID,
-		dt2mSIDStr: dt2mSID.String(),
-		remoteSrc:  remoteSrc,
-		advertised: make(map[bgp.EVPNMACKey]struct{}),
+		binding:       b,
+		bridgeIfindex: bridgeIfindex,
+		sid:           dt2uSID,
+		sidStr:        dt2uSID.String(),
+		dt2mSID:       dt2mSID,
+		dt2mSIDStr:    dt2mSID.String(),
+		remoteSrc:     remoteSrc,
+		advertised:    make(map[bgp.EVPNMACKey]struct{}),
 	}
 	e.bds[b.BDID] = st
 	// Advertise RT3 (Inclusive Multicast) so remote PEs flood BUM traffic toward

--- a/pkg/bgp/export/evpn.go
+++ b/pkg/bgp/export/evpn.go
@@ -193,7 +193,21 @@ func bdAdvertiseUnchanged(st *bdState, b vrfbgp.Binding, bridgeIfindex uint32) b
 		st.binding.RD == b.RD &&
 		st.binding.DefaultLocator == b.DefaultLocator &&
 		st.binding.MaxPrefixes == b.MaxPrefixes &&
-		slices.Equal(st.binding.ExportRTs, b.ExportRTs)
+		sameRTSet(st.binding.ExportRTs, b.ExportRTs)
+}
+
+// sameRTSet reports whether two route-target lists carry the same set. BGP RT
+// extended communities are unordered, so an export-RT list reordered (e.g. by a
+// config rewrite) is the same advertisement and must not trigger a re-enable.
+// The lists are tiny; sort clones and compare (also handles duplicates).
+func sameRTSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	ac, bc := slices.Clone(a), slices.Clone(b)
+	slices.Sort(ac)
+	slices.Sort(bc)
+	return slices.Equal(ac, bc)
 }
 
 // EnableBD makes a bridge domain eligible for EVPN auto-advertise: it mints the

--- a/pkg/bgp/export/evpn_test.go
+++ b/pkg/bgp/export/evpn_test.go
@@ -401,6 +401,26 @@ func TestEnableBDIdempotentOnUnchangedReBind(t *testing.T) {
 	}
 }
 
+// Reordering the export RTs is not a change (BGP RTs are an unordered set), so a
+// re-bind that only permutes them must stay a no-op rather than flap.
+func TestEnableBDReorderedRTsIsNoop(t *testing.T) {
+	e, adv, sid := newTestEVPNExporter(t)
+	b := evpnTestBinding()
+	b.ExportRTs = []string{"65000:100", "65000:200"}
+	if err := e.EnableBD(b, 10); err != nil {
+		t.Fatalf("EnableBD: %v", err)
+	}
+	createdBefore := len(sid.created)
+	b.ExportRTs = []string{"65000:200", "65000:100"} // same set, reversed
+	if err := e.EnableBD(b, 10); err != nil {
+		t.Fatalf("reordered-RT re-EnableBD: %v", err)
+	}
+	if len(sid.created) != createdBefore || len(sid.deleted) != 0 || len(adv.withdrawnMcast) != 0 {
+		t.Errorf("a reordered-RT re-bind must be a no-op; created=%d deleted=%d withdrawnMcast=%d",
+			len(sid.created), len(sid.deleted), len(adv.withdrawnMcast))
+	}
+}
+
 // A re-enable that changes an advertisement-affecting field (here the bridge
 // ifindex) tears the BD down and re-enables cleanly: old SIDs released, new SIDs
 // minted, RT3 withdrawn then re-advertised.

--- a/pkg/bgp/export/evpn_test.go
+++ b/pkg/bgp/export/evpn_test.go
@@ -356,6 +356,74 @@ func TestOnLocalMACPushFailureNotRecorded(t *testing.T) {
 	}
 }
 
+// A re-enable whose advertisement-affecting fields are unchanged is a no-op: no
+// SID re-mint, no RT3 flap, and the already-advertised MACs stay tracked. A change
+// to a receive-only field (import RTs) is likewise a no-op for origination.
+func TestEnableBDIdempotentOnUnchangedReBind(t *testing.T) {
+	e, adv, sid := newTestEVPNExporter(t)
+	b := evpnTestBinding()
+	if err := e.EnableBD(b, 10); err != nil {
+		t.Fatalf("EnableBD: %v", err)
+	}
+	mac := net.HardwareAddr{0xaa, 0, 0, 0, 0, 1}
+	e.OnLocalMAC(100, mac, true)
+	createdBefore, mcastBefore := len(sid.created), len(adv.pushedMcast)
+
+	// Re-bind with an identical binding + ifindex.
+	if err := e.EnableBD(b, 10); err != nil {
+		t.Fatalf("re-EnableBD: %v", err)
+	}
+	if len(sid.created) != createdBefore {
+		t.Errorf("unchanged re-bind must not re-mint SIDs; created %d -> %d", createdBefore, len(sid.created))
+	}
+	if len(sid.deleted) != 0 {
+		t.Errorf("unchanged re-bind must not release SIDs; deleted=%d", len(sid.deleted))
+	}
+	if len(adv.pushedMcast) != mcastBefore || len(adv.withdrawnMcast) != 0 {
+		t.Errorf("unchanged re-bind must not flap RT3; pushedMcast=%d withdrawnMcast=%d", len(adv.pushedMcast), len(adv.withdrawnMcast))
+	}
+
+	// A change limited to a receive-only field (import RTs) does not affect what
+	// this exporter originates, so it is still a no-op.
+	b.ImportRTs = []string{"65000:999"}
+	if err := e.EnableBD(b, 10); err != nil {
+		t.Fatalf("import-rt-only re-EnableBD: %v", err)
+	}
+	if len(sid.deleted) != 0 || len(adv.withdrawnMcast) != 0 {
+		t.Errorf("a receive-only import_rts change must not re-enable origination; deleted=%d withdrawnMcast=%d", len(sid.deleted), len(adv.withdrawnMcast))
+	}
+
+	// The MAC advertised before the re-binds is still tracked (state was preserved,
+	// not rebuilt): withdrawing it fires exactly one withdraw.
+	e.OnLocalMAC(100, mac, false)
+	if len(adv.withdrawn) != 1 {
+		t.Errorf("the pre-rebind MAC must still be tracked after a no-op re-bind; withdrawn=%d", len(adv.withdrawn))
+	}
+}
+
+// A re-enable that changes an advertisement-affecting field (here the bridge
+// ifindex) tears the BD down and re-enables cleanly: old SIDs released, new SIDs
+// minted, RT3 withdrawn then re-advertised.
+func TestEnableBDReEnablesOnChange(t *testing.T) {
+	e, adv, sid := newTestEVPNExporter(t)
+	b := evpnTestBinding()
+	if err := e.EnableBD(b, 10); err != nil {
+		t.Fatalf("EnableBD: %v", err)
+	}
+	if err := e.EnableBD(b, 20); err != nil { // bridge ifindex changed 10 -> 20
+		t.Fatalf("changed re-EnableBD: %v", err)
+	}
+	if len(sid.deleted) != 2 {
+		t.Errorf("a changed re-bind must release both old SIDs; deleted=%d want 2", len(sid.deleted))
+	}
+	if len(sid.created) != 4 {
+		t.Errorf("a changed re-bind must re-mint both SIDs; created=%d want 4", len(sid.created))
+	}
+	if len(adv.withdrawnMcast) != 1 || len(adv.pushedMcast) != 2 {
+		t.Errorf("a changed re-bind must flap RT3; pushedMcast=%d withdrawnMcast=%d", len(adv.pushedMcast), len(adv.withdrawnMcast))
+	}
+}
+
 // testESI is a Type-0 ESI whose value's high-order 6 octets (bytes 1..6) encode
 // the MAC aa:bb:cc:dd:ee:ff, which RFC 7432 Sec. 7.6 derives as the ES-Import RT.
 var testESI = [bpf.ESILen]byte{0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x01, 0x02, 0x03}

--- a/pkg/bgp/export/exporter.go
+++ b/pkg/bgp/export/exporter.go
@@ -172,11 +172,6 @@ func validateIPv6NextHop(nextHop string) error {
 	return nil
 }
 
-// validateNextHop checks this exporter's configured next hop once at Start.
-func (e *Exporter) validateNextHop() error {
-	return validateIPv6NextHop(e.nextHop)
-}
-
 // Start validates the next hop, enables every VRF binding that lists a
 // redistribute set, enables the IPv6 unicast underlay if configured, and begins
 // watching the kernel routing tables. EnableVRF mints each VRF's End.DT4/DT6
@@ -186,7 +181,7 @@ func (e *Exporter) validateNextHop() error {
 // VRFs already enabled in this call are unwound so a partial startup leaves no
 // orphaned SID.
 func (e *Exporter) Start(ctx context.Context) error {
-	if err := e.validateNextHop(); err != nil {
+	if err := validateIPv6NextHop(e.nextHop); err != nil {
 		return err
 	}
 	enabled := make([]string, 0)

--- a/pkg/bgp/export/exporter.go
+++ b/pkg/bgp/export/exporter.go
@@ -153,21 +153,28 @@ func New(advertiser bgp.RouteAdvertiser, sidOps SidOps, locators *locator.Manage
 	return e
 }
 
-// validateNextHop checks the BGP next hop once at Start: it must be a non-empty
-// IPv6 (not v4-mapped) address. SRv6 VPN / unicast transport is IPv6-only; an
-// IPv4 next hop serializes into a route no PE can forward toward.
-func (e *Exporter) validateNextHop() error {
-	if e.nextHop == "" {
+// validateIPv6NextHop checks the BGP next hop: a non-empty IPv6 (not v4-mapped)
+// address. SRv6 VPN / unicast / EVPN transport is IPv6-only; an empty / IPv4 /
+// malformed next hop serializes into a route no PE can forward toward. Shared by
+// the L3VPN exporter's Start-time check and the EVPN exporter's per-EnableBD/ES
+// check (the EVPN path has no Start).
+func validateIPv6NextHop(nextHop string) error {
+	if nextHop == "" {
 		return fmt.Errorf("bgp.global.next_hop is required for auto advertise")
 	}
-	a, err := netip.ParseAddr(e.nextHop)
+	a, err := netip.ParseAddr(nextHop)
 	if err != nil {
-		return fmt.Errorf("bgp.global.next_hop %q is invalid: %w", e.nextHop, err)
+		return fmt.Errorf("bgp.global.next_hop %q is invalid: %w", nextHop, err)
 	}
 	if !a.Is6() || a.Is4In6() {
-		return fmt.Errorf("bgp.global.next_hop %q must be an IPv6 address", e.nextHop)
+		return fmt.Errorf("bgp.global.next_hop %q must be an IPv6 address", nextHop)
 	}
 	return nil
+}
+
+// validateNextHop checks this exporter's configured next hop once at Start.
+func (e *Exporter) validateNextHop() error {
+	return validateIPv6NextHop(e.nextHop)
 }
 
 // Start validates the next hop, enables every VRF binding that lists a


### PR DESCRIPTION
PR #55 の OCR レビューで見送った residual / cleanup を1本にまとめた follow-up です。

## EnableBD の idempotency (OCR Should-Fix #2)

`VrfBgpBind` は呼ばれるたびに同じ VRF を re-bind するため、これまで変更のない re-bind でも `EnableBD` が disable → SID 再 mint → RT3 と全 RT2 を withdraw して再 advertise していました (control-plane の flap)。

advertise に影響するフィールド (RD / export RTs / default locator / bridge ifindex / MaxPrefixes) が不変なら `EnableBD` を no-op にしました。実際に変わったときだけ従来どおり tear down して re-enable します。受信専用フィールド (import RTs / redistribute) は origination に影響しないので比較から除外しています。`bdState` に `bridgeIfindex` を保持して比較に使います。

これは PR #55 で push-first 化した EnableES と同じ「無用な flap を避ける」方針を RT2/RT3 側にも適用したものです。

## next-hop validation の重複統合 (OCR Suggestion)

`evpn.go` の `checkNextHop` と `exporter.go` の `Exporter.validateNextHop` が byte 単位で同一だったので、package-level の `validateIPv6NextHop(nextHop)` に集約し、両者がそれを呼ぶようにしました。

## テスト

- `TestEnableBDIdempotentOnUnchangedReBind`: 不変 re-bind で SID 再 mint も RT3 flap も起きず、re-bind 前に advertise した MAC が tracking に残ることを確認 (state が再構築されていない)。受信専用 import_rts のみの変更も no-op。
- `TestEnableBDReEnablesOnChange`: bridge ifindex を変えると旧 SID を release・新 SID を mint・RT3 を withdraw 後に再 advertise することを確認。
- `go build ./...` / `go vet` / `gofmt` クリーン、`-race` で export / server / netresource パス。

## 引き続き見送り (別 follow-up)

global な origination cap (今は per-BD のみ、unauth surface で BD 多数に分散可)、`MaxPrefixes` の default 見直し、`DumpBridge` が `VrfBgpBind` ごとに全 host NeighList する点。いずれも既存 L3VPN と同質か rare path のため別途。