### PR TITLE
feat(scripts): add one-liner installer for prebuilt binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ https://github.com/takehaya/Vinbero-legacy/tree/master) has become outdated, so 
 
 The fastest way to get `vinberod` and `vinbero` is the one-liner installer,
 which pulls the latest GitHub release and drops both binaries into
-`/usr/local/bin`. It needs `curl` and `jq` available.
+`/usr/local/bin`. It needs `curl` and `jq` available (plus coreutils
+`install` / `sha256sum`, and `tar` when using `--with-sdk`).
 
 ```bash
 # Latest release

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ https://github.com/takehaya/Vinbero-legacy/tree/master) has become outdated, so 
 
 The fastest way to get `vinberod` and `vinbero` is the one-liner installer,
 which pulls the latest GitHub release and drops both binaries into
-`/usr/local/bin`. It needs `curl` and `jq` available (plus coreutils
-`install` / `sha256sum`, and `tar` when using `--with-sdk`).
+`/usr/local/bin`. It needs `curl`, `jq`, and `install` available. Checksum
+verification uses `sha256sum` when present and is skipped otherwise, and
+`--with-sdk` additionally needs `tar`.
 
 ```bash
 # Latest release

--- a/README.md
+++ b/README.md
@@ -10,6 +10,26 @@ https://github.com/takehaya/Vinbero-legacy/tree/master) has become outdated, so 
 
 ## Quickstart
 
+### Install (prebuilt binaries)
+
+The fastest way to get `vinberod` and `vinbero` is the one-liner installer,
+which pulls the latest GitHub release and drops both binaries into
+`/usr/local/bin`. It needs `curl` and `jq` available.
+
+```bash
+# Latest release
+curl -fsSL https://raw.githubusercontent.com/takehaya/vinbero/main/scripts/install_vinbero.sh | sudo bash
+
+# Pin a specific release
+curl -fsSL https://raw.githubusercontent.com/takehaya/vinbero/main/scripts/install_vinbero.sh | sudo bash -s -- --version v0.0.4
+
+# Also install the plugin SDK (headers + examples) under /usr/local
+curl -fsSL https://raw.githubusercontent.com/takehaya/vinbero/main/scripts/install_vinbero.sh | sudo bash -s -- --with-sdk
+```
+
+Prebuilt binaries currently target `linux/amd64`. To build from source instead,
+see below.
+
 ### Build
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ verification uses `sha256sum` when present and is skipped otherwise, and
 
 ```bash
 # Latest release
-curl -fsSL https://raw.githubusercontent.com/takehaya/vinbero/main/scripts/install_vinbero.sh | sudo bash
+curl -fsSL https://raw.githubusercontent.com/takehaya/Vinbero/main/scripts/install_vinbero.sh | sudo bash
 
 # Pin a specific release
-curl -fsSL https://raw.githubusercontent.com/takehaya/vinbero/main/scripts/install_vinbero.sh | sudo bash -s -- --version v0.0.4
+curl -fsSL https://raw.githubusercontent.com/takehaya/Vinbero/main/scripts/install_vinbero.sh | sudo bash -s -- --version v0.0.4
 
 # Also install the plugin SDK (headers + examples) under /usr/local
-curl -fsSL https://raw.githubusercontent.com/takehaya/vinbero/main/scripts/install_vinbero.sh | sudo bash -s -- --with-sdk
+curl -fsSL https://raw.githubusercontent.com/takehaya/Vinbero/main/scripts/install_vinbero.sh | sudo bash -s -- --with-sdk
 ```
 
 Prebuilt binaries currently target `linux/amd64`. To build from source instead,

