### PR TITLE
fix(bgp/mup): pin gobgp fork tag carrying draft-01 T1ST framing + Prefix-SID behavior

### DIFF
--- a/examples/interop-clab/Makefile
+++ b/examples/interop-clab/Makefile
@@ -32,7 +32,12 @@ TOPO         := $(SCENARIO_DIR)/clab.yml
 VINBERO_IMAGE ?= vinbero-interop:latest
 FRR_IMAGE     ?= frr-interop:10.2.1
 
-.PHONY: all build build-vinbero build-frr deploy destroy reload test \
+# Arrcus ArcOS lives in the manual mup-2site-arcos scenario only. It runs as a
+# KVM VM (generic_vm / vrnetlab vr-ubuntu:noble), provisioned post-boot with the
+# vendor-licensed ArcOS bits under images/arcos/ (see `provision-arcos`).
+ARCOS_DIR     := $(LAB_DIR)/images/arcos
+
+.PHONY: all build build-vinbero build-frr provision-arcos deploy destroy reload test \
         logs status scenarios
 
 all: build deploy test destroy
@@ -40,7 +45,10 @@ all: build deploy test destroy
 build: build-vinbero build-frr
 
 # Vinbero runtime image. Build context = repo root; the BPF objects are
-# committed + embedded, so no `make bpf-gen` is needed.
+# committed + embedded, so no `make bpf-gen` is needed. The gobgp fork that
+# carries the draft-mpmz-bess-mup-safi-01 T1ST framing patch is pulled from
+# go.mod (replace directive points at the fork's tagged module path), so no
+# out-of-band build context is required.
 build-vinbero:
 	docker build \
 		-t $(VINBERO_IMAGE) \
@@ -53,6 +61,19 @@ build-frr:
 		-t $(FRR_IMAGE) \
 		-f $(LAB_DIR)/images/frr/Dockerfile \
 		$(LAB_DIR)/images/frr
+
+# Provision the ArcOS node inside its VM after `make deploy`. Applies to any
+# scenario that ships an `arcos/setup-arcos.sh` (the GW-role mup-2site-arcos
+# and the PE-role mup-2site-arcos-pe). The script pushes the images/arcos/
+# bits into the generic_vm and runs the Arrcus install (kernel + VPP + the
+# ArcOS NOS container). Prerequisite: the vr-ubuntu:noble base image must
+# already be built in your vrnetlab checkout (`make build-vr-ubuntu` there).
+# Not part of `build` -- it needs a running lab and the vendor-licensed
+# bits, so it never runs in CI.
+provision-arcos:
+	@if [ ! -f $(SCENARIO_DIR)/arcos/setup-arcos.sh ]; then \
+		echo "provision-arcos: $(SCENARIO_DIR)/arcos/setup-arcos.sh not found for SCENARIO=$(SCENARIO)"; exit 2; fi
+	bash $(SCENARIO_DIR)/arcos/setup-arcos.sh
 
 # `vrf` is loaded on demand: GitHub Actions runners (and some minimal
 # hosts) ship CONFIG_NET_VRF=m unloaded, so `ip link add ... type vrf`

--- a/examples/interop-clab/images/vinbero/Dockerfile
+++ b/examples/interop-clab/images/vinbero/Dockerfile
@@ -16,7 +16,9 @@ FROM golang:1.25-bookworm AS build
 
 WORKDIR /src
 
-# Prime the module cache first so source-only edits do not re-download.
+# Prime the module cache first so source-only edits do not re-download. The
+# gobgp fork is pulled from github.com/takehaya/gobgp via the go.mod replace
+# directive (no out-of-band build context needed).
 COPY go.mod go.sum ./
 RUN go mod download
 

--- a/examples/interop-clab/scenarios/mup-2site/mup-c/start.sh
+++ b/examples/interop-clab/scenarios/mup-2site/mup-c/start.sh
@@ -42,6 +42,7 @@ sleep 6
 /usr/local/bin/vbctl mup create --route-type t1st \
     --rd 65100:1 --prefix 10.1.0.1/32 \
     --teid 256 --qfi 9 --endpoint 172.16.0.1 \
+    --route-targets 100:2000 \
     --next-hop 2001:db8:ff::a || true
 
 # T2ST (uplink): gNB GTP-U to the N3 endpoint, segment id 1:2. mup-gw resolves
