### PR TITLE
fix(examples): correct false-green FDB test, daemon leaks, and doc drift

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,16 @@ VinberoのSRv6機能を実際に試せるPlayground環境です。
 
 このページは netns example を説明します。interop ラボは [`interop-clab/README.md`](interop-clab/README.md) を参照してください。
 
+## 前提のビルド
+
+netns example は `out/bin/vinberod` と `out/bin/vinbero` を使います。clone 直後は repo ルートで一度ビルドしてください。
+
+```bash
+make protobuf-gen && make bpf-gen && make build
+```
+
+ビルドしていないと `setup.sh` は通っても `test.sh` が Vinbero failed to start で落ちます。
+
 ## クイックスタート
 
 ```bash

--- a/examples/common/test_utils.sh
+++ b/examples/common/test_utils.sh
@@ -45,6 +45,10 @@ print_info() {
 # Usage: start_vinbero <namespace> <config_path> <log_file>
 start_vinbero() {
     local ns="$1" config="$2" log="$3"
+    if [ ! -x "${VINBEROD_BIN}" ]; then
+        print_error "vinberod not found at ${VINBEROD_BIN}. Build it first from the repo root: make build"
+        return 1
+    fi
     setsid ip netns exec "$ns" ${VINBEROD_BIN} -c "$config" > "$log" 2>&1 &
     VINBERO_LAST_PID=$!
     sleep 0.5
@@ -118,7 +122,11 @@ test_ping_with_counter() {
     local interface=${4:-}
 
     print_info "Testing: $desc"
-    local ping_cmd=(ping -c 3 -W 2)
+    # Auto-detect IPv6 by the presence of a colon in the target, mirroring
+    # test_ping above so callers do not need a separate ping6 helper.
+    local ping_bin=ping
+    [[ "$target" == *":"* ]] && ping_bin=ping6
+    local ping_cmd=("$ping_bin" -c 3 -W 2)
     [ -n "$interface" ] && ping_cmd+=(-I "$interface")
     ping_cmd+=("$target")
 

--- a/examples/end-dt2/test.sh
+++ b/examples/end-dt2/test.sh
@@ -26,11 +26,12 @@ VINBERO_PID_RT1=""
 VINBERO_PID_RT3=""
 
 cleanup() {
-    if [ -n "$VINBERO_PID_RT1" ] && ps -p "$VINBERO_PID_RT1" > /dev/null 2>&1; then
+    # Guard against PID reuse: only kill if the PID is still our vinberod.
+    if [ -n "$VINBERO_PID_RT1" ] && [ "$(ps -o comm= -p "$VINBERO_PID_RT1" 2>/dev/null)" = "vinberod" ]; then
         kill "$VINBERO_PID_RT1" 2>/dev/null || true
         wait "$VINBERO_PID_RT1" 2>/dev/null || true
     fi
-    if [ -n "$VINBERO_PID_RT3" ] && ps -p "$VINBERO_PID_RT3" > /dev/null 2>&1; then
+    if [ -n "$VINBERO_PID_RT3" ] && [ "$(ps -o comm= -p "$VINBERO_PID_RT3" 2>/dev/null)" = "vinberod" ]; then
         kill "$VINBERO_PID_RT3" 2>/dev/null || true
         wait "$VINBERO_PID_RT3" 2>/dev/null || true
     fi

--- a/examples/end-dt2/test.sh
+++ b/examples/end-dt2/test.sh
@@ -139,8 +139,11 @@ if echo "$dmac_response" | grep -q '"mac"'; then
     print_success "FDB API: PASS (entries found)"
     TESTS_PASSED=$((TESTS_PASSED + 1))
 else
-    print_info "FDB API: No entries (MAC learning may not have occurred yet)"
-    TESTS_PASSED=$((TESTS_PASSED + 1))
+    # Phase 2's L2VPN ping already crossed the bridge on router3, so the FDB
+    # must hold a learned MAC by now. An empty FDB here means MAC learning is
+    # broken -> fail instead of masking it with a PASS.
+    print_error "FDB API: FAIL (no FDB entries learned after L2VPN traffic)"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 
 echo ""

--- a/examples/end-dt2m-multihomed/README.md
+++ b/examples/end-dt2m-multihomed/README.md
@@ -60,12 +60,16 @@ sudo ./teardown.sh
 1. **Split-horizon (Phase C)**: `host1 → broadcast → PE1` が PE2 経由で
    host1 に戻ってこないこと。PE1 側で `SPLIT_HORIZON_TX > 0`、PE2 側
    (fail-safe 経路) で `SPLIT_HORIZON_RX` をアサート。
-2. **DF 選出 (Phase D)**:
+2. **DF 選出 (Phase D)**: 以下のコマンド例の `vbctl` は `test.sh` /
+   `smoke_api.sh` が `vinbero -s http://127.0.0.1:<PE port>` を包んだシェル関数
+   です。netns 内に `vbctl` という実バイナリはありません。`--esi` には冒頭の実
+   ESI を渡します。
    - 初期状態は DF=PE1。両 PE で
-     `vbctl es df-set --esi ES-1 --pe fc00:1::1` を実行して DF を一致させる。
+     `vbctl es df-set --esi 01:00:00:00:00:00:00:00:00:01 --pe fc00:1::1` を実行して DF を一致させる。
    - リモートからの `PE3 → BUM → host1` は PE1 経由でのみ host1 に届く
      (PE2 側は `NON_DF_DROP` で落ちる)。
-   - DF を PE2 に切り替え: `vbctl es df-set --esi ES-1 --pe fc00:2::2`
+   - DF を PE2 に切り替え:
+     `vbctl es df-set --esi 01:00:00:00:00:00:00:00:00:01 --pe fc00:2::2`
      → 以降は PE2 経由で届く。
 
 ## ステータス

