### PR TITLE
fix(release): unify SDK staging and fix include/core packaging

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,6 +6,10 @@ env:
 before:
   hooks:
     - go mod tidy
+    # Stage the SDK tree so the `sdk` archive below can ship it verbatim. This
+    # is the same script `make sdk-archive` uses, so the CI-verified tarball and
+    # the released tarball are built from one source of truth.
+    - ./scripts/stage_sdk.sh out/sdk-stage
 builds:
   - id: vinberod
     binary: vinberod
@@ -28,10 +32,10 @@ archives:
   # `curl | sudo tar xz -C /usr/local/` and start building without cloning
   # the vinbero repo. Layout matches docs/plan/plugin-sdk-3-tarball-distribution.md §2.
   - id: sdk
-    # meta archives carry only the `files` below (headers + docs) and none of
-    # the build binaries. The deprecated `builds: []` / empty `ids: []` are both
-    # ignored by goreleaser v2 (treated as "all builds"), which leaked vinberod /
-    # vinbero into the SDK tarball and tripped the installer's entry guard.
+    # meta archives carry only the `files` below and none of the build binaries.
+    # The deprecated `builds: []` / empty `ids: []` are both ignored by goreleaser
+    # v2 (treated as "all builds"), which leaked vinberod / vinbero into the SDK
+    # tarball and tripped the installer's entry guard.
     meta: true
     name_template: "vinbero-sdk-{{ .Version }}"
     formats:
@@ -41,72 +45,17 @@ archives:
     # `include/` and `share/` directly. Re-wrapping would force users to
     # pass --strip-components=1.
     wrap_in_directory: false
+    # Ship the pre-staged tree verbatim (see the stage_sdk.sh before-hook). Each
+    # entry archives a directory under its `dst`, so structure is preserved and
+    # there is no per-file list to keep in sync — adding an SDK header is a
+    # one-line change in scripts/stage_sdk.sh. Listing files individually here
+    # (src: foo.h, dst: include/core/) silently collapses them into a single
+    # file `include/core` under goreleaser v2, which is exactly what this avoids.
     files:
