### PR TITLE
docs(examples): refresh stale READMEs (netns + interop-clab)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,13 @@
 
 VinberoのSRv6機能を実際に試せるPlayground環境です。
 
-GitHub Actionsのmatrix strategyにより、各exampleは独立したジョブとして並列実行されます。
+ここには2系統のサンプルがあります。
+
+- netns example（このディレクトリ直下の `end-*` / `headend-*` / `gtp*-*`）。各 SRv6 機能を単独の Linux network namespace 上で検証する自己完結スクリプト。`test.yaml` の matrix で並列実行します。
+- interop ラボ（[`interop-clab/`](interop-clab/)）。Vinbero を FRR など第三者実装と相互運用させる containerlab シナリオ群。
+
+このページは netns example を説明します。interop ラボは [`interop-clab/README.md`](interop-clab/README.md) を参照してください。
+
 ## クイックスタート
 
 ```bash
@@ -12,7 +18,7 @@ sudo ./test.sh     # テスト実行
 sudo ./teardown.sh # クリーンアップ
 ```
 
-各exampleはディレクトリ名をプレフィックスとして独自のnamespace空間を持つため（例: `end-host1`, `end-router1`）、衝突なく並列実行できます。
+各 example は固有のプレフィックスで独自の namespace 空間を持つため（例: `end-host1`、`dx4-router1`）、衝突なく並列実行できます。
 
 ## 新しいExampleの追加
 1. **ディレクトリを作成**: `examples/<name>/`
@@ -22,12 +28,13 @@ sudo ./teardown.sh # クリーンアップ
    - `test.sh`: テスト実行
    - `teardown.sh`: クリーンアップ
    - `vinbero_*.yaml`: Vinbero設定
-3. **プレフィックス設定**:
+3. **プレフィックス設定**: 他 example と衝突しない固有のプレフィックスを `TOPO_NS_PREFIX` に設定します。ディレクトリ名から導くか、短い固有文字列を直接指定します。
    ```bash
    EXAMPLE_NAME="$(basename "$SCRIPT_DIR")"
    export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-${EXAMPLE_NAME}-}"
+   # または短い固有プレフィックス: export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-dx4-}"
    ```
-4. **ワークフローに追加**: `.github/workflows/examples.yaml`のmatrixに追加
+4. **ワークフローに追加**: `.github/workflows/test.yaml`の`Integration Test`ジョブの`matrix.example`に追加
 
 ## 共通機能
 
@@ -52,6 +59,8 @@ sudo ./teardown.sh # クリーンアップ
 | `end-dt6/` | End.DT6 | VRF対応IPv6テーブルルックアップ |
 | `end-dt2/` | End.DT2 | L2VPN（FDB学習 + ブリッジ転送） |
 | `end-dt2-p2mp/` | End.DT2 P2MP | マルチサイトL2VPN（BUMフラッディング） |
+| `end-dt2m-multihomed/` | End.DT2M | multi-homed L2VPN（DF election + split-horizon） |
+| `end-dx2v/` | End.DX2V | VLAN単位のL2クロスコネクト |
 
 ### Headend Functions
 | ディレクトリ | 機能 | 説明 |

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ VinberoのSRv6機能を実際に試せるPlayground環境です。
 
 ここには2系統のサンプルがあります。
 
-- netns example（このディレクトリ直下の `end-*` / `headend-*` / `gtp*-*`）。各 SRv6 機能を単独の Linux network namespace 上で検証する自己完結スクリプト。`test.yaml` の matrix で並列実行します。
+- netns example（このディレクトリ直下の `end-*` / `headend-*` / `gtp*-*`）。各 SRv6 機能を単独の Linux network namespace 上で検証する自己完結スクリプト。`test.yaml` の matrix に登録した example を CI で並列実行します。matrix 未登録の example はローカル実行のみです。
 - interop ラボ（[`interop-clab/`](interop-clab/)）。Vinbero を FRR など第三者実装と相互運用させる containerlab シナリオ群。
 
 このページは netns example を説明します。interop ラボは [`interop-clab/README.md`](interop-clab/README.md) を参照してください。

