### PR TITLE
ci(examples): cover 4 uncovered netns examples in the integration matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -128,9 +128,13 @@ jobs:
           - end-dt6
           - end-dt2
           - end-dt2-p2mp
+          - end-dt2m-multihomed
+          - end-dx2v
           - headend-v4
           - headend-v6
           - headend-l2
+          - gtp6-encap
+          - gtp6-drop-in
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -152,8 +156,10 @@ jobs:
             iputils-ping \
             ethtool \
             curl \
+            python3-scapy \
             linux-modules-extra-$(uname -r)
           sudo modprobe vrf
+          sudo modprobe 8021q
 
       - name: Setup test environment
         working-directory: examples/${{ matrix.example }}

--- a/examples/end-dx2v/test.sh
+++ b/examples/end-dx2v/test.sh
@@ -177,8 +177,8 @@ print_info "Checking VLAN table on router3..."
 vlan_response=$(vbctl_rt3 --json vlan-table list --table-id 1)
 print_info "VLAN table response: $vlan_response"
 
-if echo "$vlan_response" | grep -q '"vlanId"'; then
-    entry_count=$(echo "$vlan_response" | grep -c '"vlanId"')
+if echo "$vlan_response" | grep -q '"vlan_id"'; then
+    entry_count=$(echo "$vlan_response" | grep -c '"vlan_id"')
     print_success "VLAN table API: PASS ($entry_count entries found)"
     TESTS_PASSED=$((TESTS_PASSED + 1))
 else


### PR DESCRIPTION
## 概要

netns example の CI カバレッジ穴を埋める。`test.yaml` の example matrix は 17 example 中 12 しか回しておらず、`end-dt2m-multihomed` / `end-dx2v` / `gtp6-encap` / `gtp6-drop-in` が無検証だった。この 4 件を追加し、必要な依存を入れる。

## 変更点

- **matrix に 4 example 追加**: `end-dt2m-multihomed` / `end-dx2v` / `gtp6-encap` / `gtp6-drop-in`。
- **`python3-scapy` を CI 依存に追加**: `gtp6-encap` はデータプレーン assert を scapy の GTP-U sender で行う。scapy が無いと test.sh が無言で `exit 0` するため、入れることでデータプレーンを実際に検証する。
- **`modprobe 8021q` を追加**: `end-dx2v` / `end-dt2m-multihomed` が VLAN subinterface を作る。
- **`end-dx2v/test.sh` の stale assert 修正**: Phase 3 が `vlan-table --json` 出力を camelCase の `"vlanId"` で grep していたが、CLI は snake_case の `"vlan_id"` を出すため、データプレーンが通っていても API チェックが FAIL していた。key を修正して PASS させる。

## ローカル検証

sudo + netns + XDP で全 4 件 pass を確認。

- end-dt2m-multihomed: 6/6
- end-dx2v: 5/5 (JSON key 修正後)
- gtp6-encap: 1/1 (scapy 込み)
- gtp6-drop-in: 1/1

## 除外

`gtp4-encap` は今回 matrix に入れていない。ローカル (kernel 6.15-rc) で H.M.GTP4.D が GTP-U を SRv6 に変換せず、router1 egress に SRv6 が出ないためテストが落ちる。gtp6 経路は動くので gtp4 固有。CI kernel での再現確認と原因調査を別途行ってから追加する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)