### PR TITLE
chore(interop-clab): keep proprietary MUP interop assets out of the public repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,12 @@ sdk/examples/*/plugin.o
 
 # containerlab deploy artifacts (generated under each scenario by `clab deploy`)
 examples/interop-clab/scenarios/*/clab-*/
+
+# Private interop overlays. Proprietary, license-restricted vendor labs (VM
+# images, NOS configs, provisioning scripts) live in a separate private repo
+# and are rsync'd in for local runs only. They must never be committed to this
+# public repo; these guards keep an accidental `git add -A` from publishing them.
+/clab_arcos.sh
+/examples/interop-clab/images/arcos/
+/examples/interop-clab/scenarios/mup-2site-arcos/
+/examples/interop-clab/scenarios/mup-2site-arcos-pe/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://github.com/takehaya/Vinbero-legacy/tree/master) has become outdated, so 
 - **eBPF/XDP + TC fast path** — kernel-resident packet forwarding, the only open-source SRv6 stack that does EVPN L2VPN on eBPF.
 - **In-process BGP** — GoBGP v4 inside `vinberod`, no sidecar. VPNv4/VPNv6, EVPN (SRv6), MUP, SR Policy.
 - **Unified VRF binding** — one `vbctl vrf-bgp bind --rt FAMILY:RT:DIRECTION` drives import/export policy and auto-advertise across every AF.
-- **Interop tested** — FRR (L3VPN/EVPN) and Arrcus ArcOS (MUP) in CI under `examples/interop-clab/scenarios/`.
+- **Interop tested** — FRR (L3VPN/EVPN) in CI under `examples/interop-clab/scenarios/`; MUP additionally validated against a third-party commercial router.
 - **Custom XDP plugins** — reserved tail-call slots, runtime register via `vinbero plugin`. SDK in `sdk/`.
 - **Connect RPC + gRPC** — every primitive reachable over HTTP/2.
 

--- a/examples/interop-clab/Makefile
+++ b/examples/interop-clab/Makefile
@@ -57,14 +57,15 @@ build-frr:
 		-f $(LAB_DIR)/images/frr/Dockerfile \
 		$(LAB_DIR)/images/frr
 
-# Post-deploy provisioning hook for scenarios whose node needs out-of-band
+# Post-deploy provisioning hook for a scenario whose node needs out-of-band
 # setup after `make deploy` (for example a VM-based NOS that boots from a
-# generic image and is configured over SSH). A scenario opts in by shipping
-# an executable `provision.sh` at its root; scenarios without one skip this
-# step. Not part of `build` and never runs in CI -- it needs a running lab
-# and may pull in artifacts that are not part of this repo.
+# generic image and is configured over SSH). The scenario must ship a
+# `provision.sh` at its root; this target errors if it is missing. Most
+# scenarios need no provisioning and simply never call it. Not part of
+# `build` and never runs in CI -- it needs a running lab and may pull in
+# artifacts that are not part of this repo.
 provision:
-	@if [ ! -x $(SCENARIO_DIR)/provision.sh ]; then \
+	@if [ ! -f $(SCENARIO_DIR)/provision.sh ]; then \
 		echo "provision: $(SCENARIO_DIR)/provision.sh not found for SCENARIO=$(SCENARIO)"; exit 2; fi
 	bash $(SCENARIO_DIR)/provision.sh
 

--- a/examples/interop-clab/Makefile
+++ b/examples/interop-clab/Makefile
@@ -32,12 +32,7 @@ TOPO         := $(SCENARIO_DIR)/clab.yml
 VINBERO_IMAGE ?= vinbero-interop:latest
 FRR_IMAGE     ?= frr-interop:10.2.1
 
-# Arrcus ArcOS lives in the manual mup-2site-arcos scenario only. It runs as a
-# KVM VM (generic_vm / vrnetlab vr-ubuntu:noble), provisioned post-boot with the
-# vendor-licensed ArcOS bits under images/arcos/ (see `provision-arcos`).
-ARCOS_DIR     := $(LAB_DIR)/images/arcos
-
-.PHONY: all build build-vinbero build-frr provision-arcos deploy destroy reload test \
+.PHONY: all build build-vinbero build-frr provision deploy destroy reload test \
         logs status scenarios
 
 all: build deploy test destroy
@@ -62,18 +57,16 @@ build-frr:
 		-f $(LAB_DIR)/images/frr/Dockerfile \
 		$(LAB_DIR)/images/frr
 
-# Provision the ArcOS node inside its VM after `make deploy`. Applies to any
-# scenario that ships an `arcos/setup-arcos.sh` (the GW-role mup-2site-arcos
-# and the PE-role mup-2site-arcos-pe). The script pushes the images/arcos/
-# bits into the generic_vm and runs the Arrcus install (kernel + VPP + the
-# ArcOS NOS container). Prerequisite: the vr-ubuntu:noble base image must
-# already be built in your vrnetlab checkout (`make build-vr-ubuntu` there).
-# Not part of `build` -- it needs a running lab and the vendor-licensed
-# bits, so it never runs in CI.
-provision-arcos:
-	@if [ ! -f $(SCENARIO_DIR)/arcos/setup-arcos.sh ]; then \
-		echo "provision-arcos: $(SCENARIO_DIR)/arcos/setup-arcos.sh not found for SCENARIO=$(SCENARIO)"; exit 2; fi
-	bash $(SCENARIO_DIR)/arcos/setup-arcos.sh
+# Post-deploy provisioning hook for scenarios whose node needs out-of-band
+# setup after `make deploy` (for example a VM-based NOS that boots from a
+# generic image and is configured over SSH). A scenario opts in by shipping
+# an executable `provision.sh` at its root; scenarios without one skip this
+# step. Not part of `build` and never runs in CI -- it needs a running lab
+# and may pull in artifacts that are not part of this repo.
+provision:
+	@if [ ! -x $(SCENARIO_DIR)/provision.sh ]; then \
+		echo "provision: $(SCENARIO_DIR)/provision.sh not found for SCENARIO=$(SCENARIO)"; exit 2; fi
+	bash $(SCENARIO_DIR)/provision.sh
 
 # `vrf` is loaded on demand: GitHub Actions runners (and some minimal
 # hosts) ship CONFIG_NET_VRF=m unloaded, so `ip link add ... type vrf`


### PR DESCRIPTION
## What

The license-restricted interop lab (VM images, NOS configs, provisioning scripts, MUP scenarios) is moved into a separate private overlay repo and overlaid onto a checkout for local and CI runs. This keeps the public repo vendor-neutral and prevents those assets from being committed here.

## Changes

- **`.gitignore`** — guard the overlay landing paths so an accidental `git add -A` can't publish them.
- **`examples/interop-clab/Makefile`** — generalize the vendor-specific provision target into a neutral `provision` hook that runs a scenario's optional `provision.sh`; drop the now-unused vendor directory variable.
- **`README.md`** — state interop neutrally: FRR (L3VPN/EVPN) in CI.

## Notes

- Public CI never referenced the proprietary scenario, so nothing in CI changes. Makefile still parses; `make scenarios` lists only public scenarios.
- The private overlay carries a `provision.sh` per scenario, so `make provision SCENARIO=...` keeps working after the overlay is applied.