--- a/examples/end-dx2v/README.md
+++ b/examples/end-dx2v/README.md
@@ -1,0 +1,94 @@
+# SRv6 End.DX2V Playground
+
+Vinbero XDPによるSRv6 End.DX2V (Decapsulation and VLAN L2 cross-connect) のデモ環境です。
+
+End.DX2V は外側のIPv6+SRHを除去したあと、内側L2フレームのVLAN IDを見て出力ポートを選ぶVLAN単位のクロスコネクトです。この example はVLAN 100と200を同じ物理ポートへ振り分けます。
+
+L2VPNは双方向ともH.Encaps.L2が必要なため、Vinberoはrouter1とrouter3の両方で動きます。router1が往路をencap、router3がEnd.DX2Vでdecap兼VLANクロスコネクト、戻り方向はrouter3がencapしてrouter1がdecapします。
+
+## トポロジー
+
+```mermaid
+graph LR
+    host1[host1<br/>VLAN100 172.16.100.1<br/>VLAN200 172.16.200.1] -->|L2 + VLAN| router1[router1 / Vinbero XDP<br/>fc00:1::1<br/>H.Encaps.L2]
+    router1 -->|SRv6| router2[router2<br/>fc00:2::1, fc00:2::2<br/>End]
+    router2 -->|SRv6| router3[router3 / Vinbero XDP<br/>fc00:3::3<br/>End.DX2V]
+    router3 -->|L2 + VLAN| host2[host2<br/>VLAN100 172.16.100.2<br/>VLAN200 172.16.200.2]
+```
+
+**パケットの流れ（host1→host2, VLAN 100）:**
+1. host1がVLAN 100で172.16.100.2へpingを送信
+2. **router1 (Vinbero XDP)** がH.Encaps.L2を実行し、L2フレームをSegment List `[fc00:2::1, fc00:3::3]` でSRv6カプセル化
+3. router2がfc00:2::1でEndを実行 (SL減算、次セグメントへ)
+4. **router3 (Vinbero XDP)** がfc00:3::3でEnd.DX2Vを実行:
+   - 外側IPv6+SRHを除去
+   - 内側フレームのVLAN ID 100をVLAN tableで引き、対応する出力ポートへL2転送
+5. host2がVLAN 100でpingを受信
+6. VLAN 200も同じ仕組みで同じポートへクロスコネクト
+
+veth pairではtx-vlan-offloadが有効だとVLAN tagが `skb->vlan_tci` に退避してXDPから見えなくなるため、setup.shで送信側の `txvlan` / 受信側の `rxvlan` をoffにしています。
+
+## クイックスタート
+
+```bash
+sudo ./setup.sh    # 環境構築（VLAN 100/200 + VLAN offload無効化）
+sudo ./test.sh     # テスト実行（Linux native End.DX2 baseline → Vinbero End.DX2V）
+sudo ./teardown.sh # クリーンアップ
+```
+
+`test.sh` はrouter1/router3でVinberoを起動してH.Encaps.L2を登録し、Phase 1でLinux native End.DX2をbaseline確認、Phase 2でrouter3のEnd.DX2Vに置き換えてVLAN 100/200のクロスコネクトを検証、Phase 3でVLAN table APIを確認します。
+
+## 手動実行
+
+### 1. 環境構築とVinbero起動
+
+```bash
+sudo ./setup.sh
+
+# router1 (H.Encaps.L2, port 8082)
+sudo ip netns exec dx2v-router1 ../../out/bin/vinberod -c vinbero_router1.yaml &
+# router3 (End.DX2V + 戻り方向H.Encaps.L2, port 8083)
+sudo ip netns exec dx2v-router3 ../../out/bin/vinberod -c vinbero_router3.yaml &
+```
+
+### 2. router1: H.Encaps.L2 登録（VLAN 100 / 200）
+
+```bash
+sudo ip netns exec dx2v-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
+  hl2 create --interface dx2v-rt1h1 --vlan-id 100 --src-addr fc00:1::1 --segments fc00:2::1,fc00:3::3
+sudo ip netns exec dx2v-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
+  hl2 create --interface dx2v-rt1h1 --vlan-id 200 --src-addr fc00:1::1 --segments fc00:2::1,fc00:3::3
+```
+
+### 3. router3: VLAN table と End.DX2V SID 登録
+
+```bash
+# router3のLinux native End.DX2経路を削除
+sudo ip netns exec dx2v-router3 ip -6 route del local fc00:3::3/128 2>/dev/null
+
+# VLAN ID -> 出力ポートの対応をtable_id=1に登録
+sudo ip netns exec dx2v-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
+  vlan-table create --table-id 1 --vlan-id 100 --interface dx2v-rt3h2
+sudo ip netns exec dx2v-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
+  vlan-table create --table-id 1 --vlan-id 200 --interface dx2v-rt3h2
+
+# End.DX2V SID (table_id=1 を参照)
+sudo ip netns exec dx2v-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
+  sid create --trigger-prefix fc00:3::3/128 --action END_DX2V --table-id 1
+```
+
+### 4. テスト
+
+```bash
+sudo ip netns exec dx2v-host1 ping -c 3 -I dx2v-h1rt1.100 172.16.100.2  # VLAN 100
+sudo ip netns exec dx2v-host1 ping -c 3 -I dx2v-h1rt1.200 172.16.200.2  # VLAN 200
+
+# VLAN table の確認
+sudo ip netns exec dx2v-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 --json vlan-table list --table-id 1
+```
+
+### 5. 環境のクリーンアップ
+
+```bash
+sudo ./teardown.sh
+```

