### PR TITLE
fix(build): pin goreleaser to v2.13.0 for Go 1.25 compatibility

### DIFF
--- a/scripts/install_build_tools.sh
+++ b/scripts/install_build_tools.sh
@@ -8,6 +8,11 @@ source "${SCRIPT_DIR}/libs/install_utils.sh"
 # goreleaser は go.mod の go directive (現状 1.25.x) でビルドできる版に pin する。
 # v2.14.0 以降は go 1.26 を要求し、GOTOOLCHAIN=local の環境で go install が失敗する。
 # Go を上げるときはこの pin も合わせて見直す。
-install_tool "goreleaser" "go install github.com/goreleaser/goreleaser/v2@v2.13.0"
+# install_tool は既存コマンドがあるとスキップするため、別経路で入った版に引きずられ
+# ないよう、goreleaser は常に pinned 版を go install して version を保証する。
+GORELEASER_VERSION="v2.13.0"
+echo "Installing goreleaser ${GORELEASER_VERSION}..."
+go install "github.com/goreleaser/goreleaser/v2@${GORELEASER_VERSION}"
+echo "✓ goreleaser ${GORELEASER_VERSION} installed"
 
 echo "✅ All build tools have been installed successfully!"

--- a/scripts/install_build_tools.sh
+++ b/scripts/install_build_tools.sh
@@ -5,6 +5,9 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/libs/install_utils.sh"
 
-install_tool "goreleaser" "go install github.com/goreleaser/goreleaser/v2@latest"
+# goreleaser は go.mod の go directive (現状 1.25.x) でビルドできる版に pin する。
+# v2.14.0 以降は go 1.26 を要求し、GOTOOLCHAIN=local の環境で go install が失敗する。
+# Go を上げるときはこの pin も合わせて見直す。
+install_tool "goreleaser" "go install github.com/goreleaser/goreleaser/v2@v2.13.0"
 
 echo "✅ All build tools have been installed successfully!"


### PR DESCRIPTION
## 概要

release workflow の `goreleaser` job が `Install build tools` ステップで失敗し、`Run GoReleaser` が skip されていたため、v0.0.2〜v0.0.5 のすべてのリリースで binary 資産が 0 件のままでした。

`scripts/install_build_tools.sh` が `go install github.com/goreleaser/goreleaser/v2@latest` を使っており、`@latest` が goreleaser v2.16.0 を引きます。v2.16.0 は go >= 1.26.3 を要求しますが、CI / 開発環境は go.mod の `go 1.25.5` かつ `GOTOOLCHAIN=local` のため、toolchain を自動取得せず失敗します。

```
go: github.com/goreleaser/goreleaser/v2@v2.16.0 requires go >= 1.26.3 (running go 1.25.5; GOTOOLCHAIN=local)
make: *** [Makefile:106: install-build-tools] Error 1
```

## 変更点

`go install` の対象を `@latest` から `@v2.13.0` に pin します。stable のうち go.mod の go directive (1.25.x) でビルドできる最新が v2.13.0 (go 1.25.4) です。v2.14.0 以降は go 1.26 を要求します。

なお実リリースは `goreleaser-action@v6` (prebuilt binary) が担うため、この `go install` は redundant ですが、`make install-build-tools` を直さないと release job が先に落ちます。

## 確認

- `GOTOOLCHAIN=local go install github.com/goreleaser/goreleaser/v2@v2.13.0` が go 1.25.5 でビルド成功 (exit 0)
- インストールした goreleaser で `goreleaser check` が現行 `.goreleaser.yaml` を検証成功

## 補足

このマージ後、release-please が次のリリース PR を作成し、それをマージすると goreleaser が初めて成功して資産が publish されます。one-liner installer はその資産に対して動作します。