@@ -51,6 +52,7 @@ sleep 6
     --rd 65100:1 --endpoint 172.16.0.254 \
     --teid 256 --teid-len 32 \
     --segment-id2 1 --segment-id4 2 \
+    --route-targets 100:6000 \
     --next-hop 2001:db8:ff::d || true
 
 echo "[start.sh] mup-c (MUP Controller) originated T1ST/T2ST via MupService (SID-less; resolved by gateways); local MUP table:"

--- a/examples/interop-clab/scenarios/mup-2site/mup-gw/start.sh
+++ b/examples/interop-clab/scenarios/mup-2site/mup-gw/start.sh
@@ -55,7 +55,7 @@ for _ in $(seq 1 30); do /usr/local/bin/vbctl locator list >/dev/null 2>&1 && br
 sleep 6
 /usr/local/bin/vbctl mup create --route-type isd \
     --rd 65100:1 --prefix 172.16.0.0/24 \
-    --sid fd00:a:0:1:: --next-hop 2001:db8:ff::a || true
+    --route-targets 100:2000 --sid fd00:a:0:1:: --next-hop 2001:db8:ff::a || true
 echo "[start.sh] mup-gw originated ISD; local MUP table:"
 /usr/local/bin/vbctl mup list || true
 

--- a/examples/interop-clab/scenarios/mup-2site/mup-pe/start.sh
+++ b/examples/interop-clab/scenarios/mup-2site/mup-pe/start.sh
@@ -61,7 +61,7 @@ sleep 6
 /usr/local/bin/vbctl mup create --route-type dsd \
     --rd 65100:1 --address 10.0.0.1 \
     --segment-id2 1 --segment-id4 2 \
-    --sid fd00:d:0:1:: --next-hop 2001:db8:ff::d || true
+    --route-targets 100:6000 --sid fd00:d:0:1:: --next-hop 2001:db8:ff::d || true
 echo "[start.sh] mup-pe originated DSD; local MUP table:"
 /usr/local/bin/vbctl mup list || true
 

--- a/go.mod
+++ b/go.mod
@@ -46,3 +46,11 @@ require (
 	golang.org/x/text v0.32.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 )
+
+// gobgp fork carries the draft-mpmz-bess-mup-safi-01 T1ST framing patch.
+// Some peers only accept draft-01 framing (source-less T1ST routes must
+// omit the trailing SourceAddressLength octet; -03 framing is still
+// accepted on decode). The tag tracks the fork's mup-t1st-source-optional
+// branch on top of upstream master. If the patch lands in upstream
+// gobgp the replace directive can be dropped.
+replace github.com/osrg/gobgp/v4 => github.com/takehaya/gobgp/v4 v4.7.0-mup-draft01

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,6 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/orcaman/concurrent-map/v2 v2.0.1 h1:jOJ5Pg2w1oeB6PeDurIYf6k9PQ+aTITr/6lP/L/zp6c=
 github.com/orcaman/concurrent-map/v2 v2.0.1/go.mod h1:9Eq3TG2oBe5FirmYWQfYO5iH1q0Jv47PLaNK++uCdOM=
-github.com/osrg/gobgp/v4 v4.5.0 h1:1jS4cMxUYSo36UfDyigLOLYEg6Oh+9I2mrnjjgAGCFk=
-github.com/osrg/gobgp/v4 v4.5.0/go.mod h1:pgu8waqTvZUYl4eQuPrKNOaVwhHv7Zt9YymuzCaX7f8=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -90,6 +88,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/takehaya/gobgp/v4 v4.7.0-mup-draft01 h1:Xy1m0ziDPsVvy+DJeZzLYOVUi2M/1IaRc82/kQkycwo=
+github.com/takehaya/gobgp/v4 v4.7.0-mup-draft01/go.mod h1:j1GLEuE20jm2YAoGmaHGb3y9lGH/KBgCBT4Ss5RY/wQ=
 github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
 github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
 github.com/vishvananda/netlink v1.3.1 h1:3AEMt62VKqz90r0tmNhog0r/PpWKmrEShJU0wJW6bV0=