--- a/examples/end-t/README.md
+++ b/examples/end-t/README.md
@@ -1,0 +1,76 @@
+# SRv6 End.T Playground
+
+Vinbero XDPによるSRv6 End.T (Endpoint with specific IPv6 table lookup) のデモ環境です。
+
+End.T はEndと同じくSRH処理 (DA更新とSL減算) を行いますが、転送先のFIBルックアップをdefault tableではなく指定VRFのrouting tableで行います。decapはしません。
+
+## トポロジー
+
+```mermaid
+graph LR
+    host1[host1<br/>172.0.1.1] -->|IPv4| router1[router1<br/>fc00:1::1<br/>H.Encaps / End.DX4]
+    router1 -->|SRv6| router2[router2 / Vinbero XDP<br/>fc00:2::1, fc00:2::2<br/>End.T table 100]
+    router2 -->|SRv6| router3[router3<br/>fc00:3::3<br/>End.DX4]
+    router3 -->|IPv4| host2[host2<br/>172.0.2.1]
+```
+
+router2 の `eth` 2本 (`rt2rt1` / `rt2rt3`) は VRF `vrf100` (table 100) に enslave され、router 間経路は table 100 に置かれます。End.T が更新後のDAをこのVRF tableで引きます。
+
+**パケットの流れ（host1→host2）:**
+1. host1が172.0.2.1にpingを送信 (IPv4)
+2. router1がLinux native H.Encapsを実行し、Segment List `[fc00:2::1, fc00:3::3]` でSRv6カプセル化
+3. **router2 (Vinbero XDP)** がfc00:2::1でEnd.Tを実行:
+   - SRH処理でDAをfc00:3::3に更新、SLを減算
+   - 更新後のDAをVRF table 100でFIBルックアップして転送
+4. router3がfc00:3::3でEnd.DX4を実行し、内側IPv4パケットをhost2へ転送
+5. 戻り方向は対称で、fc00:2::2のEnd.Tがhost2→host1を処理
+
+## クイックスタート
+
+```bash
+sudo ./setup.sh    # 環境構築
+sudo ./test.sh     # テスト実行（Linux native → Vinbero XDP の2フェーズ）
+sudo ./teardown.sh # クリーンアップ
+```
+
+`test.sh` はまずLinux native End.Tで疎通を確認し、native経路を削除してからVinbero XDPで再検証します。
+
+## 手動実行
+
+### 1. 環境構築とVinbero起動
+
+```bash
+sudo ./setup.sh
+
+# router2のLinux native End.T経路を削除
+sudo ip netns exec end-t-router2 ip -6 route del local fc00:2::1/128 2>/dev/null
+sudo ip netns exec end-t-router2 ip -6 route del local fc00:2::2/128 2>/dev/null
+
+# Vinbero起動
+sudo ip netns exec end-t-router2 ../../out/bin/vinberod -c vinbero_router2.yaml
+```
+
+### 2. SidFunction (End.T) エントリ登録
+
+VRFを指定して両方向のSIDを登録します。
+
+```bash
+sudo ip netns exec end-t-router2 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
+  sid create --trigger-prefix fc00:2::1/128 --action END_T --vrf-name vrf100
+sudo ip netns exec end-t-router2 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
+  sid create --trigger-prefix fc00:2::2/128 --action END_T --vrf-name vrf100
+```
+
+### 3. テスト
+
+```bash
+sudo ip netns exec end-t-host1 ping -c 3 172.0.2.1
+```
+
+bpf_fib_lookupはNDP解決済みのnext-hopを要求するため、setup.shで事前にrouter間のNDPを解決しています。
+
+### 4. 環境のクリーンアップ
+
+```bash
+sudo ./teardown.sh
+```