-      # Public ABI headers.
-      - src: sdk/c/include/vinbero/*.h
-        dst: include/vinbero/
-      # Internal headers that the public ones #include via "core/...".
-      # These are listed individually (not src/core/*.h) to keep the public
-      # surface explicit. Anything added here ships transitively to plugin
-      # authors — every entry must justify itself.
-      - src: src/core/xdp_map.h
-        dst: include/core/
-      - src: src/core/xdp_prog.h
-        dst: include/core/
-      - src: src/core/xdp_tailcall.h
-        dst: include/core/
-      - src: src/core/xdp_tailcall_helpers.h
-        dst: include/core/
-      - src: src/core/xdp_tailcall_macros.h
-        dst: include/core/
-      # xdp_stats.h is required transitively: xdp_tailcall_helpers.h
-      # implements tailcall_epilogue using stats_action_inc / slot_stats_inc
-      # from this header, so plugins that go through the epilogue (the
-      # SDK's required return contract) cannot build without it.
-      - src: src/core/xdp_stats.h
-        dst: include/core/
-      # srv6.h is required transitively from this PR onward: xdp_map.h
-      # references `struct aux_owner` (defined in srv6.h) to declare the
-      # aux_owner_map BPF map type. Without this, every plugin build that
-      # pulls <vinbero/plugin.h> -> core/xdp_map.h fails with
-      # "'core/srv6.h' file not found". scripts/sdk_archive_verify.sh
-      # exercises a real plugin build so the regression is caught in CI.
-      - src: src/core/srv6.h
-        dst: include/core/
-      # Build template — drop next to the public headers so the
-      # one-liner Makefile (`include /usr/local/include/vinbero/Makefile.plugin`)
-      # works out of the box.
-      - src: sdk/c/Makefile.plugin
-        dst: include/vinbero/Makefile.plugin
-      # Static data (docs / examples) live under share/ per FHS.
-      - src: sdk/README.md
-        dst: share/vinbero-sdk/README.md
-      - src: LICENSE
-        dst: share/vinbero-sdk/LICENSE
-      - src: sdk/examples/plugin-counter/Makefile
-        dst: share/vinbero-sdk/examples/plugin-counter/Makefile
-      - src: sdk/examples/plugin-counter/plugin.c
-        dst: share/vinbero-sdk/examples/plugin-counter/plugin.c
-      - src: sdk/examples/plugin-counter/README.md
-        dst: share/vinbero-sdk/examples/plugin-counter/README.md
-      - src: sdk/examples/simple-acl/Makefile
-        dst: share/vinbero-sdk/examples/simple-acl/Makefile
-      - src: sdk/examples/simple-acl/plugin.c
-        dst: share/vinbero-sdk/examples/simple-acl/plugin.c
-      - src: sdk/examples/simple-acl/README.md
-        dst: share/vinbero-sdk/examples/simple-acl/README.md
-      - src: sdk/examples/plugin-counter-l2/Makefile
-        dst: share/vinbero-sdk/examples/plugin-counter-l2/Makefile
-      - src: sdk/examples/plugin-counter-l2/plugin.c
-        dst: share/vinbero-sdk/examples/plugin-counter-l2/plugin.c
-      - src: sdk/examples/plugin-counter-l2/README.md
-        dst: share/vinbero-sdk/examples/plugin-counter-l2/README.md
-      - src: sdk/examples/plugin-custom-sh/Makefile
-        dst: share/vinbero-sdk/examples/plugin-custom-sh/Makefile
-      - src: sdk/examples/plugin-custom-sh/plugin.c
-        dst: share/vinbero-sdk/examples/plugin-custom-sh/plugin.c
-      - src: sdk/examples/plugin-custom-sh/README.md
-        dst: share/vinbero-sdk/examples/plugin-custom-sh/README.md
+      - src: out/sdk-stage/include
+        dst: include
+      - src: out/sdk-stage/share
+        dst: share
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/Makefile
+++ b/Makefile
@@ -177,30 +177,13 @@ SDK_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo 
 SDK_STAGE := out/sdk-stage
 SDK_TARBALL := out/vinbero-sdk-$(SDK_VERSION).tar.gz
 
+.PHONY: sdk-stage
+sdk-stage: ## Stage SDK tree into $(SDK_STAGE) (shared with goreleaser)
+	@./scripts/stage_sdk.sh $(SDK_STAGE)
+
 .PHONY: sdk-archive
-sdk-archive: ## Build SDK tarball into out/
-	@rm -rf $(SDK_STAGE)
-	@install -d $(SDK_STAGE)/include/vinbero
-	@install -d $(SDK_STAGE)/include/core
-	@install -d $(SDK_STAGE)/share/vinbero-sdk/examples
-	@install -m 644 sdk/c/include/vinbero/*.h $(SDK_STAGE)/include/vinbero/
-	@install -m 644 sdk/c/Makefile.plugin $(SDK_STAGE)/include/vinbero/Makefile.plugin
-	@install -m 644 src/core/xdp_map.h $(SDK_STAGE)/include/core/
-	@install -m 644 src/core/xdp_prog.h $(SDK_STAGE)/include/core/
-	@install -m 644 src/core/xdp_tailcall.h $(SDK_STAGE)/include/core/
-	@install -m 644 src/core/xdp_tailcall_helpers.h $(SDK_STAGE)/include/core/
-	@install -m 644 src/core/xdp_tailcall_macros.h $(SDK_STAGE)/include/core/
-	@install -m 644 src/core/xdp_stats.h $(SDK_STAGE)/include/core/
-	@install -m 644 src/core/srv6.h $(SDK_STAGE)/include/core/
-	@install -m 644 sdk/README.md $(SDK_STAGE)/share/vinbero-sdk/
-	@install -m 644 LICENSE $(SDK_STAGE)/share/vinbero-sdk/
-	@for d in sdk/examples/plugin-counter sdk/examples/simple-acl sdk/examples/plugin-counter-l2 sdk/examples/plugin-custom-sh; do \
-		name=$$(basename $$d); \
-		install -d $(SDK_STAGE)/share/vinbero-sdk/examples/$$name; \
-		install -m 644 $$d/Makefile $$d/plugin.c $$d/README.md \
-			$(SDK_STAGE)/share/vinbero-sdk/examples/$$name/; \
-	done
-	@cd $(SDK_STAGE) && tar czf ../vinbero-sdk-$(SDK_VERSION).tar.gz .
+sdk-archive: sdk-stage ## Build SDK tarball into out/
+	@cd $(SDK_STAGE) && tar czf ../vinbero-sdk-$(SDK_VERSION).tar.gz include share
 	@echo "Created: $(SDK_TARBALL)"
 
 .PHONY: sdk-archive-verify

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ curl -fsSL https://raw.githubusercontent.com/takehaya/Vinbero/main/scripts/insta
 # Pin a specific release
 curl -fsSL https://raw.githubusercontent.com/takehaya/Vinbero/main/scripts/install_vinbero.sh | sudo bash -s -- --version v0.0.4
 
-# Also install the plugin SDK (headers + examples) under /usr/local
+# Also install the plugin SDK (headers + docs) under /usr/local
 curl -fsSL https://raw.githubusercontent.com/takehaya/Vinbero/main/scripts/install_vinbero.sh | sudo bash -s -- --with-sdk
 ```
 

--- a/scripts/install_vinbero.sh
+++ b/scripts/install_vinbero.sh
@@ -27,7 +27,7 @@ Usage: install_vinbero.sh [--version <tag>] [--with-sdk]
   --version <tag>   install a specific release tag (e.g. v0.0.4).
                     defaults to the latest release.
                     can also be set via VINBERO_VERSION.
-  --with-sdk        also install the plugin SDK (headers + examples)
+  --with-sdk        also install the plugin SDK (headers + docs)
                     under /usr/local.
   -h, --help        show this help.
 EOF

--- a/scripts/sdk_archive_verify.sh
+++ b/scripts/sdk_archive_verify.sh
@@ -26,26 +26,30 @@ required=(
   "$WORK/prefix/include/core/srv6.h"
   "$WORK/prefix/share/vinbero-sdk/README.md"
   "$WORK/prefix/share/vinbero-sdk/LICENSE"
-  "$WORK/prefix/share/vinbero-sdk/examples/plugin-counter/Makefile"
-  "$WORK/prefix/share/vinbero-sdk/examples/plugin-counter/plugin.c"
-  "$WORK/prefix/share/vinbero-sdk/examples/simple-acl/Makefile"
-  "$WORK/prefix/share/vinbero-sdk/examples/simple-acl/plugin.c"
-  "$WORK/prefix/share/vinbero-sdk/examples/plugin-counter-l2/Makefile"
-  "$WORK/prefix/share/vinbero-sdk/examples/plugin-counter-l2/plugin.c"
-  "$WORK/prefix/share/vinbero-sdk/examples/plugin-custom-sh/Makefile"
-  "$WORK/prefix/share/vinbero-sdk/examples/plugin-custom-sh/plugin.c"
 )
 for f in "${required[@]}"; do
   test -f "$f" || { echo "missing: $f" >&2; exit 1; }
 done
 
-# 3. Build each example using only headers from the tarball; this fails
-#    immediately if a #include path is wrong or a header is missing.
-#    MAKEFILE_PLUGIN points at the template shipped inside the tarball
-#    so the in-tree relative include (../../c/Makefile.plugin) is bypassed.
+# The tarball ships headers + docs only; examples are NOT bundled (they live in
+# the repo under sdk/examples/). Confirm no stray example tree leaked in.
+if [ -e "$WORK/prefix/share/vinbero-sdk/examples" ]; then
+  echo "unexpected: examples/ should not be in the SDK tarball" >&2
+  exit 1
+fi
+
+# 3. Build the repo's example plugins against ONLY the tarball's headers. The
+#    sources come from the repo (sdk/examples/, not shipped in the tarball) but
+#    every #include resolves against the extracted headers, so a wrong include
+#    path or a missing/collapsed core header fails the build immediately.
+#    MAKEFILE_PLUGIN points at the template shipped inside the tarball so the
+#    in-tree relative include (../../c/Makefile.plugin) is bypassed.
+EXAMPLES_SRC="${EXAMPLES_SRC:-sdk/examples}"
 for ex in plugin-counter simple-acl plugin-counter-l2 plugin-custom-sh; do
-  exdir="$WORK/prefix/share/vinbero-sdk/examples/$ex"
-  echo "[verify] building $ex"
+  exdir="$WORK/examples/$ex"
+  mkdir -p "$exdir"
+  cp "$EXAMPLES_SRC/$ex/Makefile" "$EXAMPLES_SRC/$ex/plugin.c" "$exdir/"
+  echo "[verify] building $ex (repo source, tarball headers)"
   make -C "$exdir" \
     VINBERO_SDK_ROOT="$WORK/prefix/include" \
     VINBERO_CORE_ROOT="$WORK/prefix/include" \
@@ -63,16 +67,16 @@ if [ ! -x "$VBCTL" ]; then
   exit 1
 fi
 "$VBCTL" plugin validate \
-  --prog "$WORK/prefix/share/vinbero-sdk/examples/plugin-counter/plugin.o" \
+  --prog "$WORK/examples/plugin-counter/plugin.o" \
   --program plugin_counter
 "$VBCTL" plugin validate \
-  --prog "$WORK/prefix/share/vinbero-sdk/examples/simple-acl/plugin.o" \
+  --prog "$WORK/examples/simple-acl/plugin.o" \
   --program simple_acl
 "$VBCTL" plugin validate \
-  --prog "$WORK/prefix/share/vinbero-sdk/examples/plugin-counter-l2/plugin.o" \
+  --prog "$WORK/examples/plugin-counter-l2/plugin.o" \
   --program plugin_counter_l2
 "$VBCTL" plugin validate \
-  --prog "$WORK/prefix/share/vinbero-sdk/examples/plugin-custom-sh/plugin.o" \
+  --prog "$WORK/examples/plugin-custom-sh/plugin.o" \
   --program plugin_custom_sh
 
 echo "[verify] OK"

--- a/scripts/sdk_archive_verify.sh
+++ b/scripts/sdk_archive_verify.sh
@@ -17,6 +17,15 @@ while IFS= read -r entry; do
     /*|..|../*|*/../*|*/..) echo "unsafe path in SDK tarball: $entry" >&2; exit 1 ;;
   esac
 done <<<"$(tar -tzf "$TARBALL")"
