### PR TITLE
fix(examples): make gtp6-encap actually exercise End.M.GTP6.D + verify it

### DIFF
--- a/examples/gtp6-encap/send_gtpu_v6.py
+++ b/examples/gtp6-encap/send_gtpu_v6.py
@@ -22,7 +22,7 @@ try:
     from scapy.contrib.gtp import GTPHeader, GTPPDUSessionContainer
     from scapy.layers.inet6 import IPv6ExtHdrSegmentRouting
 except ImportError:
-    print("ERROR: scapy is required. Install with: pip3 install scapy")
+    print("ERROR: scapy is required. Install with: apt-get install -y python3-scapy")
     sys.exit(1)
 
 conf.verb = 0
@@ -52,9 +52,11 @@ def main():
         gtp = GTPHeader(teid=args.teid, gtp_type=0xFF)
 
     # SRH: segments [next_seg, sid] with segments_left=1, so the active segment
-    # (the IPv6 DA) is sid; after End.M.GTP6.D it advances to next_seg.
+    # (the IPv6 DA) is sid; after End.M.GTP6.D it advances to next_seg. nh=17
+    # (UDP) is set explicitly -- End.M.GTP6.D early-returns unless the SRH next
+    # header is UDP, so do not rely on scapy's autocompletion of it.
     srh = IPv6ExtHdrSegmentRouting(addresses=[args.next_seg, args.sid],
-                                   segleft=1, lastentry=1)
+                                   segleft=1, lastentry=1, nh=17)
 
     pkt = IPv6(src=args.src, dst=args.sid) / srh / \
         UDP(sport=2152, dport=2152) / gtp / raw(inner)

--- a/examples/gtp6-encap/send_gtpu_v6.py
+++ b/examples/gtp6-encap/send_gtpu_v6.py
@@ -1,20 +1,26 @@
 #!/usr/bin/env python3
-"""Send GTP-U/IPv6 test packets using scapy.
+"""Send an SRv6 packet carrying GTP-U to an End.M.GTP6.D SID, using scapy.
 
 Usage:
-  sudo ip netns exec gtp6-host1 python3 send_gtpu_v6.py [--qfi QFI] [--teid TEID]
+  sudo ip netns exec gtp6-host1 python3 send_gtpu_v6.py \
+      [--sid SID] [--next-seg SID] [--teid TEID] [--qfi QFI] [--count N]
 