--- a/examples/end-t/README.md
+++ b/examples/end-t/README.md
@@ -46,8 +46,8 @@ sudo ./setup.sh
 sudo ip netns exec end-t-router2 ip -6 route del local fc00:2::1/128 2>/dev/null
 sudo ip netns exec end-t-router2 ip -6 route del local fc00:2::2/128 2>/dev/null
 
-# Vinbero起動
-sudo ip netns exec end-t-router2 ../../out/bin/vinberod -c vinbero_router2.yaml
+# Vinbero起動（フォアグラウンドで動き続けるので & でバックグラウンド起動するか別ターミナルで）
+sudo ip netns exec end-t-router2 ../../out/bin/vinberod -c vinbero_router2.yaml &
 ```
 
 ### 2. SidFunction (End.T) エントリ登録

--- a/examples/end-x/README.md
+++ b/examples/end-x/README.md
@@ -44,8 +44,8 @@ sudo ./setup.sh
 sudo ip netns exec end-x-router2 ip -6 route del local fc00:2::1/128 2>/dev/null
 sudo ip netns exec end-x-router2 ip -6 route del local fc00:2::2/128 2>/dev/null
 
-# Vinbero起動
-sudo ip netns exec end-x-router2 ../../out/bin/vinberod -c vinbero_router2.yaml
+# Vinbero起動（フォアグラウンドで動き続けるので & でバックグラウンド起動するか別ターミナルで）
+sudo ip netns exec end-x-router2 ../../out/bin/vinberod -c vinbero_router2.yaml &
 ```
 
 ### 2. SidFunction (End.X) エントリ登録

