### PR TITLE
fix(examples): make gtp4-encap actually transform GTP-U->SRv6, add it to CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -133,6 +133,7 @@ jobs:
           - headend-v4
           - headend-v6
           - headend-l2
+          - gtp4-encap
           - gtp6-encap
           - gtp6-drop-in
     steps:

--- a/examples/gtp4-encap/send_gtpu.py
+++ b/examples/gtp4-encap/send_gtpu.py
@@ -24,11 +24,14 @@ def build_gtpu_packet(outer_dst, teid, qfi, inner_src, inner_dst):
     """Build a GTP-U/IPv4 packet with optional PDU Session Container."""
     outer = IP(dst=outer_dst) / UDP(sport=2152, dport=2152)
 
+    # gtp_type=0xFF marks the message as a G-PDU (user data); the BPF
+    # gtpu_parse rejects anything else, and scapy's GTPHeader defaults the
+    # field to 0, so it must be set explicitly.
     if qfi > 0:
-        gtp = GTPHeader(teid=teid, E=1, next_ex=0x85) / \
+        gtp = GTPHeader(teid=teid, gtp_type=0xFF, E=1, next_ex=0x85) / \
               GTPPDUSessionContainer(type=0, QFI=qfi)
     else:
-        gtp = GTPHeader(teid=teid)
+        gtp = GTPHeader(teid=teid, gtp_type=0xFF)
 
     inner = IP(src=inner_src, dst=inner_dst) / ICMP(id=0x1234, seq=1) / (b"A" * 32)
 

--- a/examples/gtp4-encap/setup.sh
+++ b/examples/gtp4-encap/setup.sh
@@ -24,6 +24,14 @@ veth_rt2_rt3="${TOPO_NS_PREFIX}rt2rt3"
 veth_rt3_h2="${TOPO_NS_PREFIX}rt3h2"
 veth_rt3_rt2="${TOPO_NS_PREFIX}rt3rt2"
 
+# H.M.GTP4.D writes Args.Mob.Session into the outer DA at args_offset=7 (byte 7
+# onward), so the End.M.GTP4.E SID locator must be <= 56 bits and the underlay
+# must route that /56 (the default /64 would not cover an address whose byte 7
+# carries the IPv4 destination). End.M.GTP4.E lives on fc00:1:: (return) and
+# fc00:3:: (forward); route both as /56 so the args-bearing DA is forwardable.
+export TOPO_IPV6_PREFIX_RT1=fc00:1::/56
+export TOPO_IPV6_PREFIX_RT3=fc00:3::/56
+
 setup_three_router_topology
 
 print_info "Configuring SRv6 GTP-U/IPv4 settings..."
@@ -34,13 +42,11 @@ ns_sysctl "$ns_router1" net.ipv6.conf.${veth_rt1_rt2}.seg6_enabled 1
 ns_sysctl "$ns_router1" net.ipv4.conf.${veth_rt1_rt2}.rp_filter 0
 ns_sysctl "$ns_router1" net.ipv4.conf.${veth_rt1_h1}.rp_filter 0
 
-# router2: End (transit)
+# router2: pure IPv6 transit. The H.M.GTP4.D headend encapsulates straight to
+# the End.M.GTP4.E SID (single segment), so router2 only forwards the /56 SID
+# routes set up above -- no SRv6 localsid here.
 ns_sysctl "$ns_router2" net.ipv6.conf.${veth_rt2_rt1}.seg6_enabled 1
 ns_sysctl "$ns_router2" net.ipv6.conf.${veth_rt2_rt3}.seg6_enabled 1
-
-run ip netns exec "$ns_router2" ip -6 route del local fc00:2::2 2>/dev/null || true
-run ip netns exec "$ns_router2" ip -6 route add local fc00:2::1/128 encap seg6local action End dev lo
-run ip netns exec "$ns_router2" ip -6 route add local fc00:2::2/128 encap seg6local action End dev lo
 
 # router3: End.M.GTP4.E (forward) / H.M.GTP4.D (return)
 ns_sysctl "$ns_router3" net.ipv6.conf.${veth_rt3_h2}.seg6_enabled 1
