### PR TITLE
fix(cli): stamp vinbero CLI version from build ldflags

### DIFF
--- a/cmd/vinbero/main.go
+++ b/cmd/vinbero/main.go
@@ -7,7 +7,19 @@ import (
 	vinberocli "github.com/takehaya/vinbero/pkg/cli"
 )
 
+// goreleaser injects these via the default ldflags
+// (-X main.version / main.commit / main.date / main.builtBy). They mirror the
+// vinberod daemon so `vinbero --version` reports the real release version
+// instead of "dev".
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+	builtBy = "unknown"
+)
+
 func main() {
+	vinberocli.SetVersion(fmt.Sprintf("%s, %s, %s, %s", version, commit, date, builtBy))
 	app := vinberocli.NewApp()
 	if err := app.Run(os.Args); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)


### PR DESCRIPTION
## 概要

`vinbero --version` が常に `dev` を表示していました (daemon の `vinberod` は実 version を表示)。

`cmd/vinbero/main.go` は package main に version 変数を持たず、`pkg/cli` の `SetVersion()` も呼んでいなかったため、goreleaser の既定 ldflags (`-X main.version` / `main.commit` / `main.date` / `main.builtBy`) が届いていませんでした。

## 変更点

`cmd/vinbero/main.go` に `vinberod` と同じく `version` / `commit` / `date` / `builtBy` を package main で定義し、`NewApp()` 前に `vinberocli.SetVersion()` で渡します。

## 確認

goreleaser の既定 ldflags を再現してビルド:

```
# ldflags なし (既定)
vinbero version dev, none, unknown, unknown

# -X main.version=0.0.7 ... main.builtBy=goreleaser
vinbero version 0.0.7, deadbeef, 2026-06-03T17:10:06Z, goreleaser
```

vinberod と同じ表示形式で実 version を表示することを確認しました。`.goreleaser.yaml` は既定 ldflags を使うため設定変更は不要です。
