### PR TITLE
chore(interop-clab): neutral overlay paths in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,11 +199,7 @@ sdk/examples/*/plugin.o
 # containerlab deploy artifacts (generated under each scenario by `clab deploy`)
 examples/interop-clab/scenarios/*/clab-*/
 
-# Private interop overlays. Proprietary, license-restricted vendor labs (VM
-# images, NOS configs, provisioning scripts) live in a separate private repo
-# and are rsync'd in for local runs only. They must never be committed to this
-# public repo; these guards keep an accidental `git add -A` from publishing them.
-/clab_arcos.sh
-/examples/interop-clab/images/arcos/
-/examples/interop-clab/scenarios/mup-2site-arcos/
-/examples/interop-clab/scenarios/mup-2site-arcos-pe/
+# Local-only interop overlays applied on top of this checkout (provisioned out
+# of band; not part of this repo). Kept untracked so they can't be committed.
+/examples/interop-clab/images/vendor/
+/examples/interop-clab/scenarios/vendor/


### PR DESCRIPTION
## What

Follow-up to #92. The local-only interop overlay now lands under a single neutral `vendor/` umbrella, so the `.gitignore` guards reference `images/vendor/` and `scenarios/vendor/` instead of naming a specific product or carrying a vendor/proprietary framing.

## Why

The previous guards enumerated product-specific paths (and a `vendor labs` comment) in a public file. Routing the overlay through a neutral umbrella keeps the public repo free of those names while the private overlay repo retains its descriptive layout.

## Notes

- No functional change. Public CI never referenced these paths.
- The private overlay applies under `scenarios/vendor/<name>/`; scenarios run as `make ... SCENARIO=vendor/<name>`.