### PR TITLE
refactor(examples): hoist test_ping_with_counter into common/test_utils.sh

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -128,9 +128,13 @@ jobs:
           - end-dt6
           - end-dt2
           - end-dt2-p2mp
+          - end-dt2m-multihomed
+          - end-dx2v
           - headend-v4
           - headend-v6
           - headend-l2
+          - gtp6-encap
+          - gtp6-drop-in
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -152,8 +156,10 @@ jobs:
             iputils-ping \
             ethtool \
             curl \
+            python3-scapy \
             linux-modules-extra-$(uname -r)
           sudo modprobe vrf
+          sudo modprobe 8021q
 
       - name: Setup test environment
         working-directory: examples/${{ matrix.example }}

--- a/examples/common/test_utils.sh
+++ b/examples/common/test_utils.sh
@@ -105,6 +105,12 @@ test_ping() {
 # Like test_ping but tallies the caller's TESTS_PASSED / TESTS_FAILED counters
 # (define both before calling). Pass an interface to ping with -I (used by the
 # VLAN/L2 examples to pick the source subinterface).
+#
+# Always returns 0: callers run under `set -e` and want every assertion to run
+# and be tallied, then fail at the end via `[ $TESTS_FAILED -gt 0 ] && exit 1`.
+# A non-zero return would abort the script on the first failed ping, before the
+# summary. The ping argv is built as an array so the target / -I argument are
+# never word-split or globbed.
 test_ping_with_counter() {
     local ns=$1
     local target=$2
@@ -112,20 +118,18 @@ test_ping_with_counter() {
     local interface=${4:-}
 
     print_info "Testing: $desc"
-    local ping_cmd="ping -c 3 -W 2 $target"
-    if [ -n "$interface" ]; then
-        ping_cmd="ping -c 3 -W 2 -I $interface $target"
-    fi
+    local ping_cmd=(ping -c 3 -W 2)
+    [ -n "$interface" ] && ping_cmd+=(-I "$interface")
+    ping_cmd+=("$target")
 
-    if ip netns exec "$ns" $ping_cmd > /dev/null 2>&1; then
+    if ip netns exec "$ns" "${ping_cmd[@]}" > /dev/null 2>&1; then
         print_success "$desc: PASS"
         TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
     else
         print_error "$desc: FAIL"
         TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
     fi
+    return 0
 }
 
 

--- a/examples/common/test_utils.sh
+++ b/examples/common/test_utils.sh
@@ -101,4 +101,31 @@ test_ping() {
     fi
 }
 
+# Usage: test_ping_with_counter <namespace> <destination> <description> [interface]
+# Like test_ping but tallies the caller's TESTS_PASSED / TESTS_FAILED counters
+# (define both before calling). Pass an interface to ping with -I (used by the
+# VLAN/L2 examples to pick the source subinterface).
+test_ping_with_counter() {
+    local ns=$1
+    local target=$2
+    local desc=$3
+    local interface=${4:-}
+
+    print_info "Testing: $desc"
+    local ping_cmd="ping -c 3 -W 2 $target"
+    if [ -n "$interface" ]; then
+        ping_cmd="ping -c 3 -W 2 -I $interface $target"
+    fi
+
+    if ip netns exec "$ns" $ping_cmd > /dev/null 2>&1; then
+        print_success "$desc: PASS"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        print_error "$desc: FAIL"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
 

--- a/examples/end-dt2-p2mp/test.sh
+++ b/examples/end-dt2-p2mp/test.sh
@@ -38,20 +38,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-test_ping_with_counter() {
-    local ns=$1 target=$2 desc=$3 interface=${4:-}
-    print_info "Testing: $desc"
-    local ping_cmd="ping -c 3 -W 2 $target"
-    [ -n "$interface" ] && ping_cmd="ping -c 3 -W 2 -I $interface $target"
-    if ip netns exec $ns $ping_cmd > /dev/null 2>&1; then
-        print_success "$desc: PASS"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-    else
-        print_error "$desc: FAIL"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-    fi
-}
-
 # CLI helpers
 vbctl_pe1() { ip netns exec "$ns_router1" ${VINBERO_BIN} -s http://127.0.0.1:8082 "$@"; }
 vbctl_pe2() { ip netns exec "$ns_router3" ${VINBERO_BIN} -s http://127.0.0.1:8083 "$@"; }

--- a/examples/end-dt2/test.sh
+++ b/examples/end-dt2/test.sh
@@ -37,29 +37,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-test_ping_with_counter() {
-    local ns=$1
-    local target=$2
-    local desc=$3
-    local interface=${4:-}
-
-    print_info "Testing: $desc"
-    local ping_cmd="ping -c 3 -W 2 $target"
-    if [ -n "$interface" ]; then
-        ping_cmd="ping -c 3 -W 2 -I $interface $target"
-    fi
-
-    if ip netns exec $ns $ping_cmd > /dev/null 2>&1; then
-        print_success "$desc: PASS"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        print_error "$desc: FAIL"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
 # Helper: run vinbero CLI inside a network namespace
 vbctl_rt1() { ip netns exec "$ns_router1" ${VINBERO_BIN} -s http://127.0.0.1:8082 "$@"; }
 vbctl_rt3() { ip netns exec "$ns_router3" ${VINBERO_BIN} -s http://127.0.0.1:8083 "$@"; }

--- a/examples/end-dt4/test.sh
+++ b/examples/end-dt4/test.sh
@@ -30,23 +30,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-test_ping_with_counter() {
-    local ns=$1
-    local target=$2
-    local desc=$3
-
-    print_info "Testing: $desc"
-    if ip netns exec $ns ping -c 3 -W 2 $target > /dev/null 2>&1; then
-        print_success "$desc: PASS"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        print_error "$desc: FAIL"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
 echo "=========================================="
 echo "SRv6 End.DT4 (VRF) Test"
 echo "=========================================="

--- a/examples/end-dx2v/test.sh
+++ b/examples/end-dx2v/test.sh
@@ -177,8 +177,8 @@ print_info "Checking VLAN table on router3..."
 vlan_response=$(vbctl_rt3 --json vlan-table list --table-id 1)
 print_info "VLAN table response: $vlan_response"
 
-if echo "$vlan_response" | grep -q '"vlanId"'; then
-    entry_count=$(echo "$vlan_response" | grep -c '"vlanId"')
+if echo "$vlan_response" | grep -q '"vlan_id"'; then
+    entry_count=$(echo "$vlan_response" | grep -c '"vlan_id"')
     print_success "VLAN table API: PASS ($entry_count entries found)"
     TESTS_PASSED=$((TESTS_PASSED + 1))
 else

--- a/examples/end-dx2v/test.sh
+++ b/examples/end-dx2v/test.sh
@@ -38,29 +38,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-test_ping_with_counter() {
-    local ns=$1
-    local target=$2
-    local desc=$3
-    local interface=${4:-}
-
-    print_info "Testing: $desc"
-    local ping_cmd="ping -c 3 -W 2 $target"
-    if [ -n "$interface" ]; then
-        ping_cmd="ping -c 3 -W 2 -I $interface $target"
-    fi
-
-    if ip netns exec $ns $ping_cmd > /dev/null 2>&1; then
-        print_success "$desc: PASS"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        print_error "$desc: FAIL"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
 # Helper: run vinbero CLI inside a network namespace
 vbctl_rt1() { ip netns exec "$ns_router1" ${VINBERO_BIN} -s http://127.0.0.1:8082 "$@"; }
 vbctl_rt3() { ip netns exec "$ns_router3" ${VINBERO_BIN} -s http://127.0.0.1:8083 "$@"; }

--- a/examples/end-dx4/test.sh
+++ b/examples/end-dx4/test.sh
@@ -22,24 +22,6 @@ ns_router3="${TOPO_NS_PREFIX}router3"
 TESTS_PASSED=0
 TESTS_FAILED=0
 
-# Test ping with counter
-test_ping_with_counter() {
-    local ns=$1
-    local target=$2
-    local desc=$3
-
-    print_info "Testing: $desc"
-    if ip netns exec $ns ping -c 3 -W 2 $target > /dev/null 2>&1; then
-        print_success "$desc: PASS"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        print_error "$desc: FAIL"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
 echo "=========================================="
 echo "SRv6 End.DX4 Test"
 echo "=========================================="

--- a/examples/end-t/test.sh
+++ b/examples/end-t/test.sh
@@ -31,23 +31,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-test_ping_with_counter() {
-    local ns=$1
-    local target=$2
-    local desc=$3
-
-    print_info "Testing: $desc"
-    if ip netns exec $ns ping -c 3 -W 2 $target > /dev/null 2>&1; then
-        print_success "$desc: PASS"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        print_error "$desc: FAIL"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
 echo "=========================================="
 echo "SRv6 End.T (VRF) Test"
 echo "=========================================="

--- a/examples/end-x/test.sh
+++ b/examples/end-x/test.sh
@@ -24,24 +24,6 @@ ns_router2="${TOPO_NS_PREFIX}router2"
 TESTS_PASSED=0
 TESTS_FAILED=0
 
-# Test ping with counter (wrapper around test_utils.sh's test_ping)
-test_ping_with_counter() {
-    local ns=$1
-    local target=$2
-    local desc=$3
-
-    print_info "Testing: $desc"
-    if ip netns exec $ns ping -c 3 -W 2 $target > /dev/null 2>&1; then
-        print_success "$desc: PASS"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        print_error "$desc: FAIL"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
 echo "=========================================="
 echo "SRv6 End.X Operation Test"
 echo "=========================================="

--- a/examples/end/test.sh
+++ b/examples/end/test.sh
@@ -24,24 +24,6 @@ ns_router2="${TOPO_NS_PREFIX}router2"
 TESTS_PASSED=0
 TESTS_FAILED=0
 
-# Test ping with counter (wrapper around test_utils.sh's test_ping)
-test_ping_with_counter() {
-    local ns=$1
-    local target=$2
-    local desc=$3
-
-    print_info "Testing: $desc"
-    if ip netns exec $ns ping -c 3 -W 2 $target > /dev/null 2>&1; then
-        print_success "$desc: PASS"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        print_error "$desc: FAIL"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
 echo "=========================================="
 echo "SRv6 End Operation Test"
 echo "=========================================="

--- a/examples/headend-l2/test.sh
+++ b/examples/headend-l2/test.sh
@@ -40,30 +40,6 @@ cleanup() {
 
 trap cleanup EXIT
 
-# Test ping with counter
-test_ping_with_counter() {
-    local ns=$1
-    local target=$2
-    local desc=$3
-    local interface=${4:-}
-
-    print_info "Testing: $desc"
-    local ping_cmd="ping -c 3 -W 2 $target"
-    if [ -n "$interface" ]; then
-        ping_cmd="ping -c 3 -W 2 -I $interface $target"
-    fi
-
-    if ip netns exec $ns $ping_cmd > /dev/null 2>&1; then
-        print_success "$desc: PASS"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        print_error "$desc: FAIL"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
 echo "=========================================="
 echo "SRv6 H.Encaps.L2 (Headend L2VPN) Test"
 echo "=========================================="

--- a/examples/headend-v4/test.sh
+++ b/examples/headend-v4/test.sh
@@ -23,24 +23,6 @@ ns_router1="${TOPO_NS_PREFIX}router1"
 TESTS_PASSED=0
 TESTS_FAILED=0
 
-# Test ping with counter
-test_ping_with_counter() {
-    local ns=$1
-    local target=$2
-    local desc=$3
-
-    print_info "Testing: $desc"
-    if ip netns exec $ns ping -c 3 -W 2 $target > /dev/null 2>&1; then
-        print_success "$desc: PASS"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        print_error "$desc: FAIL"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
 echo "=========================================="
 echo "SRv6 H.Encaps (Headend IPv4) Test"
 echo "=========================================="


### PR DESCRIPTION
## 概要

10 個の netns example が、ほぼ同一の `test_ping_with_counter` (TESTS_PASSED / TESTS_FAILED を加算する ping wrapper) をそれぞれローカル定義していた。superset 版 1 つを `common/test_utils.sh` の `test_ping` の隣に移し、ローカル定義を削除する。

> Note: `end-dx2v/test.sh` の JSON key 修正に依存するため #63 に stack している。#63 マージ後に base を main へ retarget する。

## 変更点

- `common/test_utils.sh` に `test_ping_with_counter` を追加。optional な第4引数 `interface` を取り、指定時は `ping -I` する。3引数 caller と VLAN/L2 系の4引数 caller の両方をカバーする superset。引数は配列で安全に組み立てる。
- 10 example (`end` / `end-x` / `end-t` / `end-dx4` / `end-dt2` / `end-dt4` / `end-dt2-p2mp` / `end-dx2v` / `headend-l2` / `headend-v4`) からローカル定義と孤立コメントを削除。実行ビットは維持。

## 意図的な挙動変更 (Copilot review 対応)

共通版は常に 0 を返す。これは意図的な変更で、ping 失敗時の制御フローが次のように変わる。

- 変更前: ローカル定義の多く (end / end-x / end-t / end-dx4 ほか) は失敗時に `return 1` していた。全 example は `set -e` なので bare call で `return 1` すると最初の FAIL でスクリプトが即終了し、サマリ出力に到達しなかった。一方 end-dt2-p2mp は 0 で fall-through して継続しており挙動が不揃いだった。
- 変更後: 失敗は TESTS_FAILED に加算して処理を継続し、末尾の `[ $TESTS_FAILED -gt 0 ] && exit 1` でまとめて FAIL する。テストハーネスの本来の意図 (全 assertion を実行して最後に判定) で、全 example で揃う。

全 caller は bare call で戻り値に依存していないため安全 (`if`/`&&`/`||`/`$?` での利用なし)。

## 検証

共有関数経由でローカル E2E pass を確認。

- end: 4/4 (3引数経路)
- end-dx2v: 5/5 (4引数 `-I` 経路)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
