### PR TITLE
fix(release): ship SDK tarball without binaries and verify goreleaser install

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,7 +28,11 @@ archives:
   # `curl | sudo tar xz -C /usr/local/` and start building without cloning
   # the vinbero repo. Layout matches docs/plan/plugin-sdk-3-tarball-distribution.md §2.
   - id: sdk
-    builds: []
+    # meta archives carry only the `files` below (headers + docs) and none of
+    # the build binaries. The deprecated `builds: []` / empty `ids: []` are both
+    # ignored by goreleaser v2 (treated as "all builds"), which leaked vinberod /
+    # vinbero into the SDK tarball and tripped the installer's entry guard.
+    meta: true
     name_template: "vinbero-sdk-{{ .Version }}"
     formats:
       - 'tar.gz'

--- a/scripts/install_build_tools.sh
+++ b/scripts/install_build_tools.sh
@@ -17,7 +17,11 @@ go install "github.com/goreleaser/goreleaser/v2@${GORELEASER_VERSION}"
 # go install の配置先 (GOBIN もしくは GOPATH/bin) を直接見て実行できるか検証する。
 # PATH 設定に依存せず install の成否を確認するため。
 gobin="$(go env GOBIN)"
-[ -n "$gobin" ] || gobin="$(go env GOPATH)/bin"
+if [ -z "$gobin" ]; then
+  # GOPATH は : 区切りで複数返ることがある。go install は先頭要素の bin に置く。
+  gopath="$(go env GOPATH)"
+  gobin="${gopath%%:*}/bin"
+fi
 if ! "${gobin}/goreleaser" --version >/dev/null 2>&1; then
   echo "✗ goreleaser is not executable at ${gobin}/goreleaser after install" >&2
   exit 1

--- a/scripts/install_build_tools.sh
+++ b/scripts/install_build_tools.sh
@@ -32,9 +32,13 @@ if ! "${gobin}/goreleaser" --version >/dev/null 2>&1; then
   exit 1
 fi
 echo "✓ goreleaser ${GORELEASER_VERSION} installed at ${gobin}/goreleaser"
-# 実際に実行される goreleaser は PATH の優先順位で決まるため、make goreleaser 等で
-# pinned 版を使うには ${gobin} を PATH に含める必要がある。
-command -v goreleaser >/dev/null 2>&1 || \
+# 実際に実行される goreleaser は PATH の優先順位で決まる。make goreleaser 等で
+# pinned 版を使うため、PATH 解決結果が ${gobin}/goreleaser と一致するか確認する。
+resolved="$(command -v goreleaser 2>/dev/null || true)"
+if [ -z "$resolved" ]; then
   echo "note: ${gobin} is not on PATH; add it (e.g. export PATH=\"${gobin}:\$PATH\") to use 'make goreleaser'." >&2
+elif [ "$resolved" != "${gobin}/goreleaser" ]; then
+  echo "note: 'goreleaser' on PATH resolves to ${resolved}, not the pinned ${gobin}/goreleaser; PATH order may run a different version." >&2
+fi
 
 echo "✅ All build tools have been installed successfully!"

--- a/scripts/install_build_tools.sh
+++ b/scripts/install_build_tools.sh
@@ -22,6 +22,11 @@ if [ -z "$gobin" ]; then
   gopath="$(go env GOPATH)"
   gobin="${gopath%%:*}/bin"
 fi
+# 先頭の ~ は変数展開では $HOME に展開されないため、明示的に展開してパスを確定する。
+case "$gobin" in
+  "~") gobin="$HOME" ;;
+  "~/"*) gobin="$HOME/${gobin#\~/}" ;;
+esac
 if ! "${gobin}/goreleaser" --version >/dev/null 2>&1; then
   echo "✗ goreleaser is not executable at ${gobin}/goreleaser after install" >&2
   exit 1

--- a/scripts/install_build_tools.sh
+++ b/scripts/install_build_tools.sh
@@ -9,10 +9,23 @@ source "${SCRIPT_DIR}/libs/install_utils.sh"
 # v2.14.0 以降は go 1.26 を要求し、GOTOOLCHAIN=local の環境で go install が失敗する。
 # Go を上げるときはこの pin も合わせて見直す。
 # install_tool は既存コマンドがあるとスキップするため、別経路で入った版に引きずられ
-# ないよう、goreleaser は常に pinned 版を go install して version を保証する。
+# ないよう、goreleaser は常に pinned 版を go install で入れ直す。
 GORELEASER_VERSION="v2.13.0"
 echo "Installing goreleaser ${GORELEASER_VERSION}..."
 go install "github.com/goreleaser/goreleaser/v2@${GORELEASER_VERSION}"
-echo "✓ goreleaser ${GORELEASER_VERSION} installed"
+
+# go install の配置先 (GOBIN もしくは GOPATH/bin) を直接見て実行できるか検証する。
+# PATH 設定に依存せず install の成否を確認するため。
+gobin="$(go env GOBIN)"
+[ -n "$gobin" ] || gobin="$(go env GOPATH)/bin"
+if ! "${gobin}/goreleaser" --version >/dev/null 2>&1; then
+  echo "✗ goreleaser is not executable at ${gobin}/goreleaser after install" >&2
+  exit 1
+fi
+echo "✓ goreleaser ${GORELEASER_VERSION} installed at ${gobin}/goreleaser"
+# 実際に実行される goreleaser は PATH の優先順位で決まるため、make goreleaser 等で
+# pinned 版を使うには ${gobin} を PATH に含める必要がある。
+command -v goreleaser >/dev/null 2>&1 || \
+  echo "note: ${gobin} is not on PATH; add it (e.g. export PATH=\"${gobin}:\$PATH\") to use 'make goreleaser'." >&2
 
 echo "✅ All build tools have been installed successfully!"


### PR DESCRIPTION
## 概要

v0.0.6 で one-liner installer の動作を実際に検証したところ、デフォルトの binary install は完全に動作した一方、`--with-sdk` が installer の entry guard で失敗しました。原因は **SDK tarball のルートに `vinberod` / `vinbero` バイナリが混入していた**ことです。

`.goreleaser.yaml` の SDK archive は `builds: []` でバイナリ除外を意図していましたが、goreleaser v2 は deprecated な `builds` も空の `ids: []` も「全 build を含める」と解釈するため、バイナリが SDK tarball に入っていました。

## 変更点

- `.goreleaser.yaml`: SDK archive を `meta: true` にし、`files` で指定した headers/docs (`include/`, `share/`) のみを含める (バイナリを除外)。
- `scripts/install_build_tools.sh`: `go install` 後に配置先 (GOBIN もしくは GOPATH/bin) を直接見て実行可能性を検証し、失敗時は exit する。PATH に無い場合は note を出す (#73 の post-merge レビュー対応)。

## 確認

CI と同じ **goreleaser v2.16.0** (prebuilt) でローカル snapshot ビルドして検証:

| 設定 | SDK tarball のルート |
|---|---|
| `builds: []` (修正前) | `vinberod` / `vinbero` が混入 |
| `ids: []` | 同上 (改善せず) |
| `meta: true` (本修正) | `include/` と `share/` のみ |

- binary archive (`vinberod_*` / `vinbero_*`) は引き続き生成される
- 修正後の SDK tarball が installer の path / type guard を通過することを確認
- `install_build_tools.sh` をローカル実行し、実行可能性検証が通ることを確認

## マージ後

release-please の 0.0.7 リリースで反映され、`--with-sdk` install が実資産に対して動作するようになります。