--- a/examples/end-x/README.md
+++ b/examples/end-x/README.md
@@ -1,0 +1,74 @@
+# SRv6 End.X Playground
+
+Vinbero XDPによるSRv6 End.X (Endpoint with L3 cross-connect) のデモ環境です。
+
+End.X はSRH処理 (DA更新とSL減算) のあと、通常のFIBルックアップではなく設定済みの明示的なnext-hopへ転送します。経路に依存しない固定next-hopのクロスコネクトを実現します。
+
+## トポロジー
+
+```mermaid
+graph LR
+    host1[host1<br/>172.0.1.1] -->|IPv4| router1[router1<br/>fc00:1::1<br/>End.DX4 / H.Encaps]
+    router1 -->|SRv6| router2[router2 / Vinbero XDP<br/>fc00:2::1, fc00:2::2<br/>End.X]
+    router2 -->|SRv6| router3[router3<br/>fc00:3::3<br/>End.DX4]
+    router3 -->|IPv4| host2[host2<br/>172.0.2.1]
+```
+
+**パケットの流れ（host1→host2）:**
+1. host1が172.0.2.1にpingを送信 (IPv4)
+2. router1がLinux native H.Encapsを実行し、Segment List `[fc00:2::1, fc00:3::3]` でSRv6カプセル化
+3. **router2 (Vinbero XDP)** がfc00:2::1でEnd.Xを実行:
+   - SRH処理でDAをfc00:3::3に更新、SLを減算
+   - FIBルックアップせず、設定済みnext-hop `fc00:23::1` (rt2-rt3リンク上のrouter3) へ転送
+4. router3がfc00:3::3でEnd.DX4を実行し、内側IPv4パケットをhost2へ転送
+5. 戻り方向は対称で、fc00:2::2のEnd.Xがnext-hop `fc00:12::1` (router1) へ転送
+
+## クイックスタート
+
+```bash
+sudo ./setup.sh    # 環境構築
+sudo ./test.sh     # テスト実行（Linux native → Vinbero XDP の2フェーズ）
+sudo ./teardown.sh # クリーンアップ
+```
+
+`test.sh` はまずLinux native End.Xで疎通を確認し、native経路を削除してからVinbero XDPで再検証します。
+
+## 手動実行
+
+### 1. 環境構築とVinbero起動
+
+```bash
+sudo ./setup.sh
+
+# router2のLinux native End.X経路を削除
+sudo ip netns exec end-x-router2 ip -6 route del local fc00:2::1/128 2>/dev/null
+sudo ip netns exec end-x-router2 ip -6 route del local fc00:2::2/128 2>/dev/null
+
+# Vinbero起動
+sudo ip netns exec end-x-router2 ../../out/bin/vinberod -c vinbero_router2.yaml
+```
+
+### 2. SidFunction (End.X) エントリ登録
+
+`--nexthop` で転送先を明示します。
+
+```bash
+# Forward: fc00:2::1 -> nexthop fc00:23::1 (router3)
+sudo ip netns exec end-x-router2 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
+  sid create --trigger-prefix fc00:2::1/128 --action END_X --nexthop fc00:23::1
+# Return: fc00:2::2 -> nexthop fc00:12::1 (router1)
+sudo ip netns exec end-x-router2 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
+  sid create --trigger-prefix fc00:2::2/128 --action END_X --nexthop fc00:12::1
+```
+
+### 3. テスト
+
+```bash
+sudo ip netns exec end-x-host1 ping -c 3 172.0.2.1
+```
+
+### 4. 環境のクリーンアップ
+
+```bash
+sudo ./teardown.sh
+```

--- a/examples/interop-clab/README.md
+++ b/examples/interop-clab/README.md
@@ -24,9 +24,17 @@ through the shared `Makefile` with the `SCENARIO` variable.
 
 ## Scenarios
 