@@ -53,12 +59,12 @@ echo "=========================================="
 echo "SRv6 GTP-U/IPv4 (H.M.GTP4.D + End.M.GTP4.E) Setup Complete!"
 echo "=========================================="
 echo "Topology:"
-echo "  gNB/host1 (172.0.1.1) <---> router1 (fc00:1::1, H.M.GTP4.D / End.M.GTP4.E)"
-echo "  router1 (fc00:12::1) <---> router2 (fc00:2::1, fc00:2::2, End)"
-echo "  router2 (fc00:23::2) <---> router3 (fc00:3::3, End.M.GTP4.E / H.M.GTP4.D)"
+echo "  gNB/host1 (172.0.1.1) <---> router1 (fc00:1::/56, H.M.GTP4.D / End.M.GTP4.E)"
+echo "  router1 (fc00:12::1) <---> router2 (IPv6 transit)"
+echo "  router2 (fc00:23::2) <---> router3 (fc00:3::/56, End.M.GTP4.E / H.M.GTP4.D)"
 echo "  router3 <---> UPF/host2 (172.0.2.1)"
 echo ""
-echo "Forward: GTP-U/IPv4 -> H.M.GTP4.D (router1) -> End (router2) -> End.M.GTP4.E (router3) -> GTP-U/IPv4"
-echo "Return:  GTP-U/IPv4 -> H.M.GTP4.D (router3) -> End (router2) -> End.M.GTP4.E (router1) -> GTP-U/IPv4"
+echo "Forward: GTP-U/IPv4 -> H.M.GTP4.D (router1) -> transit (router2) -> End.M.GTP4.E (router3) -> GTP-U/IPv4"
+echo "Return:  GTP-U/IPv4 -> H.M.GTP4.D (router3) -> transit (router2) -> End.M.GTP4.E (router1) -> GTP-U/IPv4"
 echo ""
 print_success "Ready for testing!"

--- a/examples/gtp4-encap/test.sh
+++ b/examples/gtp4-encap/test.sh
@@ -58,22 +58,22 @@ echo "=========================================="
 echo "Phase 2: Register Entries"
 echo "=========================================="
 
-# Forward path: gNB(host1) -> router1(H.M.GTP4.D) -> router2(End) -> router3(End.M.GTP4.E) -> UPF(host2)
+# Forward path: gNB(host1) -> router1(H.M.GTP4.D) -> router2(transit) -> router3(End.M.GTP4.E) -> UPF(host2)
 print_info "Forward: H.M.GTP4.D on router1..."
 ip netns exec "$ns_router1" ${VINBERO_BIN} -s http://127.0.0.1:8082 hv4 create \
   --trigger-prefix 172.0.2.0/24 --src-addr fc00:1::1 \
-  --segments fc00:2::1,fc00:3::3 --mode H_M_GTP4_D --args-offset 7 > /dev/null
+  --segments fc00:3::3 --mode H_M_GTP4_D --args-offset 7 > /dev/null
 
 print_info "Forward: End.M.GTP4.E on router3..."
 ip netns exec "$ns_router3" ${VINBERO_BIN} -s http://127.0.0.1:8083 sid create \
   --trigger-prefix fc00:3::/56 --action END_M_GTP4_E \
   --gtp-v4-src-addr 172.0.2.2 --args-offset 7 > /dev/null
 
-# Return path: UPF(host2) -> router3(H.M.GTP4.D) -> router2(End) -> router1(End.M.GTP4.E) -> gNB(host1)
+# Return path: UPF(host2) -> router3(H.M.GTP4.D) -> router2(transit) -> router1(End.M.GTP4.E) -> gNB(host1)
 print_info "Return: H.M.GTP4.D on router3..."
 ip netns exec "$ns_router3" ${VINBERO_BIN} -s http://127.0.0.1:8083 hv4 create \
   --trigger-prefix 172.0.1.0/24 --src-addr fc00:3::3 \
