### PR TITLE
docs(srv6-bgp): quote Mermaid edge labels containing parens and slashes

### DIFF
--- a/docs/design/ja/srv6_bgp.md
+++ b/docs/design/ja/srv6_bgp.md
@@ -274,8 +274,8 @@ flowchart LR
     EB["egress: End.DT2M で decap<br/>DF だけ転送 / split-horizon で抑制"]
 
     F --> Q
-    Q -->|解決 (unicast)| U --> EU
-    Q -->|未解決 / BUM| B --> EB
+    Q -->|"解決 (unicast)"| U --> EU
+    Q -->|"未解決 / BUM"| B --> EB
 ```
 
 ## SRv6 MUP (mobile user plane)


### PR DESCRIPTION
## 概要

`docs/design/ja/srv6_bgp.md` の Mermaid flowchart で、括弧やスラッシュを含むエッジラベルを二重引用符で囲み、パースエラーを防ぎます。

- `解決 (unicast)` / `未解決 / BUM` を `"..."` で囲む

描画上の修正のみで、本文の内容は変えていません。