--- a/scripts/install_vinbero.sh
+++ b/scripts/install_vinbero.sh
@@ -116,8 +116,8 @@ TAG_NAME="$(printf '%s' "$JSON" | jq -r '.tag_name // empty')"
 # JSON を渡すのに echo を使うと xpg_echo などでバックスラッシュが解釈され壊れうるため printf を使う。
 asset_url() {
   local pattern="$1"
-  # 先頭一致を jq の first() で取り、head へのパイプを無くす。pipefail 下で
-  # 複数マッチ時に上流 jq が SIGPIPE で落ちて呼び出しが失敗するのを避ける。
+  # 配列順で最初にマッチした要素を jq の first() で取り、head へのパイプを無くす。
+  # pipefail 下で複数マッチ時に上流 jq が SIGPIPE で落ちて呼び出しが失敗するのを避ける。
   printf '%s' "$JSON" | jq -r --arg p "$pattern" '
     first(.assets[]?.browser_download_url | select(test($p))) // empty
   '

--- a/scripts/install_vinbero.sh
+++ b/scripts/install_vinbero.sh
@@ -64,18 +64,22 @@ done
 # tar は --with-sdk 時にだけ、sha256sum は checksums 検証時にだけ確認する。
 for cmd in curl jq install; do
   command -v "$cmd" >/dev/null 2>&1 || {
-    echo "Required command not found: $cmd" >&2
-    echo "Please install it first (e.g. 'apt-get install -y $cmd')." >&2
+    case "$cmd" in
+      install) pkg="coreutils" ;;  # install は coreutils 由来でパッケージ名が異なる
+      *) pkg="$cmd" ;;
+    esac
+    echo "Required command not found: $cmd (provided by the '$pkg' package)" >&2
     exit 1
   }
 done
 
 # write 権限の確認。root でない場合は早めに知らせる。配置先が存在すればそのディレクトリ、
-# 無ければ最初に存在する親ディレクトリの書き込み可否を見る。
+# 無ければ最初に存在する親ディレクトリの書き込み可否を見る。配下にファイルを作るには
+# 書き込み (w) に加えて探索 (x) 権が要るため両方を確認する。
 writable_target() {
   local d="$1"
   while [ ! -e "$d" ]; do d="$(dirname "$d")"; done
-  [ -w "$d" ]
+  [ -w "$d" ] && [ -x "$d" ]
 }
 if [ "$(id -u)" -ne 0 ]; then
   for d in "$BIN_DIR" "$SHARE_DIR"; do
@@ -169,6 +173,24 @@ if [ "$WITH_SDK" -eq 1 ]; then
     SDK_FILE="$TMP/$(basename "$SDK_URL")"
     curl -fsSL "$SDK_URL" -o "$SDK_FILE"
     verify_checksum "$SDK_FILE"