-  --segments fc00:2::2,fc00:1::1 --mode H_M_GTP4_D --args-offset 7 > /dev/null
+  --segments fc00:1::1 --mode H_M_GTP4_D --args-offset 7 > /dev/null
 
 print_info "Return: End.M.GTP4.E on router1..."
 ip netns exec "$ns_router1" ${VINBERO_BIN} -s http://127.0.0.1:8082 sid create \

--- a/examples/gtp6-encap/send_gtpu_v6.py
+++ b/examples/gtp6-encap/send_gtpu_v6.py
@@ -34,12 +34,14 @@ def main():
     # Build inner packet
     inner = IPv6(src="fd00:10::1", dst="fd00:10::2") / ICMPv6EchoRequest() / (b"B" * 32)
 
-    # Build GTP-U
+    # Build GTP-U. gtp_type=0xFF marks the message as a G-PDU (user data); the
+    # BPF gtpu_parse rejects anything else, and scapy's GTPHeader defaults the
+    # field to 0, so it must be set explicitly.
     if args.qfi > 0:
-        gtp = GTPHeader(teid=args.teid, E=1, next_ex=0x85) / \
+        gtp = GTPHeader(teid=args.teid, gtp_type=0xFF, E=1, next_ex=0x85) / \
               GTPPDUSessionContainer(type=0, QFI=args.qfi)
     else:
-        gtp = GTPHeader(teid=args.teid)
+        gtp = GTPHeader(teid=args.teid, gtp_type=0xFF)
 
     # Build outer IPv6 + SRH + UDP + GTP-U
     # Note: SRH with segments is complex in scapy. Use plain IPv6 + UDP for simplicity.


### PR DESCRIPTION
## 概要

`gtp4-encap` は E2E が一度も通っておらず (だから CI matrix に未収録だった)、レビューで実機検証して 2 つの根本原因を特定・修正した。BPF の H.M.GTP4.D 自体は正常 (`pkg/bpf` の `TestXDPProgHMGtp4D` は pass)。原因はどちらも example 側。

## 根本原因と修正

1. **GTP-U message type 未設定**: 送信スクリプトが `GTPHeader()` で `gtp_type` を設定せず、scapy が message type を 0 にしていた。`gtpu_parse` は G-PDU (0xFF) のみ受理するため、全パケットが変換されず XDP_PASS で素通り。`send_gtpu.py` / `send_gtpu_v6.py` に `gtp_type=0xFF` を設定。

2. **SID locator 長と経路の不整合**: H.M.GTP4.D は Args.Mob.Session を outer DA の args_offset=7 (byte 7 以降) に書き込む。example は 2 セグメント (先頭が transit End fc00:2::1) かつ SID locator 経路が /64 だったため、args を載せた DA (byte7 = IPv4 dst) が経路にも transit End にも一致せず転送されなかった。End.M.GTP4.E SID へ直接 (単一セグメント) encap し、End.M.GTP4.E の locator (fc00:1::, fc00:3::) を /56 で経路設定するよう変更。router2 は pure IPv6 transit に。

両方直すと forward/return とも変換され SRv6 が捕捉されるので、`gtp4-encap` を `test.yaml` matrix に追加 (scapy は導入済み)。

## 検証

ローカル (sudo + netns + XDP) で gtp4-encap 2/2 (3 + 1 SRv6 packets captured)。

## 補足 (follow-up)

`gtp6-encap` は根本原因 1 (gtp_type) を共有し本 PR で修正済みだが、同じ /56 経路修正と実 assertion (現状は送信して無条件 pass の false-pass) がまだ必要。別タスクで対応する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)