+# Reject non-regular entries (symlink/device/fifo/hardlink) before extraction,
+# matching the installer: a symlink could redirect a later test -f or build.
+while IFS= read -r line; do
+  [ -n "$line" ] || continue
+  case "$line" in
+    -*|d*) ;;
+    *) echo "non-regular entry in SDK tarball: ${line##* }" >&2; exit 1 ;;
+  esac
+done <<<"$(tar -tvzf "$TARBALL")"
 mkdir -p "$WORK/prefix"
 tar xzf "$TARBALL" -C "$WORK/prefix"
 

--- a/scripts/sdk_archive_verify.sh
+++ b/scripts/sdk_archive_verify.sh
@@ -8,7 +8,15 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
-# 1. Extract tarball to a fake /usr/local prefix.
+# 1. Extract tarball to a fake /usr/local prefix. Validate entries first so a
+#    tarball with absolute or `..` paths cannot escape $WORK/prefix during
+#    extraction (defence-in-depth; this runs in CI). Mirrors the installer guard.
+while IFS= read -r entry; do
+  [ -n "$entry" ] || continue
+  case "$entry" in
+    /*|..|../*|*/../*|*/..) echo "unsafe path in SDK tarball: $entry" >&2; exit 1 ;;
+  esac
+done <<<"$(tar -tzf "$TARBALL")"
 mkdir -p "$WORK/prefix"
 tar xzf "$TARBALL" -C "$WORK/prefix"
 

