### PR TITLE
test(interop): drive mup-2site origination through MupService

### DIFF
--- a/examples/interop-clab/scenarios/mup-2site/mup-c/start.sh
+++ b/examples/interop-clab/scenarios/mup-2site/mup-c/start.sh
@@ -39,7 +39,7 @@ sleep 6
 # T1ST (downlink): UE 10.1.0.1, gNB endpoint 172.16.0.1. mup-pe resolves the
 # interwork SID from the ISD covering 172.16.0.0/24, composes Args.Mob.Session
 # onto it, and installs the H.Encaps; mup-gw's End.M.GTP4.E emits GTP-U.
-/usr/local/bin/vbctl bgp advertise-mup --route-type t1st \
+/usr/local/bin/vbctl mup create --route-type t1st \
     --rd 65100:1 --prefix 10.1.0.1/32 \
     --teid 256 --qfi 9 --endpoint 172.16.0.1 \
     --next-hop 2001:db8:ff::a || true
@@ -47,10 +47,11 @@ sleep 6
 # T2ST (uplink): gNB GTP-U to the N3 endpoint, segment id 1:2. mup-gw resolves
 # the direct SID from the DSD carrying segment id 1:2, installs the F-TEID entry
 # + H.M.GTP4.D_TEID gate; mup-pe's End.DT4 delivers to the DN.
-/usr/local/bin/vbctl bgp advertise-mup --route-type t2st \
+/usr/local/bin/vbctl mup create --route-type t2st \
     --rd 65100:1 --endpoint 172.16.0.254 \
     --teid 256 --teid-len 32 \
     --segment-id2 1 --segment-id4 2 \
     --next-hop 2001:db8:ff::d || true
 
-echo "[start.sh] mup-c (MUP Controller) advertised T1ST/T2ST (SID-less; resolved by gateways)"
+echo "[start.sh] mup-c (MUP Controller) originated T1ST/T2ST via MupService (SID-less; resolved by gateways); local MUP table:"
+/usr/local/bin/vbctl mup list || true

--- a/examples/interop-clab/scenarios/mup-2site/mup-gw/start.sh
+++ b/examples/interop-clab/scenarios/mup-2site/mup-gw/start.sh
@@ -47,14 +47,17 @@ for _ in $(seq 1 30); do /usr/local/bin/vbctl locator list >/dev/null 2>&1 && br
     --trigger-prefix fd00:a::/56 --action END_M_GTP4_E \
     --gtp-v4-src-addr 172.16.0.254 --args-offset 7 || true
 
-# Advertise this gateway's Interwork Segment Discovery route: it hosts the
+# Originate this gateway's Interwork Segment Discovery route via MupService
+# (a managed local table auto-advertised into SAFI 85): it hosts the
 # End.M.GTP4.E interwork segment (SID fd00:a:0:1::) reachable for the gNB N3
 # block. The controller's (SID-less) T1ST resolves its interwork SID from this
 # ISD by gNB endpoint, so the SID is carried here, not on the T1ST.
 sleep 6
-/usr/local/bin/vbctl bgp advertise-mup --route-type isd \
+/usr/local/bin/vbctl mup create --route-type isd \
     --rd 65100:1 --prefix 172.16.0.0/24 \
     --sid fd00:a:0:1:: --next-hop 2001:db8:ff::a || true
+echo "[start.sh] mup-gw originated ISD; local MUP table:"
+/usr/local/bin/vbctl mup list || true
 
 # Pre-resolve neighbours so bpf_fib_lookup on the redirect path succeeds.
 ping6 -c 1 -W 2 2001:db8:1::2 >/dev/null 2>&1 || true

--- a/examples/interop-clab/scenarios/mup-2site/mup-pe/start.sh
+++ b/examples/interop-clab/scenarios/mup-2site/mup-pe/start.sh
@@ -53,14 +53,17 @@ for _ in $(seq 1 30); do /usr/local/bin/vbctl locator list >/dev/null 2>&1 && br
 /usr/local/bin/vbctl sid create \
     --trigger-prefix fd00:d:0:1::/128 --action END_DT4 --vrf-name vrf-cust || true
 
-# Advertise this PE's Direct Segment Discovery route: it hosts the End.DT4
-# direct segment (SID fd00:d:0:1::) tagged with a MUP Extended Community segment
-# id, which the controller's T2ST resolves against.
+# Originate this PE's Direct Segment Discovery route via MupService (a managed
+# local table auto-advertised into SAFI 85): it hosts the End.DT4 direct segment
+# (SID fd00:d:0:1::) tagged with a MUP Extended Community segment id, which the
+# controller's T2ST resolves against.
 sleep 6
-/usr/local/bin/vbctl bgp advertise-mup --route-type dsd \
+/usr/local/bin/vbctl mup create --route-type dsd \
     --rd 65100:1 --address 10.0.0.1 \
     --segment-id2 1 --segment-id4 2 \
     --sid fd00:d:0:1:: --next-hop 2001:db8:ff::d || true
+echo "[start.sh] mup-pe originated DSD; local MUP table:"
+/usr/local/bin/vbctl mup list || true
 
 # Pre-resolve neighbours for the redirect FIB lookups.
 ping6 -c 1 -W 2 2001:db8:2::2 >/dev/null 2>&1 || true


### PR DESCRIPTION
mup-2site interop シナリオの MUP route 起点を、手動の `vbctl bgp advertise-mup`(fire-and-forget)から、managed な `vbctl mup create`(MupService CRUD)に移行します。新しい MupService の E2E になります。

## 変更

- mup-gw → ISD、mup-pe → DSD、mup-c → T1ST/T2ST を `vbctl mup create` で起点に。フラグは同一(同じ `BgpMupRoute`)なので、広告される SAFI 85 経路は不変です。
- 各ノードで `vbctl mup list` を実行し、シナリオが新しい local table read も叩くようにしました。
- `--next-hop` は全箇所で明示維持です。どのノードも `bgp.global.next_hop` を設定しておらず、特に mup-c は session route の next-hop を自ノードではなく解決先 gateway(::a/::d)に向けるため、config default に頼れません。

## 検証

- `bash -n` で 3 つの start.sh は構文 OK。README / test.sh は advertise-mup を参照しておらず変更不要。
- 実走は interop-clab ワークフロー(Docker + containerlab + sudo)で検証されます。`vbctl mup` は #59 で main 済みなので CLI ビルドは影響なし。

SR Policy の interop は SAFI 73 controller 対向(Cisco XRd / Nokia SR OS)が要るため引き続き保留です。