### PR TITLE
docs(readme): bump pinned install example to v0.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ verification uses `sha256sum` when present and is skipped otherwise, and
 curl -fsSL https://raw.githubusercontent.com/takehaya/Vinbero/main/scripts/install_vinbero.sh | sudo bash
 
 # Pin a specific release
-curl -fsSL https://raw.githubusercontent.com/takehaya/Vinbero/main/scripts/install_vinbero.sh | sudo bash -s -- --version v0.0.4
+curl -fsSL https://raw.githubusercontent.com/takehaya/Vinbero/main/scripts/install_vinbero.sh | sudo bash -s -- --version v0.0.8
 
 # Also install the plugin SDK (headers + examples) under /usr/local
 curl -fsSL https://raw.githubusercontent.com/takehaya/Vinbero/main/scripts/install_vinbero.sh | sudo bash -s -- --with-sdk


### PR DESCRIPTION
install one-liner の `--version` 例を最新リリース v0.0.8 に更新します。