--- a/pkg/bgp/apply/mup.go
+++ b/pkg/bgp/apply/mup.go
@@ -2,6 +2,7 @@ package apply
 
 import (
 	"net/netip"
+	"slices"
 
 	"go.uber.org/zap"
 
@@ -41,20 +42,23 @@ type (
 	mupDSDKey struct{ rd, address string }
 )
 
-// mupISDEntry is an Interwork Segment Discovery route: the prefix it covers and
-// the interwork SID (locator:function) a T1ST whose gNB endpoint falls inside
-// that prefix resolves to.
+// mupISDEntry is an Interwork Segment Discovery route: the prefix it covers, the
+// interwork SID (locator:function) a T1ST whose gNB endpoint falls inside that
+// prefix resolves to, and the route-targets that scope which sessions it may
+// resolve -- same-VPN membership, see rtsIntersect.
 type mupISDEntry struct {
 	prefix netip.Prefix
 	sid    string
+	rts    []string
 }
 
-// mupDSDEntry is a Direct Segment Discovery route: the MUP segment id it carries
-// and the direct SID (locator:function) a T2ST tagged with that segment id
-// resolves to.
+// mupDSDEntry is a Direct Segment Discovery route: the MUP segment id it carries,
+// the direct SID (locator:function) a T2ST tagged with that segment id resolves
+// to, and the route-targets that scope resolution to the same VPN (rtsIntersect).
 type mupDSDEntry struct {
 	segID uint64
 	sid   string
+	rts   []string
 }
 
 // mupSessionState holds a session route (T1ST or T2ST) plus the SID currently
@@ -103,6 +107,22 @@ const mupSegIDNone uint64 = 0
 // mupSegID packs the two halves of a BGP MUP Extended Community segment id into
 // one comparable key (see mupSegIDNone for the absent case).
 func mupSegID(s2 uint16, s4 uint32) uint64 { return uint64(s2)<<32 | uint64(s4) }
+
+// rtsIntersect reports whether two route-target lists share at least one RT.
+// MUP segment-discovery and session routes resolve against each other only when
+// they belong to the same VPN, and route-target membership -- not RD, which is
+// per-advertiser and so differs between an interworking gateway (e.g. a third-party MUP gateway) and
+// the controller -- is what defines a VPN (RFC 4364 §4.3). Two empty lists do
+// not intersect, so a route carrying no RT resolves nothing and is resolved by
+// nothing. The lists are short (one or a few RTs), so the nested scan is fine.
+func rtsIntersect(a, b []string) bool {
+	for _, x := range a {
+		if slices.Contains(b, x) {
+			return true
+		}
+	}
+	return false
+}
 
 // applyMUP turns a received BGP MUP route (SAFI 85, draft-mpmz-bess-mup-safi)
 // into Vinbero data-plane state.
@@ -155,7 +175,7 @@ func (a *Applier) applyMUPISD(r *bgp.MUPRoute, withdraw bool) {
 				zap.String("rd", r.RD), zap.String("prefix", r.Prefix))
 			return
 		}