--- a/scripts/sdk_archive_verify.sh
+++ b/scripts/sdk_archive_verify.sh
@@ -4,12 +4,23 @@
 set -euo pipefail
 
 TARBALL="${1:?usage: sdk_archive_verify.sh <tarball>}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
 # 1. Extract tarball to a fake /usr/local prefix.
 mkdir -p "$WORK/prefix"
 tar xzf "$TARBALL" -C "$WORK/prefix"
+
+# The installer extracts the tarball straight into /usr/local, so its top level
+# must be only include/ and share/ (this mirrors the installer's entry guard and
+# catches any stray top-level file — e.g. a leaked binary — before it ships).
+for entry in "$WORK"/prefix/*; do
+  case "$(basename "$entry")" in
+    include|share) ;;
+    *) echo "unexpected top-level entry in SDK tarball: $(basename "$entry")" >&2; exit 1 ;;
+  esac
+done
 
 # 2. Confirm the expected files landed at the documented paths.
 required=(
@@ -44,7 +55,7 @@ fi
 #    path or a missing/collapsed core header fails the build immediately.
 #    MAKEFILE_PLUGIN points at the template shipped inside the tarball so the
 #    in-tree relative include (../../c/Makefile.plugin) is bypassed.
-EXAMPLES_SRC="${EXAMPLES_SRC:-sdk/examples}"
+EXAMPLES_SRC="${EXAMPLES_SRC:-$ROOT/sdk/examples}"
 for ex in plugin-counter simple-acl plugin-counter-l2 plugin-custom-sh; do
   exdir="$WORK/examples/$ex"
   mkdir -p "$exdir"
@@ -61,7 +72,7 @@ done
 #    regressions in the tailcall_epilogue / forbidden-helper rules.
 #    Note: the binary is named `vinbero` in this repo (not `vbctl`); the
 #    `plugin validate` subcommand is provided by cmd/vinbero.
-VBCTL="${VBCTL:-./out/bin/vinbero}"
+VBCTL="${VBCTL:-$ROOT/out/bin/vinbero}"
 if [ ! -x "$VBCTL" ]; then
   echo "vinbero CLI not found at $VBCTL — run 'make build' first" >&2
   exit 1

--- a/scripts/sdk_archive_verify.sh
+++ b/scripts/sdk_archive_verify.sh
@@ -8,30 +8,31 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
-# 1. Extract tarball to a fake /usr/local prefix. Validate entries first so a
-#    tarball with absolute or `..` paths cannot escape $WORK/prefix during
-#    extraction (defence-in-depth; this runs in CI). Mirrors the installer guard.
+# 1. Extract to a fake /usr/local prefix. First assert the tarball matches the
+#    contract install_vinbero.sh enforces on download — no path traversal, only
+#    regular files/dirs, only include/ and share/ at the top level. The tarball
+#    is built in-house, so this is a producer/installer contract test: it fails
+#    CI if goreleaser ever ships something the installer would reject (e.g. the
+#    binary-leak / collapsed-header regressions this packaging has already hit).
 while IFS= read -r entry; do
   [ -n "$entry" ] || continue
   case "$entry" in
     /*|..|../*|*/../*|*/..) echo "unsafe path in SDK tarball: $entry" >&2; exit 1 ;;
   esac
 done <<<"$(tar -tzf "$TARBALL")"