--- a/examples/end-dt2m-multihomed/smoke_api.sh
+++ b/examples/end-dt2m-multihomed/smoke_api.sh
@@ -30,7 +30,8 @@ TESTS_PASSED=0
 TESTS_FAILED=0
 
 cleanup() {
-    if [ -n "$VINBERO_PID" ] && ps -p "$VINBERO_PID" > /dev/null 2>&1; then
+    # Guard against PID reuse: only kill if the PID is still our vinberod.
+    if [ -n "$VINBERO_PID" ] && [ "$(ps -o comm= -p "$VINBERO_PID" 2>/dev/null)" = "vinberod" ]; then
         kill "$VINBERO_PID" 2>/dev/null || true
         wait "$VINBERO_PID" 2>/dev/null || true
     fi

--- a/examples/end-dt2m-multihomed/test.sh
+++ b/examples/end-dt2m-multihomed/test.sh
@@ -34,7 +34,8 @@ TESTS_FAILED=0
 cleanup() {
     for pid_var in VINBERO_PID_PE1 VINBERO_PID_PE2 VINBERO_PID_PE3; do
         local pid="${!pid_var}"
-        [ -n "$pid" ] && ps -p "$pid" > /dev/null 2>&1 && kill "$pid" 2>/dev/null || true
+        # Guard against PID reuse: only kill if the PID is still our vinberod.
+        [ -n "$pid" ] && [ "$(ps -o comm= -p "$pid" 2>/dev/null)" = "vinberod" ] && kill "$pid" 2>/dev/null || true
         [ -n "$pid" ] && wait "$pid" 2>/dev/null || true
     done
 }

--- a/examples/end-dt4/test.sh
+++ b/examples/end-dt4/test.sh
@@ -73,7 +73,7 @@ print_info "Pre-resolving NDP..."
 ip netns exec "$ns_router3" ping6 -c 1 -W 1 fc00:23::2 > /dev/null 2>&1 || true
 
 test_ping_with_counter "$ns_host1" 172.0.2.1 "host1 -> host2 (Vinbero XDP End.DT4 VRF)"
-test_ping_with_counter "$ns_host2" 172.0.1.1 "host2 -> host1 (Vinbero XDP)"
+test_ping_with_counter "$ns_host2" 172.0.1.1 "host2 -> host1 (return path, native baseline)"
 
 print_info "Stopping Vinbero..."
 kill $VINBERO_PID 2>/dev/null || true

--- a/examples/end-dt4/test.sh
+++ b/examples/end-dt4/test.sh
@@ -23,7 +23,8 @@ TESTS_FAILED=0
 VINBERO_PID=""
 
 cleanup() {
-    if [ -n "$VINBERO_PID" ] && ps -p "$VINBERO_PID" > /dev/null 2>&1; then
+    # Guard against PID reuse: only kill if the PID is still our vinberod.
+    if [ -n "$VINBERO_PID" ] && [ "$(ps -o comm= -p "$VINBERO_PID" 2>/dev/null)" = "vinberod" ]; then
         kill "$VINBERO_PID" 2>/dev/null || true
         wait "$VINBERO_PID" 2>/dev/null || true
     fi

--- a/examples/end-dt6/test.sh
+++ b/examples/end-dt6/test.sh
@@ -30,23 +30,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-test_ping6_with_counter() {
-    local ns=$1
-    local target=$2
-    local desc=$3
-
-    print_info "Testing: $desc"
-    if ip netns exec $ns ping6 -c 3 -W 2 $target > /dev/null 2>&1; then
-        print_success "$desc: PASS"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        print_error "$desc: FAIL"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
 echo "=========================================="
 echo "SRv6 End.DT6 (VRF) Test"
 echo "=========================================="
@@ -57,8 +40,8 @@ echo "=========================================="
 echo "Phase 1: Linux Native SRv6 (Baseline)"
 echo "=========================================="
 
-test_ping6_with_counter "$ns_host1" 2001:2::1 "host1 -> host2 (Linux native End.DT6 VRF)"
-test_ping6_with_counter "$ns_host2" 2001:1::1 "host2 -> host1 (Linux native)"
+test_ping_with_counter "$ns_host1" 2001:2::1 "host1 -> host2 (Linux native End.DT6 VRF)"
+test_ping_with_counter "$ns_host2" 2001:1::1 "host2 -> host1 (Linux native)"
 
 print_info "Removing Linux native End.DT6 route from $ns_router3..."
 ip netns exec "$ns_router3" ip -6 route del local fc00:3::3/128 2>/dev/null || true
@@ -87,8 +70,8 @@ sleep 1
 print_info "Pre-resolving NDP..."
 ip netns exec "$ns_router3" ping6 -c 1 -W 1 fc00:23::2 > /dev/null 2>&1 || true
 
-test_ping6_with_counter "$ns_host1" 2001:2::1 "host1 -> host2 (Vinbero XDP End.DT6 VRF)"
-test_ping6_with_counter "$ns_host2" 2001:1::1 "host2 -> host1 (Vinbero XDP)"
+test_ping_with_counter "$ns_host1" 2001:2::1 "host1 -> host2 (Vinbero XDP End.DT6 VRF)"
+test_ping_with_counter "$ns_host2" 2001:1::1 "host2 -> host1 (return path, native baseline)"
 
 print_info "Stopping Vinbero..."
 kill $VINBERO_PID 2>/dev/null || true

--- a/examples/end-dt6/test.sh
+++ b/examples/end-dt6/test.sh
@@ -23,7 +23,8 @@ TESTS_FAILED=0
 VINBERO_PID=""
 
 cleanup() {
-    if [ -n "$VINBERO_PID" ] && ps -p "$VINBERO_PID" > /dev/null 2>&1; then
+    # Guard against PID reuse: only kill if the PID is still our vinberod.
+    if [ -n "$VINBERO_PID" ] && [ "$(ps -o comm= -p "$VINBERO_PID" 2>/dev/null)" = "vinberod" ]; then
         kill "$VINBERO_PID" 2>/dev/null || true
         wait "$VINBERO_PID" 2>/dev/null || true
     fi

--- a/examples/end-dx2v/test.sh
+++ b/examples/end-dx2v/test.sh
@@ -27,11 +27,12 @@ VINBERO_PID_RT1=""
 VINBERO_PID_RT3=""
 
 cleanup() {
-    if [ -n "$VINBERO_PID_RT1" ] && ps -p "$VINBERO_PID_RT1" > /dev/null 2>&1; then
+    # Guard against PID reuse: only kill if the PID is still our vinberod.
+    if [ -n "$VINBERO_PID_RT1" ] && [ "$(ps -o comm= -p "$VINBERO_PID_RT1" 2>/dev/null)" = "vinberod" ]; then
         kill "$VINBERO_PID_RT1" 2>/dev/null || true
         wait "$VINBERO_PID_RT1" 2>/dev/null || true
     fi
-    if [ -n "$VINBERO_PID_RT3" ] && ps -p "$VINBERO_PID_RT3" > /dev/null 2>&1; then
+    if [ -n "$VINBERO_PID_RT3" ] && [ "$(ps -o comm= -p "$VINBERO_PID_RT3" 2>/dev/null)" = "vinberod" ]; then
         kill "$VINBERO_PID_RT3" 2>/dev/null || true
         wait "$VINBERO_PID_RT3" 2>/dev/null || true
     fi

--- a/examples/end-dx4/test.sh
+++ b/examples/end-dx4/test.sh
@@ -21,6 +21,15 @@ ns_router3="${TOPO_NS_PREFIX}router3"
 
 TESTS_PASSED=0
 TESTS_FAILED=0
+VINBERO_PID=""
+
+cleanup() {
+    if [ -n "$VINBERO_PID" ] && ps -p "$VINBERO_PID" > /dev/null 2>&1; then
+        kill "$VINBERO_PID" 2>/dev/null || true
+        wait "$VINBERO_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
 
 echo "=========================================="
 echo "SRv6 End.DX4 Test"
@@ -61,7 +70,7 @@ print_success "SidFunction (End.DX4) entry registered"
 sleep 1
 
 test_ping_with_counter "$ns_host1" 172.0.2.1 "host1 -> host2 (Vinbero XDP End.DX4)"
-test_ping_with_counter "$ns_host2" 172.0.1.1 "host2 -> host1 (Vinbero XDP)"
+test_ping_with_counter "$ns_host2" 172.0.1.1 "host2 -> host1 (return path, native baseline)"
 
 print_info "Stopping Vinbero..."
 kill $VINBERO_PID 2>/dev/null || true

--- a/examples/end-dx4/test.sh
+++ b/examples/end-dx4/test.sh
@@ -24,7 +24,8 @@ TESTS_FAILED=0
 VINBERO_PID=""
 
 cleanup() {
-    if [ -n "$VINBERO_PID" ] && ps -p "$VINBERO_PID" > /dev/null 2>&1; then
+    # Guard against PID reuse: only kill if the PID is still our vinberod.
+    if [ -n "$VINBERO_PID" ] && [ "$(ps -o comm= -p "$VINBERO_PID" 2>/dev/null)" = "vinberod" ]; then
         kill "$VINBERO_PID" 2>/dev/null || true
         wait "$VINBERO_PID" 2>/dev/null || true
     fi

--- a/examples/end-dx6/test.sh
+++ b/examples/end-dx6/test.sh
@@ -21,24 +21,15 @@ ns_router3="${TOPO_NS_PREFIX}router3"
 
 TESTS_PASSED=0
 TESTS_FAILED=0
+VINBERO_PID=""
 
-# Test ping6 with counter
-test_ping6_with_counter() {
-    local ns=$1
-    local target=$2
-    local desc=$3
-
-    print_info "Testing: $desc"
-    if ip netns exec $ns ping -6 -c 3 -W 2 $target > /dev/null 2>&1; then
-        print_success "$desc: PASS"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        print_error "$desc: FAIL"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
+cleanup() {
+    if [ -n "$VINBERO_PID" ] && ps -p "$VINBERO_PID" > /dev/null 2>&1; then
+        kill "$VINBERO_PID" 2>/dev/null || true
+        wait "$VINBERO_PID" 2>/dev/null || true
     fi
 }
+trap cleanup EXIT
 
 echo "=========================================="
 echo "SRv6 End.DX6 Test"
@@ -52,8 +43,8 @@ echo "=========================================="
 
 print_info "Linux native End.DX6 is already configured on $ns_router3 (from setup.sh)"
 
-test_ping6_with_counter "$ns_host1" 2001:2::1 "host1 -> host2 (Linux native End.DX6)"
-test_ping6_with_counter "$ns_host2" 2001:1::1 "host2 -> host1 (Linux native)"
+test_ping_with_counter "$ns_host1" 2001:2::1 "host1 -> host2 (Linux native End.DX6)"
+test_ping_with_counter "$ns_host2" 2001:1::1 "host2 -> host1 (Linux native)"
 
 print_info "Removing Linux native End.DX6 route from $ns_router3..."
 ip netns exec "$ns_router3" ip -6 route del local fc00:3::3/128 2>/dev/null || true
@@ -78,8 +69,8 @@ print_success "SidFunction (End.DX6) entry registered"
 
 sleep 1
 
-test_ping6_with_counter "$ns_host1" 2001:2::1 "host1 -> host2 (Vinbero XDP End.DX6)"
-test_ping6_with_counter "$ns_host2" 2001:1::1 "host2 -> host1 (Vinbero XDP)"
+test_ping_with_counter "$ns_host1" 2001:2::1 "host1 -> host2 (Vinbero XDP End.DX6)"
+test_ping_with_counter "$ns_host2" 2001:1::1 "host2 -> host1 (return path, native baseline)"
 
 print_info "Stopping Vinbero..."
 kill $VINBERO_PID 2>/dev/null || true

--- a/examples/end-dx6/test.sh
+++ b/examples/end-dx6/test.sh
@@ -24,7 +24,8 @@ TESTS_FAILED=0
 VINBERO_PID=""
 
 cleanup() {
-    if [ -n "$VINBERO_PID" ] && ps -p "$VINBERO_PID" > /dev/null 2>&1; then
+    # Guard against PID reuse: only kill if the PID is still our vinberod.
+    if [ -n "$VINBERO_PID" ] && [ "$(ps -o comm= -p "$VINBERO_PID" 2>/dev/null)" = "vinberod" ]; then
         kill "$VINBERO_PID" 2>/dev/null || true
         wait "$VINBERO_PID" 2>/dev/null || true
     fi

--- a/examples/end-t/teardown.sh
+++ b/examples/end-t/teardown.sh
@@ -14,10 +14,8 @@ echo "=========================================="
 echo "Tearing down SRv6 End.T environment"
 echo "=========================================="
 
-print_info "Stopping Vinbero processes..."
-pkill -f "vinbero.*end-t" 2>/dev/null || true
-sleep 1
-
+# Teardown topology. vinberod is started and stopped within test.sh (its EXIT
+# trap fires even on an aborted run), so teardown only removes the namespaces.
 teardown_three_router_topology
 
 echo ""

--- a/examples/end-t/test.sh
+++ b/examples/end-t/test.sh
@@ -24,7 +24,8 @@ TESTS_FAILED=0
 VINBERO_PID=""
 
 cleanup() {
-    if [ -n "$VINBERO_PID" ] && ps -p "$VINBERO_PID" > /dev/null 2>&1; then
+    # Guard against PID reuse: only kill if the PID is still our vinberod.
+    if [ -n "$VINBERO_PID" ] && [ "$(ps -o comm= -p "$VINBERO_PID" 2>/dev/null)" = "vinberod" ]; then
         kill "$VINBERO_PID" 2>/dev/null || true
         wait "$VINBERO_PID" 2>/dev/null || true
     fi

--- a/examples/end-x/setup.sh
+++ b/examples/end-x/setup.sh
@@ -6,9 +6,10 @@ set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Set namespace prefix for this example (allows parallel execution)
-# Default: use directory name (e.g., "end-x" -> "end-x-")
-# Override with TOPO_NS_PREFIX environment variable if needed
+# Set namespace prefix for this example (allows parallel execution).
+# Default: directory name (e.g., "end-x" -> "end-x-").
+# Note: vinbero_*.yaml hardcodes device names with this prefix, so overriding
+# TOPO_NS_PREFIX at runtime also requires editing the devices: list in the YAML.
 EXAMPLE_NAME="$(basename "$SCRIPT_DIR")"
 export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-${EXAMPLE_NAME}-}"
 

--- a/examples/end-x/teardown.sh
+++ b/examples/end-x/teardown.sh
@@ -17,12 +17,10 @@ echo "=========================================="
 echo "Tearing down SRv6 End.X environment"
 echo "=========================================="
 
-# Kill Vinbero if running
-print_info "Stopping Vinbero processes..."
-pkill -f "vinbero.*vinbero_router2.yaml" 2>/dev/null || true
-sleep 1
-
-# Teardown topology
+# Teardown topology. vinberod is started and stopped within test.sh (its EXIT
+# trap fires even on an aborted run), so teardown only removes the namespaces.
+# A broad "pkill -f vinbero..." here would kill a sibling example's daemon
+# during parallel CI runs that share the same config filename.
 teardown_three_router_topology
 
 echo ""

--- a/examples/end-x/test.sh
+++ b/examples/end-x/test.sh
@@ -23,6 +23,15 @@ ns_router2="${TOPO_NS_PREFIX}router2"
 
 TESTS_PASSED=0
 TESTS_FAILED=0
+VINBERO_PID=""
+
+cleanup() {
+    if [ -n "$VINBERO_PID" ] && ps -p "$VINBERO_PID" > /dev/null 2>&1; then
+        kill "$VINBERO_PID" 2>/dev/null || true
+        wait "$VINBERO_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
 
 echo "=========================================="
 echo "SRv6 End.X Operation Test"

--- a/examples/end-x/test.sh
+++ b/examples/end-x/test.sh
@@ -26,7 +26,8 @@ TESTS_FAILED=0
 VINBERO_PID=""
 
 cleanup() {
-    if [ -n "$VINBERO_PID" ] && ps -p "$VINBERO_PID" > /dev/null 2>&1; then
+    # Guard against PID reuse: only kill if the PID is still our vinberod.
+    if [ -n "$VINBERO_PID" ] && [ "$(ps -o comm= -p "$VINBERO_PID" 2>/dev/null)" = "vinberod" ]; then
         kill "$VINBERO_PID" 2>/dev/null || true
         wait "$VINBERO_PID" 2>/dev/null || true
     fi

--- a/examples/end/README.md
+++ b/examples/end/README.md
@@ -29,42 +29,44 @@ sudo ./teardown.sh # クリーンアップ（環境削除）
 
 ## 手動実行
 
+namespace と veth は setup.sh が `end-` を前置します (例: namespace `end-router2`、veth `end-rt3rt2`)。TOPO_NS_PREFIX を変えた場合はこの prefix も読み替えてください。
+
 ### 1. 環境構築とVinbero起動
 
 ```bash
 sudo ./setup.sh
 
 # router2のLinux native SRv6を削除
-sudo ip netns exec router2 ip -6 route del local fc00:2::1/128 2>/dev/null
-sudo ip netns exec router2 ip -6 route del local fc00:2::2/128 2>/dev/null
+sudo ip netns exec end-router2 ip -6 route del local fc00:2::1/128 2>/dev/null
+sudo ip netns exec end-router2 ip -6 route del local fc00:2::2/128 2>/dev/null
 
-# Vinbero起動
-sudo ip netns exec router2 ../../out/bin/vinberod -c vinbero_router2.yaml
+# Vinbero起動 (バックグラウンド)
+sudo ip netns exec end-router2 ../../out/bin/vinberod -c vinbero_router2.yaml &
 ```
 
 ### 2. SID登録
 
 ```bash
-sudo ip netns exec router2 ../../out/bin/vinbero -s http://127.0.0.1:8082 sid create --trigger-prefix fc00:2::1/128 --action END
-sudo ip netns exec router2 ../../out/bin/vinbero -s http://127.0.0.1:8082 sid create --trigger-prefix fc00:2::2/128 --action END
+sudo ip netns exec end-router2 ../../out/bin/vinbero -s http://127.0.0.1:8082 sid create --trigger-prefix fc00:2::1/128 --action END
+sudo ip netns exec end-router2 ../../out/bin/vinbero -s http://127.0.0.1:8082 sid create --trigger-prefix fc00:2::2/128 --action END
 ```
 
 ### 3. テスト
 
 ```bash
-sudo ip netns exec host1 ping -c 3 172.0.2.1
-sudo ip netns exec host2 ping -c 3 172.0.1.1
+sudo ip netns exec end-host1 ping -c 3 172.0.2.1
+sudo ip netns exec end-host2 ping -c 3 172.0.1.1
 ```
 
 #### パケットキャプチャ
 
 ```bash
-sudo ip netns exec router3 tcpdump -i veth-rt3-rt2 -n ip6
+sudo ip netns exec end-router3 tcpdump -i end-rt3rt2 -n ip6
 ```
 
 SRv6 Routing Header (RT6) でsegleft: 1→0、DA: fc00:2::1→fc00:3::3の変化が確認できます。
 
-### 4. 環境のクリーンナップ
+### 4. 環境のクリーンアップ
 ```bash
 sudo ./teardown.sh
 ```

--- a/examples/end/setup.sh
+++ b/examples/end/setup.sh
@@ -6,9 +6,10 @@ set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Set namespace prefix for this example (allows parallel execution)
-# Default: use directory name (e.g., "end" -> "end-")
-# Override with TOPO_NS_PREFIX environment variable if needed
+# Set namespace prefix for this example (allows parallel execution).
+# Default: directory name (e.g., "end" -> "end-").
+# Note: vinbero_*.yaml hardcodes device names with this prefix, so overriding
+# TOPO_NS_PREFIX at runtime also requires editing the devices: list in the YAML.
 EXAMPLE_NAME="$(basename "$SCRIPT_DIR")"
 export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-${EXAMPLE_NAME}-}"
 

--- a/examples/end/teardown.sh
+++ b/examples/end/teardown.sh
@@ -17,12 +17,10 @@ echo "=========================================="
 echo "Tearing down SRv6 End environment"
 echo "=========================================="
 
-# Kill Vinbero if running
-print_info "Stopping Vinbero processes..."
-pkill -f "vinbero.*vinbero_router2.yaml" 2>/dev/null || true
-sleep 1
-
-# Teardown topology
+# Teardown topology. vinberod is started and stopped within test.sh (its EXIT
+# trap fires even on an aborted run), so teardown only removes the namespaces.
+# A broad "pkill -f vinbero..." here would kill a sibling example's daemon
+# during parallel CI runs that share the same config filename.
 teardown_three_router_topology
 
 echo ""

--- a/examples/end/test.sh
+++ b/examples/end/test.sh
@@ -23,6 +23,15 @@ ns_router2="${TOPO_NS_PREFIX}router2"
 
 TESTS_PASSED=0
 TESTS_FAILED=0
+VINBERO_PID=""
+
+cleanup() {
+    if [ -n "$VINBERO_PID" ] && ps -p "$VINBERO_PID" > /dev/null 2>&1; then
+        kill "$VINBERO_PID" 2>/dev/null || true
+        wait "$VINBERO_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
 
 echo "=========================================="
 echo "SRv6 End Operation Test"

--- a/examples/end/test.sh
+++ b/examples/end/test.sh
@@ -26,7 +26,8 @@ TESTS_FAILED=0
 VINBERO_PID=""
 
 cleanup() {
-    if [ -n "$VINBERO_PID" ] && ps -p "$VINBERO_PID" > /dev/null 2>&1; then
+    # Guard against PID reuse: only kill if the PID is still our vinberod.
+    if [ -n "$VINBERO_PID" ] && [ "$(ps -o comm= -p "$VINBERO_PID" 2>/dev/null)" = "vinberod" ]; then
         kill "$VINBERO_PID" 2>/dev/null || true
         wait "$VINBERO_PID" 2>/dev/null || true
     fi

--- a/examples/gtp4-encap/README.md
+++ b/examples/gtp4-encap/README.md
@@ -7,16 +7,16 @@ RFC 9433に基づくGTP-U/IPv4とSRv6の双方向変換のデモ環境です。
 ```mermaid
 graph LR
     gNB[gNB/host1<br/>172.0.1.1<br/>GTP-U/IPv4] -->|GTP-U| router1[router1 / Vinbero XDP<br/>fc00:1::1<br/>H.M.GTP4.D → SRv6<br/>End.M.GTP4.E ← SRv6]
-    router1 -->|SRv6| router2[router2<br/>fc00:2::1<br/>End]
-    router2 -->|SRv6| router3[router3 / Vinbero XDP<br/>fc00:3::3<br/>End.M.GTP4.E → GTP-U<br/>H.M.GTP4.D ← GTP-U]
+    router1 -->|SRv6| router2[router2<br/>IPv6 transit]
+    router2 -->|SRv6| router3[router3 / Vinbero XDP<br/>fc00:3::/56<br/>End.M.GTP4.E → GTP-U<br/>H.M.GTP4.D ← GTP-U]
     router3 -->|GTP-U| UPF[UPF/host2<br/>172.0.2.1<br/>GTP-U/IPv4]
 ```
 
 **パケットの流れ（gNB→UPF）:**
 1. gNBがGTP-U/IPv4パケットを送信 (TEID, QFI付き)
-2. **router1 (H.M.GTP4.D)**: GTP-Uを剥離、SRv6でカプセル化。Args.Mob.Session (IPv4Dst, TEID, QFI) をSIDにエンコード
-3. router2 (End): SRv6 transit (SL--, DA更新)
-4. **router3 (End.M.GTP4.E)**: SRv6を剥離、SIDからTEID/QFIをデコード、GTP-U/IPv4で再カプセル化
+2. **router1 (H.M.GTP4.D)**: GTP-Uを剥離、SRv6でカプセル化。Args.Mob.Session (IPv4Dst, TEID, QFI) を End.M.GTP4.E SID へ single segment で encode
+3. router2: 素の IPv6 として transit (localsid なし、single segment なので End hop は無い)
+4. **router3 (End.M.GTP4.E)**: SRv6を剥離、SIDからTEID/QFIを decode、GTP-U/IPv4で再カプセル化
 5. UPFがGTP-U/IPv4パケットを受信
 
 ## クイックスタート
@@ -57,21 +57,33 @@ sudo ip netns exec gtp4-router3 ../../out/bin/vinberod -c vinbero_router3.yaml &
 
 ### 2. エントリ登録
 
+router2 は素の IPv6 transit なので、headend は single segment で End.M.GTP4.E SID へ直接 encap します。End.M.GTP4.E は args-offset 7 で Args.Mob.Session が SID の byte 7-15 に入るため、`/128` ではマッチせず `/56` locator で登録します。
+
 ```bash
 # Forward: gNB -> SRv6 (router1: H.M.GTP4.D)
 sudo ip netns exec gtp4-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
   hv4 create --trigger-prefix 172.0.2.0/24 --src-addr fc00:1::1 \
-  --segments fc00:2::1,fc00:3::3 --mode H_M_GTP4_D --args-offset 7
+  --segments fc00:3::3 --mode H_M_GTP4_D --args-offset 7
 
 # Forward: SRv6 -> UPF (router3: End.M.GTP4.E)
 sudo ip netns exec gtp4-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
-  sid create --trigger-prefix fc00:3::3/128 --action END_M_GTP4_E \
+  sid create --trigger-prefix fc00:3::/56 --action END_M_GTP4_E \
   --gtp-v4-src-addr 172.0.2.2 --args-offset 7
+
+# Return: UPF -> SRv6 (router3: H.M.GTP4.D)
+sudo ip netns exec gtp4-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
+  hv4 create --trigger-prefix 172.0.1.0/24 --src-addr fc00:3::3 \
+  --segments fc00:1::1 --mode H_M_GTP4_D --args-offset 7
+
+# Return: SRv6 -> gNB (router1: End.M.GTP4.E)
+sudo ip netns exec gtp4-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
+  sid create --trigger-prefix fc00:1::/56 --action END_M_GTP4_E \
+  --gtp-v4-src-addr 172.0.1.2 --args-offset 7
 ```
 
 ### 3. Args.Mob.Session
 
-SID内のオフセット7からArgs.Mob.Sessionがエンコードされます:
+SID内のオフセット7からArgs.Mob.Sessionが encode されます:
 
 ```
 SID (128 bit): [LOC:FUNCT (56 bit)][IPv4DstAddr (32 bit)][TEID (32 bit)][QFI(6)|R(1)|U(1)]

--- a/examples/gtp4-encap/test.sh
+++ b/examples/gtp4-encap/test.sh
@@ -121,6 +121,7 @@ ip netns exec "$ns_host1" python3 "${SCRIPT_DIR}/send_gtpu.py" \
     --outer-dst 172.0.2.100 --teid 0x12345678 --qfi 9 --count 3
 
 wait $TCPDUMP_PID 2>/dev/null || true
+PIDS="${PIDS/$TCPDUMP_PID /}"  # reaped; drop it so the EXIT trap can't kill a recycled PID
 
 CAPTURED=0
 [ -f /tmp/gtp4_test1.pcap ] && CAPTURED=$(tcpdump -r /tmp/gtp4_test1.pcap 2>/dev/null | wc -l)
@@ -149,6 +150,7 @@ ip netns exec "$ns_host1" python3 "${SCRIPT_DIR}/send_gtpu.py" \
     --outer-dst 172.0.2.100 --teid 0xCAFEBABE --qfi 0 --count 1
 
 wait $TCPDUMP_PID 2>/dev/null || true
+PIDS="${PIDS/$TCPDUMP_PID /}"  # reaped; drop it so the EXIT trap can't kill a recycled PID
 
 CAPTURED=0
 [ -f /tmp/gtp4_test2.pcap ] && CAPTURED=$(tcpdump -r /tmp/gtp4_test2.pcap 2>/dev/null | wc -l)

--- a/examples/gtp4-encap/test.sh
+++ b/examples/gtp4-encap/test.sh
@@ -103,71 +103,73 @@ if ! python3 -c "from scapy.all import IP" 2>/dev/null; then
     exit 0
 fi
 
-# Test 1: GTP-U with QFI (5G)
+# Test 1: GTP-U with QFI (5G). Capture on router2's link toward router1 and
+# filter to the End.M.GTP4.E SID locator (fc00:3::/56) so we only count
+# SRv6-encapsulated packets, not stray NDP/ICMPv6 on the same link. CAPTURED is
+# initialised outside the -f guard so a missing pcap fails instead of silently
+# skipping. timeout caps tcpdump so a capture miss surfaces in ~8s.
 print_info "Test 1: GTP-U with QFI=9 (5G mode)"
+rm -f /tmp/gtp4_test1.pcap
 ip netns exec "$ns_router2" \
-    tcpdump -i "${TOPO_NS_PREFIX}rt2rt1" -c 3 -w /tmp/gtp4_test1.pcap \
-    ip6 2>/dev/null &
+    timeout 8 tcpdump -i "${TOPO_NS_PREFIX}rt2rt1" -c 3 -w /tmp/gtp4_test1.pcap \
+    'ip6 and dst net fc00:3::/56' 2>/dev/null &
 TCPDUMP_PID=$!
+PIDS="$TCPDUMP_PID $PIDS"
 sleep 1
 
 ip netns exec "$ns_host1" python3 "${SCRIPT_DIR}/send_gtpu.py" \
     --outer-dst 172.0.2.100 --teid 0x12345678 --qfi 9 --count 3
-sleep 2
 
-kill $TCPDUMP_PID 2>/dev/null || true
 wait $TCPDUMP_PID 2>/dev/null || true
 
-if [ -f /tmp/gtp4_test1.pcap ]; then
-    CAPTURED=$(tcpdump -r /tmp/gtp4_test1.pcap 2>/dev/null | wc -l)
-    if [ "$CAPTURED" -gt 0 ]; then
-        print_success "Test 1 PASS: $CAPTURED SRv6 packets captured (H.M.GTP4.D works)"
-        tcpdump -r /tmp/gtp4_test1.pcap -n 2>/dev/null | head -3
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-    else
-        print_error "Test 1 FAIL: No SRv6 packets captured"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-    fi
-    rm -f /tmp/gtp4_test1.pcap
+CAPTURED=0
+[ -f /tmp/gtp4_test1.pcap ] && CAPTURED=$(tcpdump -r /tmp/gtp4_test1.pcap 2>/dev/null | wc -l)
+if [ "$CAPTURED" -gt 0 ]; then
+    print_success "Test 1 PASS: $CAPTURED SRv6 packets toward End.M.GTP4.E captured (H.M.GTP4.D works)"
+    tcpdump -r /tmp/gtp4_test1.pcap -n 2>/dev/null | head -3
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    print_error "Test 1 FAIL: no SRv6 packets toward the End.M.GTP4.E SID captured"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
+rm -f /tmp/gtp4_test1.pcap
 
 # Test 2: GTP-U without QFI (4G/LTE mode)
 echo ""
 print_info "Test 2: GTP-U without QFI (4G/LTE mode)"
+rm -f /tmp/gtp4_test2.pcap
 ip netns exec "$ns_router2" \
-    tcpdump -i "${TOPO_NS_PREFIX}rt2rt1" -c 1 -w /tmp/gtp4_test2.pcap \
-    ip6 2>/dev/null &
+    timeout 8 tcpdump -i "${TOPO_NS_PREFIX}rt2rt1" -c 1 -w /tmp/gtp4_test2.pcap \
+    'ip6 and dst net fc00:3::/56' 2>/dev/null &
 TCPDUMP_PID=$!
+PIDS="$TCPDUMP_PID $PIDS"
 sleep 1
 
 ip netns exec "$ns_host1" python3 "${SCRIPT_DIR}/send_gtpu.py" \
     --outer-dst 172.0.2.100 --teid 0xCAFEBABE --qfi 0 --count 1
-sleep 2
 
-kill $TCPDUMP_PID 2>/dev/null || true
 wait $TCPDUMP_PID 2>/dev/null || true
 
-if [ -f /tmp/gtp4_test2.pcap ]; then
-    CAPTURED=$(tcpdump -r /tmp/gtp4_test2.pcap 2>/dev/null | wc -l)
-    if [ "$CAPTURED" -gt 0 ]; then
-        print_success "Test 2 PASS: $CAPTURED SRv6 packets captured (4G compat works)"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-    else
-        print_error "Test 2 FAIL: No SRv6 packets captured"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-    fi
-    rm -f /tmp/gtp4_test2.pcap
+CAPTURED=0
+[ -f /tmp/gtp4_test2.pcap ] && CAPTURED=$(tcpdump -r /tmp/gtp4_test2.pcap 2>/dev/null | wc -l)
+if [ "$CAPTURED" -gt 0 ]; then
+    print_success "Test 2 PASS: $CAPTURED SRv6 packets toward End.M.GTP4.E captured (4G compat works)"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    print_error "Test 2 FAIL: no SRv6 packets toward the End.M.GTP4.E SID captured"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
+rm -f /tmp/gtp4_test2.pcap
 
 # Test 3: Non-GTP-U traffic should pass through
 echo ""
 print_info "Test 3: Non-GTP-U IPv4 (should XDP_PASS)"
-ip netns exec "$ns_host1" ping -c 1 -W 2 172.0.2.1 > /dev/null 2>&1 && {
+if ip netns exec "$ns_host1" ping -c 1 -W 2 172.0.2.1 > /dev/null 2>&1; then
     print_success "Test 3 PASS: Plain IPv4 passes through"
     TESTS_PASSED=$((TESTS_PASSED + 1))
-} || {
+else
     print_info "Test 3 SKIP: Plain IPv4 ping failed (expected in some setups)"
-}
+fi
 
 echo ""
 echo "=========================================="

--- a/examples/gtp6-drop-in/README.md
+++ b/examples/gtp6-drop-in/README.md
@@ -33,4 +33,4 @@ sudo ./teardown.sh
 3. パケットを書き換えずに `XDP_PASS` でカーネルに委譲 (SL/DA/nexthdr は不変)
 4. カーネル SRv6 スタックがそのまま処理
 
-変換が無いため、`test.sh` は per-slot 呼び出しカウンタ (`vbctl stats slot show`) で Di プログラムが当該パケットに対して実行されたことを確認します。
+変換が無いため、`test.sh` は per-slot 呼び出しカウンタ (`vinbero stats slot show`) で Di プログラムが当該パケットに対して実行されたことを確認します。netns example のクライアントバイナリは `vinbero` です (`out/bin/vbctl` はありません。`vbctl` は interop-clab の Docker image 内の symlink です)。

--- a/examples/gtp6-encap/README.md
+++ b/examples/gtp6-encap/README.md
@@ -14,9 +14,9 @@ graph LR
 
 **パケットの流れ:**
 1. gNB が素の GTP-U/IPv6 パケットを N3/UPF アドレス (2001:db8:caf::/64) 宛に送信。router1 経由でルーティングされる
-2. **router1 (H.M.GTP6.D)**: outer IPv6 dst で GTP-U tunnel を intercept し、外側 IPv6+UDP+GTP-U を剥離して End.M.GTP6.E SID 向けに SRv6 encap。TEID/QFI を SID の Args.Mob.Session (args_offset 8) にエンコード
+2. **router1 (H.M.GTP6.D)**: outer IPv6 dst で GTP-U tunnel を intercept し、外側 IPv6+UDP+GTP-U を剥離して End.M.GTP6.E SID 向けに SRv6 encap。TEID/QFI を SID の Args.Mob.Session (args_offset 8) に encode
 3. router2: SRv6 を素の IPv6 として transit (localsid なし)
-4. **router3 (End.M.GTP6.E)**: SRv6 を剥離、SID から TEID/QFI をデコードして GTP-U/IPv6 で再カプセル化
+4. **router3 (End.M.GTP6.E)**: SRv6 を剥離、SID から TEID/QFI を decode して GTP-U/IPv6 で再カプセル化
 
 args_offset を 8 にすることで Args.Mob.Session の 5 バイトが /64 locator の外 (byte 8-12) に入り、SID が経路可能なまま保たれます。
 

--- a/examples/gtp6-encap/test.sh
+++ b/examples/gtp6-encap/test.sh
@@ -102,6 +102,7 @@ ip netns exec "$ns_host1" python3 "${SCRIPT_DIR}/send_gtpu_v6.py" \
     --dst 2001:db8:caf::1 --teid 0xAABBCCDD --qfi 5 --count 3
 
 wait $TCPDUMP_PID 2>/dev/null || true
+PIDS="${PIDS/$TCPDUMP_PID /}"  # reaped; drop it so the EXIT trap can't kill a recycled PID
 
 CAPTURED=0
 if [ -f /tmp/gtp6_encap.pcap ]; then

--- a/examples/headend-l2/test.sh
+++ b/examples/headend-l2/test.sh
@@ -28,11 +28,12 @@ VINBERO_PID_RT3=""
 
 # Cleanup function
 cleanup() {
-    if [ -n "$VINBERO_PID_RT1" ] && ps -p "$VINBERO_PID_RT1" > /dev/null 2>&1; then
+    # Guard against PID reuse: only kill if the PID is still our vinberod.
+    if [ -n "$VINBERO_PID_RT1" ] && [ "$(ps -o comm= -p "$VINBERO_PID_RT1" 2>/dev/null)" = "vinberod" ]; then
         kill "$VINBERO_PID_RT1" 2>/dev/null || true
         wait "$VINBERO_PID_RT1" 2>/dev/null || true
     fi
-    if [ -n "$VINBERO_PID_RT3" ] && ps -p "$VINBERO_PID_RT3" > /dev/null 2>&1; then
+    if [ -n "$VINBERO_PID_RT3" ] && [ "$(ps -o comm= -p "$VINBERO_PID_RT3" 2>/dev/null)" = "vinberod" ]; then
         kill "$VINBERO_PID_RT3" 2>/dev/null || true
         wait "$VINBERO_PID_RT3" 2>/dev/null || true
     fi

--- a/examples/headend-v4/test.sh
+++ b/examples/headend-v4/test.sh
@@ -22,6 +22,15 @@ ns_router1="${TOPO_NS_PREFIX}router1"
 
 TESTS_PASSED=0
 TESTS_FAILED=0
+VINBERO_PID=""
+
+cleanup() {
+    if [ -n "$VINBERO_PID" ] && ps -p "$VINBERO_PID" > /dev/null 2>&1; then
+        kill "$VINBERO_PID" 2>/dev/null || true
+        wait "$VINBERO_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
 
 echo "=========================================="
 echo "SRv6 H.Encaps (Headend IPv4) Test"

--- a/examples/headend-v4/test.sh
+++ b/examples/headend-v4/test.sh
@@ -25,7 +25,8 @@ TESTS_FAILED=0
 VINBERO_PID=""
 
 cleanup() {
-    if [ -n "$VINBERO_PID" ] && ps -p "$VINBERO_PID" > /dev/null 2>&1; then
+    # Guard against PID reuse: only kill if the PID is still our vinberod.
+    if [ -n "$VINBERO_PID" ] && [ "$(ps -o comm= -p "$VINBERO_PID" 2>/dev/null)" = "vinberod" ]; then
         kill "$VINBERO_PID" 2>/dev/null || true
         wait "$VINBERO_PID" 2>/dev/null || true
     fi

--- a/examples/headend-v6/test.sh
+++ b/examples/headend-v6/test.sh
@@ -25,7 +25,8 @@ TESTS_FAILED=0
 VINBERO_PID=""
 
 cleanup() {
-    if [ -n "$VINBERO_PID" ] && ps -p "$VINBERO_PID" > /dev/null 2>&1; then
+    # Guard against PID reuse: only kill if the PID is still our vinberod.
+    if [ -n "$VINBERO_PID" ] && [ "$(ps -o comm= -p "$VINBERO_PID" 2>/dev/null)" = "vinberod" ]; then
         kill "$VINBERO_PID" 2>/dev/null || true
         wait "$VINBERO_PID" 2>/dev/null || true
     fi

--- a/examples/headend-v6/test.sh
+++ b/examples/headend-v6/test.sh
@@ -22,24 +22,15 @@ ns_router1="${TOPO_NS_PREFIX}router1"
 
 TESTS_PASSED=0
 TESTS_FAILED=0
+VINBERO_PID=""
 
-# Test ping6 with counter
-test_ping6_with_counter() {
-    local ns=$1
-    local target=$2
-    local desc=$3
-
-    print_info "Testing: $desc"
-    if ip netns exec $ns ping6 -c 3 -W 2 $target > /dev/null 2>&1; then
-        print_success "$desc: PASS"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        print_error "$desc: FAIL"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
+cleanup() {
+    if [ -n "$VINBERO_PID" ] && ps -p "$VINBERO_PID" > /dev/null 2>&1; then
+        kill "$VINBERO_PID" 2>/dev/null || true
+        wait "$VINBERO_PID" 2>/dev/null || true
     fi
 }
+trap cleanup EXIT
 
 echo "=========================================="
 echo "SRv6 H.Encaps (Headend IPv6) Test"
@@ -53,8 +44,8 @@ echo "=========================================="
 
 print_info "Linux native T.Encaps is already configured on $ns_router1 (from setup.sh)"
 
-test_ping6_with_counter "$ns_host1" 2001:2::1 "host1 -> host2 (Linux native T.Encaps)"
-test_ping6_with_counter "$ns_host2" 2001:1::1 "host2 -> host1 (Linux native T.Encaps)"
+test_ping_with_counter "$ns_host1" 2001:2::1 "host1 -> host2 (Linux native T.Encaps)"
+test_ping_with_counter "$ns_host2" 2001:1::1 "host2 -> host1 (Linux native T.Encaps)"
 
 print_info "Removing Linux native T.Encaps route from $ns_router1..."
 ip netns exec "$ns_router1" ip -6 route del 2001:2::/64 2>/dev/null || true
@@ -79,8 +70,8 @@ print_success "HeadendV6 entry registered"
 
 sleep 1
 
-test_ping6_with_counter "$ns_host1" 2001:2::1 "host1 -> host2 (Vinbero XDP H.Encaps)"
-test_ping6_with_counter "$ns_host2" 2001:1::1 "host2 -> host1 (Vinbero XDP)"
+test_ping_with_counter "$ns_host1" 2001:2::1 "host1 -> host2 (Vinbero XDP H.Encaps)"
+test_ping_with_counter "$ns_host2" 2001:1::1 "host2 -> host1 (Vinbero XDP)"
 
 print_info "Stopping Vinbero..."
 kill $VINBERO_PID 2>/dev/null || true


### PR DESCRIPTION
## 概要

`examples/` を起点にしたレビューで挙がった指摘のうち、Blocker 1 件と Should Fix 9 件に対応します。test の PASS が実際の機能を保証するようにし、早期失敗時の daemon / XDP bpf_link リークを止め、README と実装の乖離を解消します。

## Blocker

- **end-dt2 の FDB テストが常に PASS していた問題** (`end-dt2/test.sh`)。Phase 3 が `if`/`else` の両分岐で `TESTS_PASSED` を加算しており、FDB が空でも成功扱いになっていました。Phase 2 の L2VPN ping がブリッジを通って MAC を学習させるため、空 FDB は本当の故障とみなして FAIL にします。

## Should Fix

- **test の cleanup 契約**: `set -e` 下で `return 1` する独自 `test_ping6_with_counter` を 3 example から削除し、IPv6 自動判定を入れた共通 `test_ping_with_counter` に統合します。trap 欠落の 6 example (`end` / `end-x` / `end-dx4` / `end-dx6` / `headend-v4` / `headend-v6`) に `trap cleanup EXIT` を追加し、早期失敗で vinberod と XDP bpf_link が残らないようにします。
- **teardown の pkill 誤殺**: `end` / `end-x` / `end-t` が同名 config を使うため `pkill -f vinbero...` が並列 CI で隣の daemon を巻き添えにしていました。namespace 削除と test の EXIT trap で停止できるので pkill を削除します。
- **gtp4-encap の pcap 検証**: filter を End.M.GTP4.E の SID locator (`dst net fc00:3::/56`) に絞って SRv6 encap を実証し、`CAPTURED` を初期化、Test 3 を if/else 化します (gtp6-encap に整合)。
- **reverse ラベルの修正**: `end-dx4` / `end-dx6` / `end-dt4` / `end-dt6` のリバース ping は router1 の Linux native が decap するため、`(Vinbero XDP)` から native baseline 表記に直します。end-x はリバースも Vinbero End.X を通るためそのままです。
- **ドキュメント**: `examples/README.md` に make build 前提を追記、`end/README.md` の手動コマンドの namespace prefix 欠落を修正、`gtp4-encap/README.md` を single segment / `/56` の実装に合わせる、netns README の存在しない `vbctl` を `vinbero` に置換、per-example YAML が device 名を prefix で固定する点を明記、`encode` / `decode` のカタカナ転写を修正します。
- **common/test_utils.sh**: vinberod 未ビルド時に分かりやすいメッセージで早期 fail します。

## 検証

- 変更した 16 個のシェルスクリプトは `bash -n` を通過します。
- Go コードは変更していません。

## 繰り越し

slot-counter による正検証の横展開、`set -euo pipefail` の一斉統一、interop-clab の README 2 階層化や `make status` / `logs` のシナリオ対応、interop ja README の文体修正は、設計判断や実機検証が要るため別 PR にします。