+    # root で /usr/local に展開するため、path traversal を防ぐ。展開前に各 entry を
+    # 検証し、絶対パス・`..`・include/ share/ 配下以外を含む場合は中断する。grep の
+    # -v / -q は実装差があるため、移植性のある case で 1 行ずつ判定する。
+    sdk_entries="$(tar tzf "$SDK_FILE")"
+    while IFS= read -r entry; do
+      [ -n "$entry" ] || continue
+      case "$entry" in
+        /*|..|../*|*/../*|*/..)
+          echo "error: SDK tarball contains absolute or '..' paths; aborting" >&2
+          exit 1 ;;
+      esac
+      case "${entry#./}" in
+        include|share|include/*|share/*) ;;
+        *)
+          echo "error: SDK tarball has entries outside include/ or share/; aborting" >&2
+          exit 1 ;;
+      esac
+    done <<<"$sdk_entries"
     # tarball の top-level は include/ と share/ なので /usr/local に直接展開する。
     # root 実行を想定し、archive 内の owner / permission を持ち込まない。
     tar --no-same-owner --no-same-permissions -xzf "$SDK_FILE" -C "$SDK_PREFIX"

--- a/scripts/install_vinbero.sh
+++ b/scripts/install_vinbero.sh
@@ -60,8 +60,9 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-# 必須コマンドの確認。
-for cmd in curl jq tar install; do
+# 必須コマンドの確認。常に使う curl / jq / install のみ必須にする。
+# tar は --with-sdk 時にだけ、sha256sum は checksums 検証時にだけ確認する。
+for cmd in curl jq install; do
   command -v "$cmd" >/dev/null 2>&1 || {
     echo "Required command not found: $cmd" >&2
     echo "Please install it first (e.g. 'apt-get install -y $cmd')." >&2
@@ -107,9 +108,15 @@ TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 verify_checksum() {
   local file="$1"
   [ -n "$CHK_URL" ] || return 0
+  if ! command -v sha256sum >/dev/null 2>&1; then
+    echo "warning: sha256sum not found, skipping checksum verification" >&2
+    return 0
+  fi
   [ -f "$TMP/checksums.txt" ] || curl -fsSL "$CHK_URL" -o "$TMP/checksums.txt"
   local base line; base="$(basename "$file")"
-  line="$(grep " ${base}\$" "$TMP/checksums.txt" || true)"
+  # checksums.txt は `<sha256>  <filename>` 形式。ファイル名を第2フィールドで厳密一致
+  # させ、grep の正規表現で `.` などが任意文字として誤マッチするのを避ける。
+  line="$(awk -v f="$base" '$2 == f {print; exit}' "$TMP/checksums.txt")"
   if [ -n "$line" ]; then
     ( cd "$TMP" && printf '%s\n' "$line" | sha256sum -c - >/dev/null )
     echo "verified  ${base}"
@@ -133,13 +140,15 @@ done
 
 # plugin SDK (optional)
 if [ "$WITH_SDK" -eq 1 ]; then
+  command -v tar >/dev/null 2>&1 || { echo "Required command not found: tar (needed for --with-sdk)" >&2; exit 1; }
   SDK_URL="$(asset_url "/vinbero-sdk-.*\\.tar\\.gz$")"
   if [ -n "$SDK_URL" ]; then
     SDK_FILE="$TMP/$(basename "$SDK_URL")"
     curl -fsSL "$SDK_URL" -o "$SDK_FILE"
     verify_checksum "$SDK_FILE"
     # tarball の top-level は include/ と share/ なので /usr/local に直接展開する。
-    tar xzf "$SDK_FILE" -C "$SDK_PREFIX"
+    # root 実行を想定し、archive 内の owner / permission を持ち込まない。
+    tar --no-same-owner --no-same-permissions -xzf "$SDK_FILE" -C "$SDK_PREFIX"
     echo "SDK      ${SDK_PREFIX}/include/vinbero, ${SDK_PREFIX}/share/vinbero-sdk"
   else
     echo "warning: --with-sdk requested but no SDK tarball found in ${TAG_NAME:-release}" >&2

--- a/scripts/install_vinbero.sh
+++ b/scripts/install_vinbero.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Vinbero one-liner installer.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/takehaya/vinbero/main/scripts/install_vinbero.sh | sudo bash
+#   curl -fsSL https://raw.githubusercontent.com/takehaya/vinbero/main/scripts/install_vinbero.sh | sudo bash -s -- --version v0.0.4
+#   curl -fsSL https://raw.githubusercontent.com/takehaya/vinbero/main/scripts/install_vinbero.sh | sudo bash -s -- --with-sdk
+#
+# GitHub release から goreleaser 生成のバイナリ (vinberod / vinbero) を取得し
+# /usr/local/bin に配置する。--with-sdk を付けると plugin SDK tarball も
+# /usr/local 以下へ展開する。
+set -euo pipefail
+
+REPO="takehaya/vinbero"
+BIN_DIR="/usr/local/bin"
+SHARE_DIR="/usr/local/share/vinbero"
+STATE_FILE="${SHARE_DIR}/.installed-from-tag"
+SDK_PREFIX="/usr/local"
+
+VERSION="${VINBERO_VERSION:-}"
+WITH_SDK=0
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: install_vinbero.sh [--version <tag>] [--with-sdk]
+
+  --version <tag>   install a specific release tag (e.g. v0.0.4).
+                    defaults to the latest release.
+                    can also be set via VINBERO_VERSION.
+  --with-sdk        also install the plugin SDK (headers + examples)
+                    under /usr/local.
+  -h, --help        show this help.
+EOF
+}
+
+# 引数 parse。`bash -s -- --version v0.0.4 --with-sdk` の順不同を許容する。
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      VERSION="${2:?--version requires a value}"
+      shift 2
+      ;;
+    --version=*)
+      VERSION="${1#*=}"
+      shift
+      ;;
+    --with-sdk)
+      WITH_SDK=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+# 必須コマンドの確認。
+for cmd in curl jq tar install; do
+  command -v "$cmd" >/dev/null 2>&1 || {
+    echo "Required command not found: $cmd" >&2
+    echo "Please install it first (e.g. 'apt-get install -y $cmd')." >&2
+    exit 1
+  }
+done
+
+# write 権限の確認。root でない場合は早めに知らせる。
+if [ ! -w "$(dirname "$BIN_DIR")" ] && [ "$(id -u)" -ne 0 ]; then
+  echo "This installer needs to write under ${BIN_DIR}; re-run with sudo." >&2
+  exit 1
+fi
+
+case "$(uname -m)" in
+  x86_64|amd64) ARCH="amd64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
+esac
+
+if [ -z "$VERSION" ] || [ "$VERSION" = "latest" ]; then
+  META_URL="https://api.github.com/repos/${REPO}/releases/latest"
+else
+  META_URL="https://api.github.com/repos/${REPO}/releases/tags/${VERSION}"
+fi
+JSON="$(curl -fsSL "$META_URL")"
+
+TAG_NAME="$(echo "$JSON" | jq -r '.tag_name // empty')"
+
+# goreleaser の format=binary は各バイナリを
+# `{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}` (例: vinberod_0.0.4_linux_amd64) で upload する。
+asset_url() {
+  local pattern="$1"
+  echo "$JSON" | jq -r --arg p "$pattern" '
+    .assets[]?.browser_download_url | select(test($p))
+  ' | head -n1
+}
+
+CHK_URL="$(asset_url "/checksums\\.txt$")"
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+# checksums.txt があれば best-effort で sha256 を検証する。
+verify_checksum() {
+  local file="$1"
+  [ -n "$CHK_URL" ] || return 0
+  [ -f "$TMP/checksums.txt" ] || curl -fsSL "$CHK_URL" -o "$TMP/checksums.txt"
+  local base line; base="$(basename "$file")"
+  line="$(grep " ${base}\$" "$TMP/checksums.txt" || true)"
+  if [ -n "$line" ]; then
+    ( cd "$TMP" && printf '%s\n' "$line" | sha256sum -c - >/dev/null )
+    echo "verified  ${base}"
+  else
+    echo "warning: no checksum entry for ${base}, skipping verification" >&2
+  fi
+}
+
+mkdir -p "$BIN_DIR" "$SHARE_DIR"
+
+# vinberod (daemon) と vinbero (CLI) を取得して /usr/local/bin に配置する。
+# CLI の `vinbero_` は daemon の `vinberod_` と接頭辞が衝突しない (末尾 `_` が次の文字を分ける)。
+for bin in vinberod vinbero; do
+  url="$(asset_url "/${bin}_.*_linux_${ARCH}$")"
+  [ -n "$url" ] || { echo "No ${bin} binary matched for linux_${ARCH} in ${TAG_NAME:-$META_URL}" >&2; exit 1; }
+  file="$TMP/$(basename "$url")"
+  curl -fsSL "$url" -o "$file"
+  verify_checksum "$file"
+  install -m 0755 "$file" "$BIN_DIR/$bin"
+done
+
+# plugin SDK (optional)
+if [ "$WITH_SDK" -eq 1 ]; then
+  SDK_URL="$(asset_url "/vinbero-sdk-.*\\.tar\\.gz$")"
+  if [ -n "$SDK_URL" ]; then
+    SDK_FILE="$TMP/$(basename "$SDK_URL")"
+    curl -fsSL "$SDK_URL" -o "$SDK_FILE"
+    verify_checksum "$SDK_FILE"
+    # tarball の top-level は include/ と share/ なので /usr/local に直接展開する。
+    tar xzf "$SDK_FILE" -C "$SDK_PREFIX"
+    echo "SDK      ${SDK_PREFIX}/include/vinbero, ${SDK_PREFIX}/share/vinbero-sdk"
+  else
+    echo "warning: --with-sdk requested but no SDK tarball found in ${TAG_NAME:-release}" >&2
+  fi
+fi
+
+echo "${TAG_NAME:-${VERSION:-latest}}" > "$STATE_FILE"
+
+cat <<EOF
+
+Installed Vinbero
+  daemon   ${BIN_DIR}/vinberod
+  CLI      ${BIN_DIR}/vinbero
+  version  ${TAG_NAME:-${VERSION:-latest}}
+
+Next steps:
+  vinberod --help        # start the SRv6 daemon
+  vinbero --help         # control it via the CLI
+EOF

--- a/scripts/install_vinbero.sh
+++ b/scripts/install_vinbero.sh
@@ -116,9 +116,11 @@ TAG_NAME="$(printf '%s' "$JSON" | jq -r '.tag_name // empty')"
 # JSON を渡すのに echo を使うと xpg_echo などでバックスラッシュが解釈され壊れうるため printf を使う。
 asset_url() {
   local pattern="$1"
+  # 先頭一致を jq の first() で取り、head へのパイプを無くす。pipefail 下で
+  # 複数マッチ時に上流 jq が SIGPIPE で落ちて呼び出しが失敗するのを避ける。
   printf '%s' "$JSON" | jq -r --arg p "$pattern" '
-    .assets[]?.browser_download_url | select(test($p))
-  ' | head -n1
+    first(.assets[]?.browser_download_url | select(test($p))) // empty
+  '
 }
 
 CHK_URL="$(asset_url "/checksums\\.txt$")"
@@ -191,6 +193,18 @@ if [ "$WITH_SDK" -eq 1 ]; then
           exit 1 ;;
       esac
     done <<<"$sdk_entries"
+    # entry の種別も検証する。tar -tv の先頭文字が type を表すため、通常ファイル (-)
+    # とディレクトリ (d) 以外 (symlink / hardlink / device / fifo 等) は中断する。
+    # root で /usr/local に展開するため、非通常 entry の持ち込みを防ぐ。
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      case "$line" in
+        -*|d*) ;;
+        *)
+          echo "error: SDK tarball has a non-regular entry (symlink/device/fifo); aborting" >&2
+          exit 1 ;;
+      esac
+    done <<<"$(tar tvzf "$SDK_FILE")"
     # tarball の top-level は include/ と share/ なので /usr/local に直接展開する。
     # root 実行を想定し、archive 内の owner / permission を持ち込まない。
     tar --no-same-owner --no-same-permissions -xzf "$SDK_FILE" -C "$SDK_PREFIX"

--- a/scripts/install_vinbero.sh
+++ b/scripts/install_vinbero.sh
@@ -89,13 +89,14 @@ else
 fi
 JSON="$(curl -fsSL "$META_URL")"
 
-TAG_NAME="$(echo "$JSON" | jq -r '.tag_name // empty')"
+TAG_NAME="$(printf '%s' "$JSON" | jq -r '.tag_name // empty')"
 
 # goreleaser の format=binary は各バイナリを
 # `{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}` (例: vinberod_0.0.4_linux_amd64) で upload する。
+# JSON を渡すのに echo を使うと xpg_echo などでバックスラッシュが解釈され壊れうるため printf を使う。
 asset_url() {
   local pattern="$1"
-  echo "$JSON" | jq -r --arg p "$pattern" '
+  printf '%s' "$JSON" | jq -r --arg p "$pattern" '
     .assets[]?.browser_download_url | select(test($p))
   ' | head -n1
 }
@@ -112,7 +113,13 @@ verify_checksum() {
     echo "warning: sha256sum not found, skipping checksum verification" >&2
     return 0
   fi
-  [ -f "$TMP/checksums.txt" ] || curl -fsSL "$CHK_URL" -o "$TMP/checksums.txt"
+  if [ ! -f "$TMP/checksums.txt" ]; then
+    # 取得に失敗しても install は止めず、検証だけスキップする (best-effort)。
+    curl -fsSL "$CHK_URL" -o "$TMP/checksums.txt" || {
+      echo "warning: failed to download checksums.txt, skipping verification" >&2
+      return 0
+    }
+  fi
   local base line; base="$(basename "$file")"
   # checksums.txt は `<sha256>  <filename>` 形式。ファイル名を第2フィールドで厳密一致
   # させ、grep の正規表現で `.` などが任意文字として誤マッチするのを避ける。
@@ -165,6 +172,7 @@ Installed Vinbero
   version  ${TAG_NAME:-${VERSION:-latest}}
 
 Next steps:
-  vinberod --help        # start the SRv6 daemon
-  vinbero --help         # control it via the CLI
+  sudo vinberod -c vinbero.yml   # start the SRv6 daemon
+  vinberod --help                # daemon options
+  vinbero --help                 # CLI usage
 EOF

--- a/scripts/install_vinbero.sh
+++ b/scripts/install_vinbero.sh
@@ -2,16 +2,16 @@
 # Vinbero one-liner installer.
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/takehaya/vinbero/main/scripts/install_vinbero.sh | sudo bash
-#   curl -fsSL https://raw.githubusercontent.com/takehaya/vinbero/main/scripts/install_vinbero.sh | sudo bash -s -- --version v0.0.4
-#   curl -fsSL https://raw.githubusercontent.com/takehaya/vinbero/main/scripts/install_vinbero.sh | sudo bash -s -- --with-sdk
+#   curl -fsSL https://raw.githubusercontent.com/takehaya/Vinbero/main/scripts/install_vinbero.sh | sudo bash
+#   curl -fsSL https://raw.githubusercontent.com/takehaya/Vinbero/main/scripts/install_vinbero.sh | sudo bash -s -- --version v0.0.4
+#   curl -fsSL https://raw.githubusercontent.com/takehaya/Vinbero/main/scripts/install_vinbero.sh | sudo bash -s -- --with-sdk
 #
 # GitHub release から goreleaser 生成のバイナリ (vinberod / vinbero) を取得し
 # /usr/local/bin に配置する。--with-sdk を付けると plugin SDK tarball も
 # /usr/local 以下へ展開する。
 set -euo pipefail
 
-REPO="takehaya/vinbero"
+REPO="takehaya/Vinbero"
 BIN_DIR="/usr/local/bin"
 SHARE_DIR="/usr/local/share/vinbero"
 STATE_FILE="${SHARE_DIR}/.installed-from-tag"
@@ -131,8 +131,8 @@ TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 verify_checksum() {
   local file="$1"
   [ -n "$CHK_URL" ] || return 0
-  if ! command -v sha256sum >/dev/null 2>&1; then
-    echo "warning: sha256sum not found, skipping checksum verification" >&2
+  if ! command -v sha256sum >/dev/null 2>&1 || ! command -v awk >/dev/null 2>&1; then
+    echo "warning: sha256sum/awk not found, skipping checksum verification" >&2
     return 0
   fi
   if [ ! -f "$TMP/checksums.txt" ]; then
@@ -147,8 +147,12 @@ verify_checksum() {
   # させ、grep の正規表現で `.` などが任意文字として誤マッチするのを避ける。
   line="$(awk -v f="$base" '$2 == f {print; exit}' "$TMP/checksums.txt")"
   if [ -n "$line" ]; then
-    ( cd "$TMP" && printf '%s\n' "$line" | sha256sum -c - >/dev/null )
-    echo "verified  ${base}"
+    if ( cd "$TMP" && printf '%s\n' "$line" | sha256sum -c - >/dev/null 2>&1 ); then
+      echo "verified  ${base}"
+    else
+      echo "error: checksum verification failed for ${base}; aborting" >&2
+      exit 1
+    fi
   else
     echo "warning: no checksum entry for ${base}, skipping verification" >&2
   fi
@@ -178,7 +182,7 @@ if [ "$WITH_SDK" -eq 1 ]; then
     # root で /usr/local に展開するため、path traversal を防ぐ。展開前に各 entry を
     # 検証し、絶対パス・`..`・include/ share/ 配下以外を含む場合は中断する。grep の
     # -v / -q は実装差があるため、移植性のある case で 1 行ずつ判定する。
-    sdk_entries="$(tar tzf "$SDK_FILE")"
+    sdk_entries="$(tar -tzf "$SDK_FILE")"
     while IFS= read -r entry; do
       [ -n "$entry" ] || continue
       case "$entry" in
@@ -204,7 +208,7 @@ if [ "$WITH_SDK" -eq 1 ]; then
           echo "error: SDK tarball has a non-regular entry (symlink/device/fifo); aborting" >&2
           exit 1 ;;
       esac
-    done <<<"$(tar tvzf "$SDK_FILE")"
+    done <<<"$(tar -tvzf "$SDK_FILE")"
     # tarball の top-level は include/ と share/ なので /usr/local に直接展開する。
     # root 実行を想定し、archive 内の owner / permission を持ち込まない。
     tar --no-same-owner --no-same-permissions -xzf "$SDK_FILE" -C "$SDK_PREFIX"

--- a/scripts/install_vinbero.sh
+++ b/scripts/install_vinbero.sh
@@ -70,11 +70,27 @@ for cmd in curl jq install; do
   }
 done
 
-# write 権限の確認。root でない場合は早めに知らせる。
-if [ ! -w "$(dirname "$BIN_DIR")" ] && [ "$(id -u)" -ne 0 ]; then
-  echo "This installer needs to write under ${BIN_DIR}; re-run with sudo." >&2
-  exit 1
+# write 権限の確認。root でない場合は早めに知らせる。配置先が存在すればそのディレクトリ、
+# 無ければ最初に存在する親ディレクトリの書き込み可否を見る。
+writable_target() {
+  local d="$1"
+  while [ ! -e "$d" ]; do d="$(dirname "$d")"; done
+  [ -w "$d" ]
+}
+if [ "$(id -u)" -ne 0 ]; then
+  for d in "$BIN_DIR" "$SHARE_DIR"; do
+    writable_target "$d" || {
+      echo "This installer needs to write under ${d}; re-run with sudo." >&2
+      exit 1
+    }
+  done
 fi
+
+# Vinbero は linux バイナリのみ配布するため、Linux 以外は早期に中断する。
+case "$(uname -s)" in
+  Linux) ;;
+  *) echo "Unsupported OS: $(uname -s) (Vinbero ships linux binaries only)" >&2; exit 1 ;;
+esac
 
 case "$(uname -m)" in
   x86_64|amd64) ARCH="amd64" ;;


### PR DESCRIPTION
## 概要

xdperf の installer を参考に、GitHub release から goreleaser 生成の `vinberod` / `vinbero` バイナリを取得して `/usr/local/bin` に配置する `curl | bash` 形式の one-liner installer を追加します。

```bash
curl -fsSL https://raw.githubusercontent.com/takehaya/vinbero/main/scripts/install_vinbero.sh | sudo bash
```

## 変更点

- `scripts/install_vinbero.sh` を追加
  - `--version <tag>` でリリースタグを指定 (既定は latest、`VINBERO_VERSION` でも指定可)
  - `--with-sdk` で plugin SDK tarball (`vinbero-sdk-*.tar.gz`) を `/usr/local` 以下へ展開
  - release に `checksums.txt` があれば sha256 を best-effort で検証 (不一致なら中断)
  - `curl` / `jq` / `tar` / `install` の存在と write 権限を事前確認
  - amd64 / arm64 を検出 (現状 goreleaser は amd64 のみビルド)
- `README.md` の Quickstart に install セクションを追加

## 設計メモ

- goreleaser の `format: binary` は `{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}` 形式で個別バイナリを upload するため、`vinberod` / `vinbero` を binary list の loop で取得します。CLI の `vinbero_` は daemon の `vinberod_` と末尾 `_` で衝突しません。
- standalone 実行 (`curl | bash` でリポジトリ未取得) を前提とするため、`scripts/libs/install_utils.sh` などリポジトリ内 helper は source しません。

## 確認

- `bash -n` 構文チェック
- `--help` / 未知引数 (exit 1)
- jq マッチ (daemon / CLI / SDK / checksums) が衝突なく解決
- checksum 検証の happy path / tamper 検出 / 未登録スキップ

注意: 現状のリリース (v0.0.2〜v0.0.4) はまだバイナリ資産が未公開のため、release-please + goreleaser が資産を上げた後に機能します。