-| Scenario       | Peer       | What it proves                                                                 |
-|----------------|------------|--------------------------------------------------------------------------------|
-| `l3vpn-2site`  | FRR 10.2.1 | 2-site SRv6 L3VPN — VPNv4/VPNv6 Service TLV encode+decode (RFC 9252 §4 transposition) and a bidirectional SRv6 data-plane ping. See [`scenarios/l3vpn-2site/README.md`](scenarios/l3vpn-2site/README.md). |
+Each row links to the scenario's own README.
+
+| Scenario | Peer | What it proves |
+|----------|------|----------------|
+| [`l3vpn-2site`](scenarios/l3vpn-2site/README.md) | FRR 10.2.1 | 2-site SRv6 L3VPN — VPNv4/VPNv6 Service TLV encode+decode (RFC 9252 §4 transposition) and a bidirectional SRv6 data-plane ping. |
+| [`l3vpn-2site-auto`](scenarios/l3vpn-2site-auto/README.md) | FRR 10.2.1 | The same L3VPN, but Vinbero originates its VRF route automatically from config (`auto_advertise` + `vrf_bindings`) via the `pkg/bgp/export` exporter — no `vbctl` advertise call. |
+| [`sr-policy-2site`](scenarios/sr-policy-2site/README.md) | FRR 10.2.1 | Color-based SR Policy steering (RFC 9256 / RFC 9252 §8): FRR tags a route with a Color Extended Community and Vinbero steers it onto an operator-defined SR Policy carrying a two-segment service chain. |
+| [`sr-policy-bgp-2site`](scenarios/sr-policy-bgp-2site/README.md) | Vinbero | Edge-to-edge SR Policy exchange over BGP (SAFI 73): both PEs advertise and receive SR Policies and steer their L3VPN traffic through a shared TE waypoint — exercises the SR Policy receive/decode path. |
+| [`evpn-2site`](scenarios/evpn-2site/README.md) | Vinbero | SRv6 EVPN L2VPN (ELAN): RT2 (MAC/IP) unicast + RT3 (Inclusive Multicast) BUM flood, a stretched broadcast domain signalled entirely by BGP EVPN. |
+| [`evpn-multihoming`](scenarios/evpn-multihoming/README.md) | Vinbero | SRv6 EVPN multi-homing: RT4 (Ethernet Segment) with RFC 8584 DF election + split-horizon for a dual-homed CE. |
+| [`mup-2site`](scenarios/mup-2site/README.md) | Vinbero | SRv6 MUP (SAFI 85, `draft-mpmz-bess-mup-safi` / RFC 9433): a MUP controller signals UE-session state over iBGP, GW/PE nodes program the SRv6 GTP data plane, and emulated gNB/DN endpoints drive real GTP-U ⇄ SRv6 traffic. |
 
 ## Layout
 
@@ -39,14 +47,20 @@ examples/interop-clab/
 │   └── frr/                   # FRR peer image
 │       ├── Dockerfile
 │       └── daemons