-# Reject non-regular entries (symlink/device/fifo/hardlink) before extraction,
-# matching the installer: a symlink could redirect a later test -f or build.
+# Only regular files / directories — the installer rejects symlink/device/fifo.
 while IFS= read -r line; do
   [ -n "$line" ] || continue
   case "$line" in
     -*|d*) ;;
-    *) echo "non-regular entry in SDK tarball: ${line##* }" >&2; exit 1 ;;
+    *) echo "non-regular entry in SDK tarball: $line" >&2; exit 1 ;;
   esac
 done <<<"$(tar -tvzf "$TARBALL")"
 mkdir -p "$WORK/prefix"
 tar xzf "$TARBALL" -C "$WORK/prefix"
 
-# The installer extracts the tarball straight into /usr/local, so its top level
-# must be only include/ and share/ (this mirrors the installer's entry guard and
-# catches any stray top-level file — e.g. a leaked binary — before it ships).
+# Top level must be only include/ and share/ (catches a stray entry — e.g. a
+# leaked binary — that the installer would also reject).
 for entry in "$WORK"/prefix/*; do
   case "$(basename "$entry")" in
     include|share) ;;

--- a/scripts/stage_sdk.sh
+++ b/scripts/stage_sdk.sh
@@ -15,8 +15,12 @@ set -euo pipefail
 DEST="${1:?usage: stage_sdk.sh <dest-dir>}"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# Guard the rm -rf below against obviously catastrophic destinations.
-case "$DEST" in
+# Guard the rm -rf below against obviously catastrophic destinations. Strip
+# trailing slashes first so "/", "$HOME/" etc. can't slip past the match.
+norm="$DEST"
+while [ -n "$norm" ] && [ "$norm" != "${norm%/}" ]; do norm="${norm%/}"; done
+[ -n "$norm" ] || norm="/"
+case "$norm" in
   /|.|..|"$HOME") echo "stage_sdk.sh: refusing to wipe '$DEST'" >&2; exit 1 ;;
 esac
 

--- a/scripts/stage_sdk.sh
+++ b/scripts/stage_sdk.sh
@@ -15,6 +15,11 @@ set -euo pipefail
 DEST="${1:?usage: stage_sdk.sh <dest-dir>}"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# Guard the rm -rf below against obviously catastrophic destinations.
+case "$DEST" in
+  /|.|..|"$HOME") echo "stage_sdk.sh: refusing to wipe '$DEST'" >&2; exit 1 ;;
+esac
+
 rm -rf "$DEST"
 install -d "$DEST/include/vinbero" "$DEST/include/core" "$DEST/share/vinbero-sdk"
 

--- a/scripts/stage_sdk.sh
+++ b/scripts/stage_sdk.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Stage the plugin SDK tree (headers + docs) into <dest>.
+#
+# This is the single source of truth for the SDK tarball contents. Both
+# `make sdk-archive` (used by CI's SDK Archive Verify) and the goreleaser
+# release archive stage from here, so the verified tarball and the released
+# tarball can never drift apart.
+#
+# Resulting layout mirrors what gets extracted to /usr/local:
+#   <dest>/include/vinbero/   public ABI headers + Makefile.plugin
+#   <dest>/include/core/      internal headers the public ones #include
+#   <dest>/share/vinbero-sdk/ README + LICENSE
+set -euo pipefail
+
+DEST="${1:?usage: stage_sdk.sh <dest-dir>}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+rm -rf "$DEST"
+install -d "$DEST/include/vinbero" "$DEST/include/core" "$DEST/share/vinbero-sdk"
+
+# Public ABI headers + the one-liner plugin build template.
+install -m 644 "$ROOT"/sdk/c/include/vinbero/*.h "$DEST/include/vinbero/"
+install -m 644 "$ROOT/sdk/c/Makefile.plugin" "$DEST/include/vinbero/Makefile.plugin"
+
+# Internal headers that the public ones #include via "core/...". Shipped
+# wholesale on purpose: the public headers pull a transitive subset, and a
+# glob avoids a hand-kept list that silently breaks plugin builds the moment a
+# public header starts depending on another core header.
+install -m 644 "$ROOT"/src/core/*.h "$DEST/include/core/"
+
+# Static docs under share/ (FHS). Examples are intentionally NOT shipped: they
+# live in the repo under sdk/examples/ and are linked from the SDK README.
+install -m 644 "$ROOT/sdk/README.md" "$DEST/share/vinbero-sdk/README.md"
+install -m 644 "$ROOT/LICENSE" "$DEST/share/vinbero-sdk/LICENSE"


### PR DESCRIPTION
## 背景

v0.0.8 の SDK で実際に plugin をビルドしようとして 2 つの実バグが判明しました。

1. **`include/core` がディレクトリでなく単一ファイルに潰れていた**。公開ヘッダ (`plugin.h` など) は `#include "core/xdp_map.h"` を参照するため、公開中の SDK では plugin がビルドできませんでした。原因は goreleaser v2 が「個別 `src` + `dst: include/core/`」を 1 ファイルに潰すためです。
2. **SDK tarball を作る実装が 2 つあってドリフトしていた**。`make sdk-archive` (Makefile、CI の SDK Archive Verify が使う) は正しく staging する一方、リリースは `.goreleaser.yaml` の archive を使い、こちらが潰れていました。CI は実リリースと別物の tarball を検証していたため緑のままバグが出荷されていました。

あわせて、ユーザー要望の examples 除外と、per-header 列挙の保守負担解消も対応します。

## 変更点

- `scripts/stage_sdk.sh` を追加。SDK ツリーの単一の真実。`src/core/*.h` を glob し (手書きリスト不要)、headers + docs のみ。examples は同梱しない (repo の `sdk/examples/` と README リンクで参照)。
- `.goreleaser.yaml`: before-hook で staging し、staged の `include/` `share/` を 2 エントリで archive。構造保持・checksums 維持・per-file 列挙撤廃。
- `Makefile`: `sdk-stage` ターゲットを切り出し、`sdk-archive` は同じ script を使用。
- `scripts/sdk_archive_verify.sh`: examples は tarball に無いので、repo の example source を tarball のヘッダに対してビルドして検証。stray な `examples/` を拒否。
- `README.md`: SDK install の説明を「headers + docs」に。

## 検証 (goreleaser v2.16.0 = リリースと同じ版)

- make 版と goreleaser 版の tarball のファイル集合が一致 (ドリフト解消)
- `include/core/` が実ディレクトリ (10 ヘッダ)、バイナリ混入なし、examples なし
- goreleaser SDK tarball が `checksums.txt` に入る
- 4 つの example plugin が **両方の tarball のヘッダ**でビルド成功 + `vinbero plugin validate` の plugin contract pass