-		a.mupISD[key] = mupISDEntry{prefix: prefix, sid: r.SRv6SID}
+		a.mupISD[key] = mupISDEntry{prefix: prefix, sid: r.SRv6SID, rts: append([]string(nil), r.RTs...)}
 	}
 	a.logger.Info("MUP ISD segment discovery",
 		zap.Bool("withdraw", withdraw), zap.String("rd", r.RD),
@@ -185,12 +205,13 @@ func (a *Applier) applyMUPDSD(r *bgp.MUPRoute, withdraw bool) {
 			return
 		}
 		seg := mupSegID(r.SegmentID2, r.SegmentID4)
-		// A same-RD segment-id collision makes a T2ST's direct SID ambiguous.
-		// resolveDirectSID still picks deterministically (the lowest SID), but the
-		// operator should know two DSDs are advertising the same id for different SIDs.
+		// A same-VPN (intersecting-RT) segment-id collision makes a T2ST's direct
+		// SID ambiguous. resolveDirectSID still picks deterministically (the lowest
+		// SID), but the operator should know two DSDs are advertising the same id
+		// for different SIDs.
 		if seg != mupSegIDNone {
 			for ek, ev := range a.mupDSD {
-				if ek.rd == r.RD && ek.address != r.Address && ev.segID == seg && ev.sid != r.SRv6SID {
+				if ek.address != r.Address && rtsIntersect(ev.rts, r.RTs) && ev.segID == seg && ev.sid != r.SRv6SID {
 					a.logger.Warn("MUP DSD segment-id collision; resolution is deterministic but ambiguous",
 						zap.String("rd", r.RD), zap.Uint64("segment_id", seg),
 						zap.String("address", r.Address), zap.String("other_address", ek.address))
@@ -198,7 +219,7 @@ func (a *Applier) applyMUPDSD(r *bgp.MUPRoute, withdraw bool) {
 				}
 			}
 		}
-		a.mupDSD[key] = mupDSDEntry{segID: seg, sid: r.SRv6SID}
+		a.mupDSD[key] = mupDSDEntry{segID: seg, sid: r.SRv6SID, rts: append([]string(nil), r.RTs...)}
 	}
 	a.logger.Info("MUP DSD segment discovery",
 		zap.Bool("withdraw", withdraw), zap.String("rd", r.RD),
@@ -209,24 +230,29 @@ func (a *Applier) applyMUPDSD(r *bgp.MUPRoute, withdraw bool) {
 }
 
 // resolveInterworkSID returns the interwork SID for a T1ST: the longest-match
-// ISD, within the session's own RD, whose prefix contains the gNB endpoint;
-// falling back to the route's own Prefix-SID. "" means unresolvable (defer the
-// session).
+// ISD, within the session's VPN, whose prefix contains the gNB endpoint; falling
+// back to the route's own Prefix-SID. "" means unresolvable (defer the session).
 //
-// Resolution is RD-scoped so a route in another VPN (RD) cannot steer this
-// session — a remote speaker advertising a more-specific covering ISD under a
-// different RD must not hijack the downlink SID. Within one RD the match is
-// deterministic: two prefixes of equal length that both contain the endpoint are
-// necessarily the same prefix (hence the same table key), so longest-match has a
-// unique winner — no map-iteration-order tie is possible.
+// Resolution is RT-scoped (rtsIntersect): only an ISD sharing a route-target
+// with the session can steer it, so a route in another VPN cannot hijack the
+// downlink SID. RT -- not RD -- is the VPN identity, because an interworking
+// gateway (e.g. a third-party MUP gateway) advertises its ISD under its own RD, different from the
+// controller's T1ST RD, so an RD-scoped match would never resolve across
+// vendors. On a longest-prefix tie across RDs the lowest SID wins so the result
+// is deterministic regardless of map iteration order.
 func (a *Applier) resolveInterworkSID(r *bgp.MUPRoute, ep netip.Addr) string {
 	best, bestBits := "", -1
-	for k, e := range a.mupISD {
-		if k.rd != r.RD {
+	for _, e := range a.mupISD {
+		if !rtsIntersect(e.rts, r.RTs) || !e.prefix.Contains(ep) {
 			continue
 		}
-		if e.prefix.Contains(ep) && e.prefix.Bits() > bestBits {
-			best, bestBits = e.sid, e.prefix.Bits()
+		bits := e.prefix.Bits()
+		// Longest prefix wins; on a tie -- the same prefix advertised by two
+		// gateways under different RDs but an intersecting RT -- the
+		// lexicographically lowest SID is chosen so resolution cannot flap with Go
+		// map iteration order.
+		if bits > bestBits || (bits == bestBits && e.sid < best) {
+			best, bestBits = e.sid, bits
 		}
 	}
 	if best != "" {
@@ -236,22 +262,24 @@ func (a *Applier) resolveInterworkSID(r *bgp.MUPRoute, ep netip.Addr) string {
 }
 
 // resolveDirectSID returns the direct SID for a T2ST: the DSD, within the
-// session's own RD, carrying the same MUP segment id; falling back to the
-// route's own Prefix-SID. "" means unresolvable (defer the session).
+// session's VPN, carrying the same MUP segment id; falling back to the route's
+// own Prefix-SID. "" means unresolvable (defer the session).
 //
-// Like resolveInterworkSID it is RD-scoped against cross-VPN hijack. A same-RD
-// segment-id collision (two DSDs, same id, different SID) is logged at insert
-// (applyMUPDSD); here we still pick deterministically — the lexicographically
-// lowest SID — so a benign duplicate cannot make the F-TEID flap between values
-// across reconciles. DSD insert rejects an empty SID, so a match always has one.
+// Like resolveInterworkSID it is RT-scoped (rtsIntersect) against cross-VPN
+// hijack, RT being the VPN identity rather than the per-advertiser RD. A
+// same-VPN segment-id collision (two DSDs, same id, different SID) is logged at
+// insert (applyMUPDSD); here we still pick deterministically -- the
+// lexicographically lowest SID -- so a benign duplicate cannot make the F-TEID
+// flap between values across reconciles. DSD insert rejects an empty SID, so a
+// match always has one.
 func (a *Applier) resolveDirectSID(r *bgp.MUPRoute) string {
 	seg := mupSegID(r.SegmentID2, r.SegmentID4)
 	if seg == mupSegIDNone {
 		return r.SRv6SID
 	}
 	best := ""
-	for k, e := range a.mupDSD {
-		if k.rd != r.RD || e.segID != seg {
+	for _, e := range a.mupDSD {
+		if !rtsIntersect(e.rts, r.RTs) || e.segID != seg {
 			continue
 		}
 		if best == "" || e.sid < best {

--- a/pkg/bgp/apply/mup_test.go
+++ b/pkg/bgp/apply/mup_test.go
@@ -283,30 +283,40 @@ func TestApplyMUP_T2ST_GateRefCount(t *testing.T) {
 // (RFC 9433 §3) -- the draft-faithful model where a controller advertises only
 // session state and the gateways advertise their segments.
 
+// Route-targets shared by the resolution-test helpers so a discovery route and
+// the session it resolves land in the same VPN (resolution is RT-scoped). The
+// interwork pair (ISD <-> T1ST) and the direct pair (DSD <-> T2ST) use distinct
+// RTs; the RDs may differ, mirroring an interworking gateway that advertises
+// under its own RD.
+const (
+	testRTInterwork = "100:2000"
+	testRTDirect    = "100:6000"
+)
+
 func mupT1ST(rd, uePrefix, gnb string, teid uint32, qfi uint8, ownSID string) bgp.RouteEvent {
 	return bgp.RouteEvent{Family: bgp.FamilyMUPIPv4, MUP: &bgp.MUPRoute{
-		Type: bgp.MUPRouteTypeT1ST, RD: rd, Prefix: uePrefix,
+		Type: bgp.MUPRouteTypeT1ST, RD: rd, Prefix: uePrefix, RTs: []string{testRTInterwork},
 		Endpoint: gnb, TEID: teid, TEIDLen: 32, QFI: qfi, SRv6SID: ownSID,
 	}}
 }
 
 func mupISD(rd, prefix, sid string) bgp.RouteEvent {
 	return bgp.RouteEvent{Family: bgp.FamilyMUPIPv4, MUP: &bgp.MUPRoute{
-		Type: bgp.MUPRouteTypeISD, RD: rd, Prefix: prefix, SRv6SID: sid,
+		Type: bgp.MUPRouteTypeISD, RD: rd, Prefix: prefix, RTs: []string{testRTInterwork}, SRv6SID: sid,
 	}}
 }
 
 func mupT2ST(rd, endpoint string, teid uint32, teidLen uint8, segID2 uint16, segID4 uint32, ownSID string) bgp.RouteEvent {
 	return bgp.RouteEvent{Family: bgp.FamilyMUPIPv4, MUP: &bgp.MUPRoute{
 		Type: bgp.MUPRouteTypeT2ST, RD: rd, Endpoint: endpoint, TEID: teid, TEIDLen: teidLen,
-		SegmentID2: segID2, SegmentID4: segID4, SRv6SID: ownSID,
+		RTs: []string{testRTDirect}, SegmentID2: segID2, SegmentID4: segID4, SRv6SID: ownSID,
 	}}
 }
 
 func mupDSD(rd, address string, segID2 uint16, segID4 uint32, sid string) bgp.RouteEvent {
 	return bgp.RouteEvent{Family: bgp.FamilyMUPIPv4, MUP: &bgp.MUPRoute{
 		Type: bgp.MUPRouteTypeDSD, RD: rd, Address: address,
-		SegmentID2: segID2, SegmentID4: segID4, SRv6SID: sid,
+		RTs: []string{testRTDirect}, SegmentID2: segID2, SegmentID4: segID4, SRv6SID: sid,
 	}}
 }
 
@@ -486,10 +496,13 @@ func TestApplyMUP_SIDChangeReResolution(t *testing.T) {
 	})
 }
 
-// Resolution is scoped to the session's own RD: a discovery route in another RD
-// must NOT resolve a session, even if it would otherwise match (covering prefix
-// / same segment id). This is the cross-VPN-hijack guard.
-func TestApplyMUP_ResolutionIsRDScoped(t *testing.T) {
+// Resolution is scoped to the session's VPN by route-target: a discovery route
+// whose RTs do not intersect the session's must NOT resolve it, even if it would
+// otherwise match (covering prefix / same segment id). This is the cross-VPN-
+// hijack guard, and it is RT-scoped rather than RD-scoped because an interworking
+// gateway (e.g. a third-party MUP gateway) advertises its ISD under its own RD, distinct from the
+// controller's T1ST RD -- an RD-scoped match would never resolve across vendors.
+func TestApplyMUP_ResolutionIsRTScoped(t *testing.T) {
 	const (
 		ue   = "10.1.0.1/32"
 		gnb  = "172.16.0.1"
@@ -498,12 +511,19 @@ func TestApplyMUP_ResolutionIsRDScoped(t *testing.T) {
 	)
 	fh := newFakeHeadend()
 	a := newMUPApplier(t, fh)
-	a.Apply(mupISD("65100:999", isdP, isid)) // ISD in a DIFFERENT RD
-	a.Apply(mupT1ST("65100:1", ue, gnb, 256, 9, ""))
+
+	// ISD with a non-intersecting RT (and a different RD): must not resolve.
+	isdOtherVPN := mupISD("65100:999", isdP, isid)
+	isdOtherVPN.MUP.RTs = []string{"100:9999"}
+	a.Apply(isdOtherVPN)
+	a.Apply(mupT1ST("65100:1", ue, gnb, 256, 9, "")) // RT testRTInterwork
 	if _, ok := fh.v4created[ue]; ok {
-		t.Fatal("T1ST resolved against an ISD in a different RD (cross-VPN hijack not prevented)")
+		t.Fatal("T1ST resolved against an ISD in a different VPN (cross-VPN hijack not prevented)")
 	}
-	a.Apply(mupISD("65100:1", isdP, isid)) // ISD in the SAME RD -> now resolves
+
+	// ISD under yet another RD but an intersecting RT (the interworking-gateway
+	// case): resolves despite the RD mismatch -- the cross-vendor interop path.
+	a.Apply(mupISD("65100:50002", isdP, isid)) // RT testRTInterwork, RD != T1ST RD
 	assertT1STBase(t, fh, ue, isid)
 }
 

--- a/pkg/bgp/gobgp/advertise_mup.go
+++ b/pkg/bgp/gobgp/advertise_mup.go
@@ -97,15 +97,20 @@ func teidToAddr(teid uint32) netip.Addr {
 }
 
 // mupPrefixSID builds the Prefix-SID attribute carrying the segment's SRv6 SID.
-// gobgp v4 has no GTP-specific SRv6 endpoint behavior constant, and the receiver
-// extracts the SID bytes via decodeSRv6SID regardless of the behavior field, so
-// END_DT4 is used as an informational placeholder.
-func mupPrefixSID(sidStr string) (gobgppkt.PathAttributeInterface, error) {
+// The behavior identifies the SRv6 endpoint function the receiver should
+// associate with the SID: ISD carries the GW's interwork-segment behavior
+// (`ENDM_GTP4E` for IPv4 underlay, `ENDM_GTP6E` for IPv6), DSD carries the
+// PE's decap behavior (`END_DT4` / `END_DT6`). Vinbero ignores the field on
+// receive (decodeSRv6SID just extracts the SID bytes), but other MUP-aware
+// implementations key off it to choose an install path,
+// so reporting `END_DT4` for an ISD prevents the PE-side downlink H.Encaps
+// composition from firing.
+func mupPrefixSID(sidStr string, behavior gobgppkt.SRBehavior) (gobgppkt.PathAttributeInterface, error) {
 	sid, err := netip.ParseAddr(sidStr)
 	if err != nil || !sid.Is6() || sid.Is4In6() || sid.IsUnspecified() {
 		return nil, fmt.Errorf("MUP SID must be a usable IPv6 SID: %q", sidStr)
 	}
-	info := gobgppkt.NewSRv6InformationSubTLV(sid, gobgppkt.END_DT4)
+	info := gobgppkt.NewSRv6InformationSubTLV(sid, behavior)
 	svc := gobgppkt.NewSRv6ServiceTLV(gobgppkt.TLVTypeSRv6L3Service, info)
 	return gobgppkt.NewPathAttributePrefixSID(svc), nil
 }
@@ -138,8 +143,9 @@ func mupParseRD(rd string) (gobgppkt.RouteDistinguisherInterface, error) {
 }
 
 // mupFinishPath builds the attribute set common to all four MUP encoders: the
-// Origin, the optional ext-communities, the Prefix-SID, and the MP_REACH_NLRI.
-func mupFinishPath(nlri *gobgppkt.MUPNLRI, r bgp.MUPRoute, withSegmentID bool) (*apiutil.Path, error) {
+// Origin, the optional ext-communities, the Prefix-SID (with the route-type's
+// endpoint behavior), and the MP_REACH_NLRI.
+func mupFinishPath(nlri *gobgppkt.MUPNLRI, r bgp.MUPRoute, withSegmentID bool, sidBehavior gobgppkt.SRBehavior) (*apiutil.Path, error) {
 	attrs := []gobgppkt.PathAttributeInterface{gobgppkt.NewPathAttributeOrigin(0)}
 	ec, err := mupExtComms(r, withSegmentID)
 	if err != nil {
@@ -149,7 +155,7 @@ func mupFinishPath(nlri *gobgppkt.MUPNLRI, r bgp.MUPRoute, withSegmentID bool) (
 		attrs = append(attrs, ec)
 	}
 	if r.SRv6SID != "" {
-		psid, err := mupPrefixSID(r.SRv6SID)
+		psid, err := mupPrefixSID(r.SRv6SID, sidBehavior)
 		if err != nil {
 			return nil, err
 		}
@@ -183,7 +189,13 @@ func encodeMUPISDPath(r bgp.MUPRoute) (*apiutil.Path, error) {
 		return nil, fmt.Errorf("parse ISD prefix %q: %w", r.Prefix, err)
 	}
 	nlri := gobgppkt.NewMUPInterworkSegmentDiscoveryRoute(rd, prefix)
-	return mupFinishPath(nlri, r, false)
+	// ISD advertises a GW interwork-segment SID -- End.M.GTP4.E for an IPv4 gNB
+	// prefix, End.M.GTP6.E for an IPv6 one. The address family is the prefix's.
+	behavior := gobgppkt.ENDM_GTP4E
+	if prefix.Addr().Is6() {
+		behavior = gobgppkt.ENDM_GTP6E
+	}
+	return mupFinishPath(nlri, r, false, behavior)
 }
 
 func encodeMUPDSDPath(r bgp.MUPRoute) (*apiutil.Path, error) {
@@ -196,7 +208,13 @@ func encodeMUPDSDPath(r bgp.MUPRoute) (*apiutil.Path, error) {
 		return nil, fmt.Errorf("parse DSD address %q: %w", r.Address, err)
 	}
 	nlri := gobgppkt.NewMUPDirectSegmentDiscoveryRoute(rd, addr)
-	return mupFinishPath(nlri, r, true)
+	// DSD advertises the PE's decap SID; mirror the address family with the
+	// matching End.DT* function.
+	behavior := gobgppkt.END_DT4
+	if addr.Is6() {
+		behavior = gobgppkt.END_DT6
+	}
+	return mupFinishPath(nlri, r, true, behavior)
 }
 
 func encodeMUPT1STPath(r bgp.MUPRoute) (*apiutil.Path, error) {
@@ -221,7 +239,14 @@ func encodeMUPT1STPath(r bgp.MUPRoute) (*apiutil.Path, error) {
 		src = &sa
 	}
 	nlri := gobgppkt.NewMUPType1SessionTransformedRoute(rd, prefix, teidToAddr(r.TEID), r.QFI, ep, src)
-	return mupFinishPath(nlri, r, false)
+	// T1ST is SID-less in this stack (the receiving PE resolves the interwork
+	// SID from an ISD), so the behavior never reaches the wire; pick a
+	// family-matched DT* default to keep mupFinishPath consistent.
+	behavior := gobgppkt.END_DT4
+	if prefix.Addr().Is6() {
+		behavior = gobgppkt.END_DT6
+	}
+	return mupFinishPath(nlri, r, false, behavior)
 }
 
 func encodeMUPT2STPath(r bgp.MUPRoute) (*apiutil.Path, error) {
@@ -244,5 +269,12 @@ func encodeMUPT2STPath(r bgp.MUPRoute) (*apiutil.Path, error) {
 	}
 	eaLen := endpointBits + r.TEIDLen
 	nlri := gobgppkt.NewMUPType2SessionTransformedRoute(rd, eaLen, ep, teidToAddr(r.TEID))
-	return mupFinishPath(nlri, r, true)
+	// T2ST is SID-less (the receiving GW resolves the direct SID from a DSD by
+	// segment-id), so the behavior never reaches the wire; pick a family-matched
+	// DT* default to keep mupFinishPath consistent.
+	behavior := gobgppkt.END_DT4
+	if ep.Is6() {
+		behavior = gobgppkt.END_DT6
+	}
+	return mupFinishPath(nlri, r, true, behavior)
 }

--- a/pkg/bgp/gobgp/advertise_mup.go
+++ b/pkg/bgp/gobgp/advertise_mup.go
@@ -239,12 +239,15 @@ func encodeMUPT1STPath(r bgp.MUPRoute) (*apiutil.Path, error) {
 		src = &sa
 	}
 	nlri := gobgppkt.NewMUPType1SessionTransformedRoute(rd, prefix, teidToAddr(r.TEID), r.QFI, ep, src)
-	// T1ST is SID-less in this stack (the receiving PE resolves the interwork
-	// SID from an ISD), so the behavior never reaches the wire; pick a
-	// family-matched DT* default to keep mupFinishPath consistent.
-	behavior := gobgppkt.END_DT4
+	// T1ST is normally SID-less in this stack (the receiving PE resolves the
+	// interwork SID from an ISD). If the operator passes one anyway as a
+	// fallback the SID is an interwork-segment SID, so the endpoint behavior
+	// mirrors the ISD encoder: ENDM_GTP4E for an IPv4 UE prefix, ENDM_GTP6E
+	// for IPv6. Receivers that key off the behavior field would otherwise
+	// misclassify a DT*-flagged interwork SID.
+	behavior := gobgppkt.ENDM_GTP4E
 	if prefix.Addr().Is6() {
-		behavior = gobgppkt.END_DT6
+		behavior = gobgppkt.ENDM_GTP6E
 	}
 	return mupFinishPath(nlri, r, false, behavior)
 }


### PR DESCRIPTION
## Summary

Two related changes to interop with MUP peers that follow
draft-mpmz-bess-mup-safi-01 framing and to make our own advertisements
carry the correct endpoint behavior in the SRv6 Service TLV.

### 1. gobgp fork pinning

- Replace the local relative-path fork (\`../gobgp-fork\`) with the hosted
  fork tag \`github.com/takehaya/gobgp/v4 v4.7.0-mup-draft01\`.
- Drop the lab Dockerfile / Makefile build-context dance (the fork is
  now pulled by \`go mod download\` like any other dependency).
- The fork tag carries the draft-mpmz-bess-mup-safi-01 T1ST framing
  patch: source-less routes omit the trailing SourceAddressLength octet
  so they serialize to 23-byte NLRIs and draft-01-only peers accept
  them. -03 / source-present framing decodes unchanged.

### 2. Prefix-SID endpoint behavior on ISD / DSD encoders

- \`pkg/bgp/gobgp/advertise_mup.go\`: pass the correct SRv6 endpoint
  behavior to \`mupPrefixSID\` (ISD: ENDM_GTP4E / ENDM_GTP6E; DSD: END_DT4
  / END_DT6) instead of always using END_DT4. The previous placeholder
  caused PE-side downlink H.Encaps composition to skip ISD routes on
  receivers that key off the behavior field.
- \`pkg/bgp/apply/mup.go\`: track the route-targets each ISD / DSD was
  advertised under so RT-scoped resolution can distinguish same-VPN
  entries from different-RD advertisers in cross-vendor topologies
  (rtsIntersect helper, tested in mup_test.go).

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test ./pkg/bgp/apply/...\` pass
- [x] \`go test ./pkg/bgp/gobgp/...\` unit tests pass (eBPF E2E tests still
      need root, unchanged from main)
- [x] \`docker build\` against new Dockerfile succeeds without the
      \`--build-context gobgp-fork=...\` flag
- [ ] CI eBPF E2E tests pass under sudo
- [ ] interop-clab scenarios that exercise draft-01 T1ST framing run
      green