-└── scenarios/
-    └── l3vpn-2site/           # scenario #1
-        ├── README.md          # this scenario's detailed doc
-        ├── clab.yml           # containerlab topology
-        ├── test.sh            # scenario assertions
-        ├── core/start.sh
-        ├── frr/{frr.conf,start.sh}
-        └── vinbero/{vinbero.yml,start.sh}
+└── scenarios/                 # one subdir per scenario (see the table above)
+    ├── l3vpn-2site/
+    │   ├── README.md          # this scenario's detailed doc (+ README.ja.md)
+    │   ├── clab.yml           # containerlab topology
+    │   ├── test.sh            # scenario assertions
+    │   ├── core/start.sh
+    │   ├── frr/{frr.conf,start.sh}
+    │   └── vinbero/{vinbero.yml,start.sh}
+    ├── l3vpn-2site-auto/
+    ├── sr-policy-2site/
+    ├── sr-policy-bgp-2site/
+    ├── evpn-2site/
+    ├── evpn-multihoming/
+    └── mup-2site/
 ```
 
 `images/` is per-implementation so a future `images/srlinux/` slots in

--- a/examples/interop-clab/scenarios/l3vpn-2site-auto/README.ja.md
+++ b/examples/interop-clab/scenarios/l3vpn-2site-auto/README.ja.md
@@ -1,0 +1,27 @@
+# l3vpn-2site-auto — auto-advertise SRv6 L3VPN interop (Vinbero ⇄ FRR)
+
+*(English: [README.md](./README.md))*
+
+[l3vpn-2site](../l3vpn-2site/) の auto-advertise 版。トポロジ・アドレッシング・FRR PE は同一で、違いは Vinbero PE が顧客経路をどう originate するかだけ。
+
+`l3vpn-2site` では Vinbero は `vbctl sid create` + `vbctl bgp advertise-vpn` の明示呼び出しで `10.1.0.0/24` を広告する。ここでは **config から自動的に** 広告する — `bgp.global.auto_advertise: true` と、`redistribute: [static]` を持つ `vrf_bindings` エントリを置く。exporter (`pkg/bgp/export`) が `LOC1` から End.DT4/DT6 service SID を採番し、VRF-local prefix を自前で広告する。`vbctl` 呼び出しは不要で、受信方向の `pkg/bgp/apply` と対になる送信方向の実装。
+
+## l3vpn-2site との差分
+
+- **vinbero/vinbero.yml**: `bgp.locators` が `LOC1` を静的に宣言する (exporter は起動時、RPC より前に binding の `default_locator` を解決する)。`bgp.global.auto_advertise: true`。`bgp.global.next_hop` は PE の loopback (BGP next hop は通常のノードアドレスである必要がある。locator base は subnet-router anycast アドレスで、受信側 PE が local 扱いして転送が壊れる)。`vrf_bindings` が `rd` / `import_rts` / `export_rts` / `default_locator` / `redistribute` を持つ。
+- **vinbero/start.sh**: `vbctl sid create` / `bgp advertise-vpn` がない。顧客経路は `proto static` で追加し、`redistribute: [static]` allowlist が転送するようにする (素の `ip route` は `RTPROT_BOOT` で、casual な経路が VPN に漏れるのを避けるため除外される)。
+- **frr/start.sh**: /128 glue 経路の向き先が、手動の `fd00:100:0:1::` でなく auto 採番された SID `fd00:100:0:10::` (function `0x10`、最初に auto 割り当てされる End.DT4) になる。
+
+広告される SID は動的なので、`test.sh` は SID をハードコードせず Vinbero の End.DT4 SID を discover する。
+
+## 実行
+
+Docker・`containerlab`・`sudo` が必要。`examples/interop-clab/` から:
+
+```bash
+make all SCENARIO=l3vpn-2site-auto
+```
+
+## test.sh が検証する内容
+
+`l3vpn-2site` と同じ 4 点 — iBGP Established、FRR → Vinbero の SRv6 Service TLV decode (RFC 9252 §4 transposition 込み)、Vinbero → FRR encode、`ce-tokyo` ⇄ `ce-osaka` 間の双方向 `ping` が SRv6 L3VPN を通ること。違いは Vinbero → FRR の経路が operator の RPC なしに auto-advertise exporter で originate される点。

--- a/examples/interop-clab/scenarios/l3vpn-2site-auto/README.md
+++ b/examples/interop-clab/scenarios/l3vpn-2site-auto/README.md
@@ -1,5 +1,7 @@
 # l3vpn-2site-auto — auto-advertise SRv6 L3VPN interop (Vinbero ⇄ FRR)
 
+*(日本語: [README.ja.md](./README.ja.md))*
+
 The auto-advertise variant of [l3vpn-2site](../l3vpn-2site/). The topology,
 addressing, and FRR PE are identical; the only difference is how the Vinbero PE
 originates its customer route.


### PR DESCRIPTION
## 概要

examples/ の README staleness をまとめて解消する docs-only PR。スクリプトの挙動は変えていない。

## 変更点

### netns example
- **トップ `examples/README.md`**
  - 存在しない `.github/workflows/examples.yaml` への参照を修正 (netns example は `test.yaml` の matrix で回る)。
  - netns example と interop-clab の 2 系統があることを冒頭で明示し、interop-clab への導線を追加。
  - Example 一覧に欠落していた `end-dt2m-multihomed` / `end-dx2v` を追記。
  - プレフィックス指針を、実際に使われている短い固有 prefix の慣習に合わせた。
- **欠落 README を新規作成**: `end-t` / `end-x` / `end-dx2v`。`end-dx4` のフォーマット (トポロジ mermaid + パケットの流れ + 手動実行) に揃えた。

### interop-clab
- **`interop-clab/README.md`**: scenario index を 1 行 (l3vpn-2site のみ) から全 7 scenario に展開し、各行を scenario README へリンク。Layout ツリーも全 scenario 表示に一般化。
- **`l3vpn-2site-auto`**: 他 6 scenario と揃うよう `README.ja.md` を追加し、en README に bilingual リンク行を追加。topology は基底 l3vpn-2site と同一のため mermaid は基底参照のまま (重複 drift を避ける)。

## 確認

- mermaid フェンスの対応・全相対リンク先の実在を確認済み。
- docs-only のためテスト・ビルドへの影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)