-Sends a plain IPv6/UDP/GTP-U packet to the specified destination SID.
-Note: This sends a direct GTP-U/IPv6 packet WITHOUT an SRH. For full SRv6+GTP-U
-testing with SRH, an SRH-aware packet generator is needed.
+Vinbero's End.M.GTP6.D processes the GTP-U tunnel carried *inside* an SRv6
+packet, not a bare GTP-U/IPv6 tunnel. The on-the-wire shape it expects is:
+
+  [IPv6(DA=sid)][SRH(nh=UDP, SL=1, segs=[next_seg, sid])][UDP:2152][GTP-U][inner]
+
+so this builds exactly that. End.M.GTP6.D strips the UDP+GTP-U, advances the
+SRH (SL->0, DA->next_seg with Args.Mob.Session encoded), and forwards the inner
+packet over SRv6 toward next_seg (the End.M.GTP6.E SID).
 """
 import argparse
 import sys
 
 try:
-    from scapy.all import IPv6, UDP, ICMPv6EchoRequest, send, conf, raw
+    from scapy.all import IPv6, UDP, IP, ICMP, send, conf, raw
     from scapy.contrib.gtp import GTPHeader, GTPPDUSessionContainer
-    from scapy.layers.inet6 import IPv6ExtHdrRouting
+    from scapy.layers.inet6 import IPv6ExtHdrSegmentRouting
 except ImportError:
     print("ERROR: scapy is required. Install with: pip3 install scapy")
     sys.exit(1)
@@ -23,33 +29,38 @@ conf.verb = 0
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Send GTP-U/IPv6 test packets")
-    parser.add_argument("--src", default="fd00:1::1")
-    parser.add_argument("--dst", default="fc00:1::1", help="SID of End.M.GTP6.D")
+    parser = argparse.ArgumentParser(description="Send SRv6-carried GTP-U test packets")
+    parser.add_argument("--src", default="fc00:10::1")
+    parser.add_argument("--sid", "--dst", dest="sid", default="fc00:1::1",
+                        help="active SID = End.M.GTP6.D SID (IPv6 DA)")
+    parser.add_argument("--next-seg", default="fc00:3::3",
+                        help="next segment = End.M.GTP6.E SID")
     parser.add_argument("--teid", type=lambda x: int(x, 0), default=0xAABBCCDD)
     parser.add_argument("--qfi", type=int, default=5)
     parser.add_argument("--count", type=int, default=3)
     args = parser.parse_args()
 
-    # Build inner packet
-    inner = IPv6(src="fd00:10::1", dst="fd00:10::2") / ICMPv6EchoRequest() / (b"B" * 32)
+    # Inner user packet carried inside GTP-U.
+    inner = IP(src="10.0.0.1", dst="10.0.0.2") / ICMP(id=0x1234, seq=1) / (b"B" * 32)
 
-    # Build GTP-U. gtp_type=0xFF marks the message as a G-PDU (user data); the
-    # BPF gtpu_parse rejects anything else, and scapy's GTPHeader defaults the
-    # field to 0, so it must be set explicitly.
+    # GTP-U. gtp_type=0xFF marks a G-PDU (user data); gtpu_parse rejects anything
+    # else and scapy defaults the field to 0, so it must be set explicitly.
     if args.qfi > 0:
         gtp = GTPHeader(teid=args.teid, gtp_type=0xFF, E=1, next_ex=0x85) / \
               GTPPDUSessionContainer(type=0, QFI=args.qfi)
     else:
         gtp = GTPHeader(teid=args.teid, gtp_type=0xFF)
 
-    # Build outer IPv6 + SRH + UDP + GTP-U
-    # Note: SRH with segments is complex in scapy. Use plain IPv6 + UDP for simplicity.
-    pkt = IPv6(src=args.src, dst=args.dst) / \
-          UDP(sport=2152, dport=2152) / gtp / raw(inner)
+    # SRH: segments [next_seg, sid] with segments_left=1, so the active segment
+    # (the IPv6 DA) is sid; after End.M.GTP6.D it advances to next_seg.
+    srh = IPv6ExtHdrSegmentRouting(addresses=[args.next_seg, args.sid],
+                                   segleft=1, lastentry=1)
 
-    print(f"Sending {args.count} GTP-U/IPv6 packets:")
-    print(f"  Dst SID: {args.dst}")
+    pkt = IPv6(src=args.src, dst=args.sid) / srh / \
+        UDP(sport=2152, dport=2152) / gtp / raw(inner)
+
+    print(f"Sending {args.count} SRv6+GTP-U packets:")
+    print(f"  Active SID (DA): {args.sid}  ->  next segment: {args.next_seg}")
     print(f"  TEID: 0x{args.teid:08X}, QFI: {args.qfi}")
     print()
 

--- a/examples/gtp6-encap/setup.sh
+++ b/examples/gtp6-encap/setup.sh
@@ -13,9 +13,11 @@ export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-gtp6-}"
 
 source "${SCRIPT_DIR}/../common/topologies/three_router.sh"
 
+ns_host1="${TOPO_NS_PREFIX}host1"
 ns_router1="${TOPO_NS_PREFIX}router1"
 ns_router2="${TOPO_NS_PREFIX}router2"
 ns_router3="${TOPO_NS_PREFIX}router3"
+veth_h1_rt1="${TOPO_NS_PREFIX}h1rt1"
 veth_rt1_h1="${TOPO_NS_PREFIX}rt1h1"
 veth_rt1_rt2="${TOPO_NS_PREFIX}rt1rt2"
 veth_rt2_rt1="${TOPO_NS_PREFIX}rt2rt1"
@@ -33,10 +35,17 @@ for ns in "$ns_router1" "$ns_router2" "$ns_router3"; do
     done
 done
 
-# router2: End (transit)
-run ip netns exec "$ns_router2" ip -6 route del local fc00:2::2 2>/dev/null || true
-run ip netns exec "$ns_router2" ip -6 route add local fc00:2::1/128 encap seg6local action End dev lo
-run ip netns exec "$ns_router2" ip -6 route add local fc00:2::2/128 encap seg6local action End dev lo
+# router2 is a pure IPv6 transit: End.M.GTP6.D forwards the inner straight to the
+# End.M.GTP6.E SID (no transit localsid), so router2 only forwards the /56 route.
+
+# host1 plays the upstream node that SRv6-encapsulates GTP-U and sends it to
+# router1's End.M.GTP6.D SID. Give the host1<->router1 link a global IPv6 so
+# host1 can route to fc00:1::/56 (the SID); router1 processes the frame in XDP.
+run ip netns exec "$ns_host1" ip -6 addr add fc00:10::1/64 dev "$veth_h1_rt1"
+run ip netns exec "$ns_router1" ip -6 addr add fc00:10::2/64 dev "$veth_rt1_h1"
+run ip netns exec "$ns_host1" ip -6 route add fc00:1::/56 via fc00:10::2 dev "$veth_h1_rt1"
+# Pre-resolve NDP so the first SRv6 frame is not dropped waiting on it.
+ip netns exec "$ns_host1" ping6 -c 1 -W 1 fc00:10::2 > /dev/null 2>&1 || true
 
 echo ""
 echo "=========================================="

--- a/examples/gtp6-encap/test.sh
+++ b/examples/gtp6-encap/test.sh
@@ -46,47 +46,70 @@ start_vinbero "$ns_router3" "${SCRIPT_DIR}/vinbero_router3.yaml" "/tmp/vinbero_g
 PIDS="$VINBERO_LAST_PID $PIDS"
 wait_vinbero_ready "$ns_router3" "127.0.0.1:8083" 10
 
-# Phase 2: Register entries
-# End.M.GTP6.E uses /56 prefix (Args.Mob.Session at offset 7)
+# Phase 2: Register entries.
+# End.M.GTP6.D/E encode Args.Mob.Session (TEID + QFI = 5 bytes) into the SID at
+# args_offset. GTP6 masks the offset with & 0x0B and 8 stays 8, so the args land
+# at bytes 8-12 and the /64 SID locator (bytes 0-7) stays intact and routable.
 print_info "Registering End.M.GTP6.D on router1..."
 ip netns exec "$ns_router1" ${VINBERO_BIN} -s http://127.0.0.1:8082 sid create \
-  --trigger-prefix fc00:1::/56 --action END_M_GTP6_D --args-offset 7 > /dev/null
+  --trigger-prefix fc00:1::/56 --action END_M_GTP6_D --args-offset 8 > /dev/null
 
 print_info "Registering End.M.GTP6.E on router3..."
 ip netns exec "$ns_router3" ${VINBERO_BIN} -s http://127.0.0.1:8083 sid create \
   --trigger-prefix fc00:3::/56 --action END_M_GTP6_E \
-  --src-addr fc00:3::3 --dst-addr fc00:100::1 --args-offset 7 > /dev/null
+  --src-addr fc00:3::3 --dst-addr fc00:100::1 --args-offset 8 > /dev/null
 
 print_success "All entries registered"
 
-# NDP pre-resolve
+# NDP pre-resolve (End.M.GTP6.D's bpf_fib_lookup + redirect needs the next-hop
+# toward the End.M.GTP6.E SID resolved).
 print_info "Resolving NDP entries..."
 ip netns exec "$ns_router1" ping6 -c 1 -W 1 fc00:12::2 > /dev/null 2>&1 || true
 ip netns exec "$ns_router2" ping6 -c 1 -W 1 fc00:23::3 > /dev/null 2>&1 || true
 sleep 1
 
-# Phase 3: Packet test
+# Phase 3: data-plane test. host1 sends an SRv6 packet carrying GTP-U to router1's
+# End.M.GTP6.D SID; router1 strips the GTP-U and forwards the inner over SRv6
+# toward the End.M.GTP6.E SID (fc00:3::), which we capture on the r1->r2 link.
 echo ""
 echo "=========================================="
-echo "Phase 3: GTP-U/IPv6 Packet Test"
+echo "Phase 3: SRv6+GTP-U Packet Test"
 echo "=========================================="
 
 if ! python3 -c "from scapy.all import IPv6" 2>/dev/null; then
-    print_info "scapy not installed, skipping packet test"
-    print_info "Install with: pip3 install scapy"
+    print_info "scapy not installed, skipping data-plane test"
+    print_info "Install with: apt-get install -y python3-scapy"
+    print_success "Entry registration test passed (packet test skipped)"
     exit 0
 fi
 
-print_info "Listing entries..."
-ip netns exec "$ns_router1" ${VINBERO_BIN} -s http://127.0.0.1:8082 sid list
-ip netns exec "$ns_router3" ${VINBERO_BIN} -s http://127.0.0.1:8083 sid list
-echo ""
+print_info "Capturing SRv6 on the router1->router2 link while sending..."
+ip netns exec "$ns_router2" \
+    tcpdump -i "${TOPO_NS_PREFIX}rt2rt1" -c 3 -w /tmp/gtp6_encap.pcap \
+    'ip6 and dst net fc00:3::/64' 2>/dev/null &
+TCPDUMP_PID=$!
+sleep 1
 
-print_info "Test: Sending GTP-U/IPv6 (QFI=5, TEID=0xAABBCCDD)..."
 ip netns exec "$ns_host1" python3 "${SCRIPT_DIR}/send_gtpu_v6.py" \
-    --dst fc00:1::1 --teid 0xAABBCCDD --qfi 5 --count 1
+    --sid fc00:1::1 --next-seg fc00:3::3 --teid 0xAABBCCDD --qfi 5 --count 3
+sleep 2
 
-TESTS_PASSED=$((TESTS_PASSED + 1))
+kill $TCPDUMP_PID 2>/dev/null || true
+wait $TCPDUMP_PID 2>/dev/null || true
+
+CAPTURED=0
+if [ -f /tmp/gtp6_encap.pcap ]; then
+    CAPTURED=$(tcpdump -r /tmp/gtp6_encap.pcap 2>/dev/null | wc -l)
+fi
+if [ "$CAPTURED" -gt 0 ]; then
+    print_success "End.M.GTP6.D PASS: $CAPTURED SRv6 packets toward End.M.GTP6.E captured"
+    tcpdump -r /tmp/gtp6_encap.pcap -n 2>/dev/null | head -3
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    print_error "End.M.GTP6.D FAIL: no SRv6 packets captured on the r1->r2 link"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+rm -f /tmp/gtp6_encap.pcap
 
 echo ""
 echo "=========================================="
@@ -94,4 +117,11 @@ echo "Test Summary"
 echo "=========================================="
 echo "Passed: $TESTS_PASSED"
 echo "Failed: $TESTS_FAILED"
-print_success "All tests passed!"
+
+if [ $TESTS_FAILED -gt 0 ]; then
+    print_error "Some tests failed"
+    exit 1
+else
+    print_success "All tests passed!"
+    exit 0
+fi

--- a/examples/gtp6-encap/test.sh
+++ b/examples/gtp6-encap/test.sh
@@ -76,18 +76,22 @@ echo "=========================================="
 echo "Phase 3: SRv6+GTP-U Packet Test"
 echo "=========================================="
 
-if ! python3 -c "from scapy.all import IPv6" 2>/dev/null; then
-    print_info "scapy not installed, skipping data-plane test"
+# Check every dependency send_gtpu_v6.py actually imports, not just scapy.all,
+# so a partial scapy install skips cleanly instead of failing mid-run under set -e.
+if ! python3 -c "from scapy.all import IPv6, UDP, IP; from scapy.contrib.gtp import GTPHeader; from scapy.layers.inet6 import IPv6ExtHdrSegmentRouting" 2>/dev/null; then
+    print_info "scapy (with contrib.gtp + SRH) not installed, skipping data-plane test"
     print_info "Install with: apt-get install -y python3-scapy"
     print_success "Entry registration test passed (packet test skipped)"
     exit 0
 fi
 
 print_info "Capturing SRv6 on the router1->router2 link while sending..."
+rm -f /tmp/gtp6_encap.pcap  # drop any stale capture so we never read a previous run's
 ip netns exec "$ns_router2" \
     tcpdump -i "${TOPO_NS_PREFIX}rt2rt1" -c 3 -w /tmp/gtp6_encap.pcap \
     'ip6 and dst net fc00:3::/64' 2>/dev/null &
 TCPDUMP_PID=$!
+PIDS="$TCPDUMP_PID $PIDS"  # also kill it on early exit
 sleep 1
 
 ip netns exec "$ns_host1" python3 "${SCRIPT_DIR}/send_gtpu_v6.py" \

--- a/examples/gtp6-encap/test.sh
+++ b/examples/gtp6-encap/test.sh
@@ -78,7 +78,7 @@ echo "=========================================="
 
 # Check every dependency send_gtpu_v6.py actually imports, not just scapy.all,
 # so a partial scapy install skips cleanly instead of failing mid-run under set -e.
-if ! python3 -c "from scapy.all import IPv6, UDP, IP; from scapy.contrib.gtp import GTPHeader; from scapy.layers.inet6 import IPv6ExtHdrSegmentRouting" 2>/dev/null; then
+if ! python3 -c "from scapy.all import IPv6, UDP, IP, ICMP, raw; from scapy.contrib.gtp import GTPHeader, GTPPDUSessionContainer; from scapy.layers.inet6 import IPv6ExtHdrSegmentRouting" 2>/dev/null; then
     print_info "scapy (with contrib.gtp + SRH) not installed, skipping data-plane test"
     print_info "Install with: apt-get install -y python3-scapy"
     print_success "Entry registration test passed (packet test skipped)"


### PR DESCRIPTION
## 概要

`gtp6-encap` は実質 no-op のテストだった。素の GTP-U/IPv6 パケットを送って無条件に pass していた。Vinbero の End.M.GTP6.D は **SRv6 パケットの中に載った** GTP-U (`[IPv6(DA=SID)][SRH(nh=UDP, SL=1)][UDP][GTP-U][inner]`) を処理するので、旧パケットは一致せず何も検証していなかった (#39)。

## 変更点

- **send_gtpu_v6.py**: End.M.GTP6.D が要求する SRv6-carried GTP-U を生成 (`IPv6ExtHdrSegmentRouting` で `[next_seg, sid]`, segleft=1)、`gtp_type=0xFF` (G-PDU)。
- **setup.sh**: host1↔router1 リンクにグローバル IPv6 を付与し、host1 (upstream SRv6 source 役) が End.M.GTP6.D SID へ到達できるように。router2 は未使用の transit localsid を外して pure IPv6 transit に。
- **test.sh**: `--args-offset 8` で登録 (End.M.GTP6.D は offset を `& 0x0B` でマスクし 8 は 8 のまま。args 5 バイトが byte8-12 に入り /64 SID locator が無傷で経路可能。offset 7 は 3 にマスクされ locator を壊していた)。無条件 pass を、r1→r2 リンクで変換後 SRv6 を捕捉する実 assertion に置換。

`gtp6-encap` は既に CI matrix にあり、本 PR でその job を vacuous pass から実 End.M.GTP6.D データプレーン検証に変える。

## 検証

ローカル (sudo + netns + XDP) で gtp6-encap 1/1 (3 SRv6 packets captured)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)