### PR TITLE
refactor(bgp): make L3VPN AddVRF idempotent on an unchanged re-bind

### DIFF
--- a/pkg/bgp/export/evpn.go
+++ b/pkg/bgp/export/evpn.go
@@ -193,14 +193,16 @@ func bdAdvertiseUnchanged(st *bdState, b vrfbgp.Binding, bridgeIfindex uint32) b
 		st.binding.RD == b.RD &&
 		st.binding.DefaultLocator == b.DefaultLocator &&
 		st.binding.MaxPrefixes == b.MaxPrefixes &&
-		sameRTSet(st.binding.ExportRTs, b.ExportRTs)
+		sameStringSet(st.binding.ExportRTs, b.ExportRTs)
 }
 
-// sameRTSet reports whether two route-target lists carry the same set. BGP RT
-// extended communities are unordered, so an export-RT list reordered (e.g. by a
-// config rewrite) is the same advertisement and must not trigger a re-enable.
-// The lists are tiny; sort clones and compare (also handles duplicates).
-func sameRTSet(a, b []string) bool {
+// sameStringSet reports whether two string lists carry the same set, ignoring
+// order. Used for the re-bind idempotency check on fields that are semantically
+// unordered sets: BGP route-target extended communities and the redistribute
+// protocol list. Reordering them (e.g. a config rewrite) is the same
+// advertisement and must not trigger a re-enable. The lists are tiny; sort clones
+// and compare (also handles duplicates).
+func sameStringSet(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/pkg/bgp/export/exporter.go
+++ b/pkg/bgp/export/exporter.go
@@ -400,12 +400,16 @@ func (e *Exporter) AddVRF(b vrfbgp.Binding) error {
 
 // vrfAdvertiseUnchanged reports whether re-enabling b would produce the same
 // VPNv4/VPNv6 advertisements and SIDs as the current state, so AddVRF can skip a
-// needless flap. It compares the binding fields that shape origination -- RD and
-// export RTs (route keys + attributes), default locator (SID minting),
-// MaxPrefixes (cap), and the redistribute set (which prefixes export) -- plus the
-// resolved device: a VRF netdev recreated under the same name with a new
-// ifindex/table must re-enable so the End.DT4/DT6 aux and the table mapping
-// refresh. A resolve failure returns false so the normal path surfaces the error.
+// needless flap. It compares the cheap binding fields that shape origination
+// FIRST -- RD and export RTs (route keys + attributes), default locator (SID
+// minting), MaxPrefixes (cap), and the redistribute set (which prefixes export) --
+// so a binding change forces a re-enable without a netlink resolve. Only when the
+// binding matches does it resolve the device, since the one remaining trigger is a
+// VRF netdev recreated under the same name with a new ifindex/table (the
+// End.DT4/DT6 aux and table mapping would be stale). A transient resolve failure
+// on an otherwise-unchanged binding is treated as unchanged: tearing down a
+// working VRF over a momentary netlink error is worse than leaving it, and a later
+// re-bind reconciles once resolve recovers.
 func (e *Exporter) vrfAdvertiseUnchanged(b vrfbgp.Binding) bool {
 	e.mu.Lock()
 	st, ok := e.vrfs[b.VRFName]
@@ -413,17 +417,18 @@ func (e *Exporter) vrfAdvertiseUnchanged(b vrfbgp.Binding) bool {
 	if !ok {
 		return false
 	}
-	ifindex, table, err := e.resolver.Resolve(b.VRFName)
-	if err != nil {
+	if st.binding.RD != b.RD ||
+		st.binding.DefaultLocator != b.DefaultLocator ||
+		st.binding.MaxPrefixes != b.MaxPrefixes ||
+		!sameStringSet(st.binding.ExportRTs, b.ExportRTs) ||
+		!sameStringSet(st.binding.Redistribute, b.Redistribute) {
 		return false
 	}
-	return st.table == table &&
-		st.ifindex == ifindex &&
-		st.binding.RD == b.RD &&
-		st.binding.DefaultLocator == b.DefaultLocator &&
-		st.binding.MaxPrefixes == b.MaxPrefixes &&
-		sameStringSet(st.binding.ExportRTs, b.ExportRTs) &&
-		sameStringSet(st.binding.Redistribute, b.Redistribute)
+	ifindex, table, err := e.resolver.Resolve(b.VRFName)
+	if err != nil {
+		return true
+	}
+	return st.ifindex == ifindex && st.table == table
 }
 
 // enableAndWatch enables one VRF binding and registers its table with the

--- a/pkg/bgp/export/exporter.go
+++ b/pkg/bgp/export/exporter.go
@@ -71,6 +71,7 @@ type UnderlayConfig struct {
 type vrfState struct {
 	binding    vrfbgp.Binding
 	table      uint32
+	ifindex    uint32 // the VRF l3mdev device, for the re-bind idempotency check
 	v4SID      netip.Addr
 	v6SID      netip.Addr
 	advertised map[bgp.RouteKey]struct{}
@@ -302,6 +303,7 @@ func (e *Exporter) EnableVRF(b vrfbgp.Binding) (uint32, error) {
 	st := &vrfState{
 		binding:    b,
 		table:      table,
+		ifindex:    ifindex,
 		v4SID:      v4SID,
 		v6SID:      v6SID,
 		advertised: make(map[bgp.RouteKey]struct{}),
@@ -375,6 +377,15 @@ func (e *Exporter) AddVRF(b vrfbgp.Binding) error {
 		// Stop has begun; refuse new enablement so no dumpWG.Go races dumpWG.Wait.
 		return fmt.Errorf("exporter is shutting down")
 	}
+	// Idempotent re-bind: if the VRF is already enabled and nothing that affects its
+	// advertisements changed (binding export fields + the resolved device), skip the
+	// disable + Endpoint-SID re-mint + table re-register + replay below, which would
+	// otherwise withdraw and re-originate every VPNv4/VPNv6 prefix for no change.
+	// VrfBgpBind re-binds the same VRF on every call, so without this an unchanged
+	// re-bind flaps the whole VRF (the EVPN EnableBD path guards the same way).
+	if e.vrfAdvertiseUnchanged(b) {
+		return nil
+	}
 	// Replace any existing enablement so a re-bind updates cleanly instead of
 	// hitting EnableVRF's already-enabled check, which would leave the exporter
 	// advertising while the handler rolls the manager binding back (desync).
@@ -385,6 +396,34 @@ func (e *Exporter) AddVRF(b vrfbgp.Binding) error {
 		return nil
 	}
 	return e.enableAndWatch(b, true)
+}
+
+// vrfAdvertiseUnchanged reports whether re-enabling b would produce the same
+// VPNv4/VPNv6 advertisements and SIDs as the current state, so AddVRF can skip a
+// needless flap. It compares the binding fields that shape origination -- RD and
+// export RTs (route keys + attributes), default locator (SID minting),
+// MaxPrefixes (cap), and the redistribute set (which prefixes export) -- plus the
+// resolved device: a VRF netdev recreated under the same name with a new
+// ifindex/table must re-enable so the End.DT4/DT6 aux and the table mapping
+// refresh. A resolve failure returns false so the normal path surfaces the error.
+func (e *Exporter) vrfAdvertiseUnchanged(b vrfbgp.Binding) bool {
+	e.mu.Lock()
+	st, ok := e.vrfs[b.VRFName]
+	e.mu.Unlock()
+	if !ok {
+		return false
+	}
+	ifindex, table, err := e.resolver.Resolve(b.VRFName)
+	if err != nil {
+		return false
+	}
+	return st.table == table &&
+		st.ifindex == ifindex &&
+		st.binding.RD == b.RD &&
+		st.binding.DefaultLocator == b.DefaultLocator &&
+		st.binding.MaxPrefixes == b.MaxPrefixes &&
+		sameStringSet(st.binding.ExportRTs, b.ExportRTs) &&
+		sameStringSet(st.binding.Redistribute, b.Redistribute)
 }
 
 // enableAndWatch enables one VRF binding and registers its table with the

--- a/pkg/bgp/export/exporter_test.go
+++ b/pkg/bgp/export/exporter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/netip"
+	"slices"
 	"testing"
 
 	"go.uber.org/zap"
@@ -492,6 +493,73 @@ func TestAddVRFRollsBackOnRegisterTableFailure(t *testing.T) {
 	if len(sid.created) != 2 || len(sid.deleted) != 2 {
 		t.Errorf("both Endpoint SIDs must be minted then rolled back; created=%d deleted=%d",
 			len(sid.created), len(sid.deleted))
+	}
+}
+
+// vrfFullBinding is testBinding plus a redistribute set and a second export RT,
+// so the set/order-independence of the re-bind idempotency check is exercised.
+func vrfFullBinding() vrfbgp.Binding {
+	b := testBinding()
+	b.ExportRTs = []string{"65000:100", "65000:200"}
+	b.Redistribute = []string{"connected", "static"}
+	return b
+}
+
+// vrfAdvertiseUnchanged treats an identical re-bind (and one that only reorders
+// the RT / redistribute sets) as unchanged, but any change to an
+// advertisement-affecting field forces a re-enable.
+func TestVRFAdvertiseUnchanged(t *testing.T) {
+	e, _, _ := newTestExporter(t)
+	b := vrfFullBinding()
+	if _, err := e.EnableVRF(b); err != nil {
+		t.Fatalf("EnableVRF: %v", err)
+	}
+	if !e.vrfAdvertiseUnchanged(b) {
+		t.Error("an identical re-bind must be unchanged")
+	}
+	reordered := b
+	reordered.ExportRTs = []string{"65000:200", "65000:100"}
+	reordered.Redistribute = []string{"static", "connected"}
+	if !e.vrfAdvertiseUnchanged(reordered) {
+		t.Error("reordered RT / redistribute sets must be unchanged")
+	}
+	for name, mut := range map[string]func(*vrfbgp.Binding){
+		"rd":           func(x *vrfbgp.Binding) { x.RD = "65000:999" },
+		"export rts":   func(x *vrfbgp.Binding) { x.ExportRTs = []string{"65000:100"} },
+		"redistribute": func(x *vrfbgp.Binding) { x.Redistribute = []string{"connected"} },
+		"locator":      func(x *vrfbgp.Binding) { x.DefaultLocator = "LOC2" },
+		"max prefixes": func(x *vrfbgp.Binding) { x.MaxPrefixes = 5 },
+	} {
+		changed := b
+		changed.ExportRTs = slices.Clone(b.ExportRTs)
+		changed.Redistribute = slices.Clone(b.Redistribute)
+		mut(&changed)
+		if e.vrfAdvertiseUnchanged(changed) {
+			t.Errorf("a changed %s must force re-enable", name)
+		}
+	}
+	other := b
+	other.VRFName = "vrf2"
+	if e.vrfAdvertiseUnchanged(other) {
+		t.Error("an unenabled VRF must not report unchanged")
+	}
+}
+
+// A VRF netdev recreated under the same name with a new ifindex or table must
+// force a re-enable, so the End.DT4/DT6 aux and table mapping refresh.
+func TestVRFAdvertiseUnchangedDetectsDeviceChange(t *testing.T) {
+	e, _, _ := newTestExporter(t) // fakeResolver{ifindex:10, table:testTable}
+	b := vrfFullBinding()
+	if _, err := e.EnableVRF(b); err != nil {
+		t.Fatalf("EnableVRF: %v", err)
+	}
+	e.resolver = fakeResolver{ifindex: 11, table: testTable}
+	if e.vrfAdvertiseUnchanged(b) {
+		t.Error("a recreated device (new ifindex) must force re-enable")
+	}
+	e.resolver = fakeResolver{ifindex: 10, table: testTable + 1}
+	if e.vrfAdvertiseUnchanged(b) {
+		t.Error("a changed routing table must force re-enable")
 	}
 }
 

--- a/pkg/bgp/export/exporter_test.go
+++ b/pkg/bgp/export/exporter_test.go
@@ -563,6 +563,26 @@ func TestVRFAdvertiseUnchangedDetectsDeviceChange(t *testing.T) {
 	}
 }
 
+// A transient resolve failure on an otherwise-unchanged binding stays a no-op
+// (don't tear down a working VRF over a momentary netlink error), but a binding
+// change is still detected without needing resolve at all.
+func TestVRFAdvertiseUnchangedResolveFailure(t *testing.T) {
+	e, _, _ := newTestExporter(t)
+	b := vrfFullBinding()
+	if _, err := e.EnableVRF(b); err != nil {
+		t.Fatalf("EnableVRF: %v", err)
+	}
+	e.resolver = fakeResolver{err: errors.New("netlink busy")}
+	if !e.vrfAdvertiseUnchanged(b) {
+		t.Error("a transient resolve failure on an unchanged binding must stay a no-op")
+	}
+	changed := b
+	changed.RD = "65000:999"
+	if e.vrfAdvertiseUnchanged(changed) {
+		t.Error("a binding change must force re-enable even when resolve would fail (binding compared first)")
+	}
+}
+
 // RemoveVRF of an unknown VRF is a no-op: nothing to withdraw, no SID to release.
 func TestRemoveVRFUnknownIsNoop(t *testing.T) {
 	e, adv, sid := newTestExporter(t)


### PR DESCRIPTION
PR #56 で EVPN の `EnableBD` を idempotent 化したときに /simplify の altitude レビューが指摘した、L3VPN 側の同じ re-bind flap を対称に潰す follow-up です。

## 背景

`VrfBgpBind` は呼ばれるたびに同じ VRF を re-bind します。これまで L3VPN の `Exporter.AddVRF` は無条件に `removeVRFLocked` → `enableAndWatch` していたため、変更のない re-bind でも全 VPNv4/VPNv6 prefix を withdraw して再 originate し、End.DT4/DT6 SID を再 mint、table を再登録 + replay していました。EVPN 側は #56 で直しましたが L3VPN が非対称に残っていました。

## 変更

`AddVRF` は `vrfAdvertiseUnchanged` のとき no-op にします。判定は origination に影響するフィールド (RD / export RTs / default locator / MaxPrefixes / redistribute set) が不変で、かつ VRF device が同じ ifindex・table に解決されることを条件にします。同名で netdev が作り直された (ifindex/table が変わった) 場合は End.DT4/DT6 aux と table マッピングを更新するため re-enable します。比較用に `vrfState` へ解決済み ifindex を保持します。

順序非依存の集合比較は `sameRTSet` を `sameStringSet` に一般化しました (redistribute のプロトコル列も順序に意味のない集合なので同じ比較を使います)。これで両 exporter が同じ方針で re-bind を guard します。

## テスト

- `TestVRFAdvertiseUnchanged`: 同一 re-bind と RT/redistribute の順序入れ替えは unchanged、RD / export RTs / redistribute / locator / max_prefixes のいずれかが変わると re-enable。
- `TestVRFAdvertiseUnchangedDetectsDeviceChange`: 同名 device の ifindex 変更・table 変更を検知して re-enable。
- `go build ./...` / `go vet` / `gofmt` クリーン、`-race` で export / server パス。

挙動変更ではなく無用な flap の除去です (不変 re-bind が観測可能な広告状態を変えなくなる)。EVPN #56 と対になる cleanup です。