### PR TITLE
feat(bgp/evpn): rescue early EVPN routes with an attach/bind-time loc-rib replay

### DIFF
--- a/cmd/vinberod/main.go
+++ b/cmd/vinberod/main.go
@@ -257,7 +257,26 @@ func run(cliCtx *cli.Context) error {
 		)
 		evpnES = evpnExporter
 	}
-	srv := server.NewServer(cfg, vin.GetMapOperations(), vin.GetResourceManager(), vin.GetFDBWatcher(), locatorMgr, vrfBgpMgr, advertiser, srPolicyAdvertiser, evpnAdvertiser, mupAdvertiser, applier, vrfExp, evpnCoord, evpnES, lg)
+	// evpnReplay rescues EVPN routes that arrived before their import surface
+	// (binding + bridge facet) existed: VrfBridgeAttach / commitBinding fire
+	// it after the surface widens, and the applier re-applies the loc-rib
+	// snapshot idempotently. Independent of evpn_auto_advertise -- a
+	// receive-only PE imports without advertising. Best-effort: before the
+	// session starts ListRoutes returns ErrSessionNotStarted (boot loads
+	// bindings and facets before the session, so there is nothing to rescue),
+	// and any later failure self-heals on the next peer event.
+	var evpnReplay func()
+	if bgpSession != nil {
+		evpnReplay = func() {
+			err := applier.ReplayEVPN(func(h bgp.RouteHandler) error {
+				return bgpSession.ListRoutes(bgp.FamilyEVPN, h)
+			})
+			if err != nil {
+				lg.Warn("EVPN loc-rib replay", zap.Error(err))
+			}
+		}
+	}
+	srv := server.NewServer(cfg, vin.GetMapOperations(), vin.GetResourceManager(), vin.GetFDBWatcher(), locatorMgr, vrfBgpMgr, advertiser, srPolicyAdvertiser, evpnAdvertiser, mupAdvertiser, applier, vrfExp, evpnCoord, evpnES, evpnReplay, lg)
 
 	// Seed the VRF objects with the kernel devices and bridges the resource
 	// manager reconciled from its state file (InitResourceManager ran before

--- a/docs/design/ja/srv6_bgp.md
+++ b/docs/design/ja/srv6_bgp.md
@@ -196,7 +196,7 @@ flowchart LR
 2. RT で取り込み先の VRF を決め、その VRF の bridge facet から bd を得る。経路の RT が binding の import RT に一致し、かつ binding の VRF に bridge facet が付いているときだけ取り込みます (facet の無い binding は fail-closed で match しません)。
 3. service SID へ向ける install にする。RT2 なら相手の End.DT2U SID を segment に持つ bd_peer を作り、`fdb_map[bd, MAC]` をその peer へ向けます。以後その MAC 宛ての L2 フレームは XDP headend が SID へ H.Encaps.L2 します。RT3 なら相手の End.DT2M SID への flood 用 bd_peer を作り、BUM をそこへ複製します。
 
-RT と VRF の対応は config か RPC で事前に登録し、bd はその VRF の bridge facet (vrf bridge-attach) が唯一の出所です。広報方向も同じ data model で、ローカルの顧客 MAC を End.DT2U SID 付きで RT2、flood 宛先を End.DT2M SID 付きで RT3 として出します。
+RT と VRF の対応は config か RPC で事前に登録し、bd はその VRF の bridge facet (vrf bridge-attach) が唯一の出所です。import 面がそろう前に届いて drop された route は、VrfBridgeAttach / vrf-bgp bind が面を広げた時点で gobgp loc-rib の snapshot から再適用されます (自 node が広告した route は local-origin として skip)。広報方向も同じ data model で、ローカルの顧客 MAC を End.DT2U SID 付きで RT2、flood 宛先を End.DT2M SID 付きで RT3 として出します。
 
 ```mermaid
 flowchart LR

--- a/docs/design/ja/vrf.md
+++ b/docs/design/ja/vrf.md
@@ -68,7 +68,7 @@ EVPN / L2VPN の bridge domain も VRF オブジェクトの facet です。End.
 
 - attach は `VrfService/VrfBridgeAttach` (CLI は `vbctl vrf bridge-attach --vrf X --name brN --bd-id N [--members ...]`)。netlink と JSON state への永続化は device facet と同じく `pkg/netresource` が `BridgeOps` interface 経由で担い、state record は owning VRF 名も持ちます。attach は FDBWatcher への登録 (MAC 学習と EVPN RT2 の供給源) も行います。
 - 一意性は attach 時に強制されます。1 つの VRF が持てる bridge は 1 つ、1 つの bridge device / 1 つの bd_id が属せる VRF も 1 つです。
-- facet が bridge domain の唯一の出所です。BGP binding は bd を持たず、受信した EVPN route (RT2/RT3) は RT が一致した binding の VRF が持つ facet の bd に install されます。facet の無い VRF の binding は EVPN route を import しません (fail-closed)。このため運用では bridge-attach を vrf-bgp bind より先に行います。binding が match 可能になった時点で bd が必ず解決でき、bind と attach の間に届いた route が落ちて再適用されない、という窓が生じません。
+- facet が bridge domain の唯一の出所です。BGP binding は bd を持たず、受信した EVPN route (RT2/RT3) は RT が一致した binding の VRF が持つ facet の bd に install されます。facet の無い VRF の binding は EVPN route を import しません (fail-closed)。import 面 (binding + facet) がそろっていない間に届いた route は drop されますが、attach または bind で面が広がった時点で gobgp loc-rib の snapshot を受信経路に再適用して救済します (install は冪等なので重複適用は無害)。bridge-attach を vrf-bgp bind より先に行う順序は引き続き推奨で、replay はその安全網です。
 - adopt のセマンティクスは device facet と同じです。link が本当に bridge であること、state 上の bd_id / owner と矛盾しないことを検証し、up + 不足 member の enslave で収束します。
 - detach (`vbctl vrf bridge-detach --vrf X`) は End.DT2/DT2M の SID が bridge を参照している間は拒否します (EVPN auto-advertise が自分で入れた lifecycle SID は除外)。device の削除に成功してから FDBWatcher を解除し、EVPN auto-advertise を disable し、最後に facet を消します。削除失敗時は facet も watcher も無傷で retry できます。
 

--- a/examples/interop-clab/scenarios/evpn-2site/pe-osaka/start.sh
+++ b/examples/interop-clab/scenarios/evpn-2site/pe-osaka/start.sh
@@ -48,8 +48,8 @@ for i in $(seq 1 30); do
 done
 
 # The bridge as evi-100's L2 facet, attached BEFORE the bind so a received
-# RT2/RT3 always finds its bridge domain (see pe-tokyo/start.sh for the
-# full rationale).
+# RT2/RT3 immediately finds its bridge domain (a route landing in a gap is
+# rescued by the loc-rib replay; see pe-tokyo/start.sh).
 /usr/local/bin/vbctl vrf bridge-attach \
     --vrf evi-100 \
     --name br100 \

--- a/examples/interop-clab/scenarios/evpn-2site/pe-tokyo/start.sh
+++ b/examples/interop-clab/scenarios/evpn-2site/pe-tokyo/start.sh
@@ -56,10 +56,11 @@ done
 # End.DT2U decaps a core-bound frame into br100, which forwards it to
 # ce-tokyo on eth2. The CE port is enslaved for that egress direction; XDP
 # still sees CE->core frames first (ingress). The facet is the bridge
-# domain's single source: it must attach BEFORE the vrf-bgp bind below, so
-# the moment the binding can match a received RT2/RT3 its bd is resolvable
-# (a route landing between bind and attach would be dropped fail-closed and
-# is not re-applied). Attaching also registers br100 with the FDB watcher.
+# domain's single source: attaching BEFORE the vrf-bgp bind below means the
+# moment the binding can match a received RT2/RT3 its bd is resolvable (a
+# route landing in a gap is rescued by the loc-rib replay the attach/bind
+# fires, so the order is a preference, not a correctness requirement).
+# Attaching also registers br100 with the FDB watcher.
 /usr/local/bin/vbctl vrf bridge-attach \
     --vrf evi-100 \
     --name br100 \

--- a/examples/interop-clab/scenarios/evpn-multihoming/pe1/start.sh
+++ b/examples/interop-clab/scenarios/evpn-multihoming/pe1/start.sh
@@ -59,8 +59,9 @@ done
 
 # bd 100 local delivery as evi-100's L2 facet: End.DT2/DT2M decap into br100
 # -> ce-mh on eth2 (enslaved via --members). The facet is the bridge domain's
-# single source and must attach BEFORE the vrf-bgp bind below, so the moment
-# the binding can match a received RT2/RT3/RT4 its bd is resolvable.
+# single source; attaching BEFORE the vrf-bgp bind below means a received
+# RT2/RT3/RT4 immediately finds its bd (a route landing in a gap is rescued
+# by the loc-rib replay the attach/bind fires).
 /usr/local/bin/vbctl vrf bridge-attach \
     --vrf evi-100 \
     --name br100 \

--- a/examples/interop-clab/scenarios/evpn-multihoming/pe2/start.sh
+++ b/examples/interop-clab/scenarios/evpn-multihoming/pe2/start.sh
@@ -52,10 +52,10 @@ for i in $(seq 1 30); do
 done
 
 # bd 100 local delivery as evi-100's L2 facet: End.DT2/DT2M decap into br100
-# -> the CE on eth2 (enslaved via --members). The facet is the bridge
-# domain's single source and must attach BEFORE the vrf-bgp bind below, so
-# the moment the binding can match a received RT2/RT3/RT4 its bd is
-# resolvable.
+# -> the CE on eth2 (enslaved via --members). The facet is the bridge domain's
+# single source; attaching BEFORE the vrf-bgp bind below means a received
+# RT2/RT3/RT4 immediately finds its bd (a route landing in a gap is rescued
+# by the loc-rib replay the attach/bind fires).
 /usr/local/bin/vbctl vrf bridge-attach \
     --vrf evi-100 \
     --name br100 \

--- a/examples/interop-clab/scenarios/evpn-multihoming/pe3/start.sh
+++ b/examples/interop-clab/scenarios/evpn-multihoming/pe3/start.sh
@@ -45,10 +45,10 @@ for i in $(seq 1 30); do
 done
 
 # bd 100 local delivery as evi-100's L2 facet: End.DT2/DT2M decap into br100
-# -> the CE on eth2 (enslaved via --members). The facet is the bridge
-# domain's single source and must attach BEFORE the vrf-bgp bind below, so
-# the moment the binding can match a received RT2/RT3/RT4 its bd is
-# resolvable.
+# -> the CE on eth2 (enslaved via --members). The facet is the bridge domain's
+# single source; attaching BEFORE the vrf-bgp bind below means a received
+# RT2/RT3/RT4 immediately finds its bd (a route landing in a gap is rescued
+# by the loc-rib replay the attach/bind fires).
 /usr/local/bin/vbctl vrf bridge-attach \
     --vrf evi-100 \
     --name br100 \

--- a/pkg/bgp/apply/applier.go
+++ b/pkg/bgp/apply/applier.go
@@ -99,7 +99,12 @@ type Applier struct {
 	// GoBGP RouteHandler goroutine, so it needs no extra locking; the
 	// srPolicyTable it drives is mutex-guarded for the concurrent CRUD path.
 	steeredRoutes map[bgp.RouteKey]policyKey
-	logger        *zap.Logger
+	// evpnMu serializes the EVPN receive state (evpnTable.peers/fdb/mcast)
+	// between the GoBGP RouteHandler goroutine (applyEVPN) and the RPC-driven
+	// ReplayEVPN (VrfBridgeAttach / commitBinding re-pull the loc-rib after
+	// the EVPN import surface widens). Same pattern as mupMu.
+	evpnMu sync.Mutex
+	logger *zap.Logger
 }
 
 // NewApplier wires an Applier. srcLocator names the locator whose prefix

--- a/pkg/bgp/apply/evpn.go
+++ b/pkg/bgp/apply/evpn.go
@@ -178,6 +178,13 @@ func isUsableSRv6SID(sid string) bool {
 }
 
 func (a *Applier) applyEVPN(r *bgp.EVPNRoute, withdraw bool) {
+	a.evpnMu.Lock()
+	defer a.evpnMu.Unlock()
+	a.applyEVPNLocked(r, withdraw)
+}
+
+// applyEVPNLocked dispatches one EVPN route. Caller holds evpnMu.
+func (a *Applier) applyEVPNLocked(r *bgp.EVPNRoute, withdraw bool) {
 	switch r.Type {
 	case bgp.EVPNRouteTypeMACIP:
 		a.applyEVPNMacIP(r, withdraw)
@@ -188,6 +195,42 @@ func (a *Applier) applyEVPN(r *bgp.EVPNRoute, withdraw bool) {
 	default:
 		// Unsupported route types (RT1 Ethernet A-D, RT5 IP Prefix) are ignored.
 	}
+}
+
+// ReplayEVPN re-applies the current EVPN loc-rib through the receive path.
+// VrfBridgeAttach / commitBinding call it after the EVPN import surface
+// widens (a bridge facet attached, an import RT added): a route that arrived
+// while no binding+facet could match it was dropped fail-closed and the
+// watch stream never re-delivers it, so the rib snapshot is the only way to
+// rescue it. snapshot is a closure over bgp.RouteLister.ListRoutes; every
+// install it triggers is idempotent, so replaying already-applied routes is
+// a no-op.
+//
+// evpnMu is held across the snapshot AND the re-applies, which makes any
+// interleaving with the live watch goroutine converge: a route withdrawn
+// before the snapshot is not in it, and a withdraw racing the replay blocks
+// on evpnMu and lands after, overwriting the re-install. Holding the mutex
+// across ListRoutes cannot deadlock: gobgp's watch delivery runs on a
+// dedicated goroutine fed by an unbounded queue, so the mgmt loop ListRoutes
+// waits on never blocks on our callback.
+func (a *Applier) ReplayEVPN(snapshot func(bgp.RouteHandler) error) error {
+	a.evpnMu.Lock()
+	defer a.evpnMu.Unlock()
+	n := 0
+	err := snapshot(func(ev bgp.RouteEvent) {
+		// Rib-resident paths always carry IsWithdraw=false; the guard keeps a
+		// misbehaving snapshot from turning the rescue into a teardown.
+		if ev.Family != bgp.FamilyEVPN || ev.EVPN == nil || ev.IsWithdraw {
+			return
+		}
+		a.applyEVPNLocked(ev.EVPN, false)
+		n++
+	})
+	if err != nil {
+		return fmt.Errorf("replay EVPN rib: %w", err)
+	}
+	a.logger.Debug("replayed EVPN loc-rib", zap.Int("routes", n))
+	return nil
 }
 
 func (a *Applier) applyEVPNMacIP(r *bgp.EVPNRoute, withdraw bool) {

--- a/pkg/bgp/apply/evpn.go
+++ b/pkg/bgp/apply/evpn.go
@@ -86,11 +86,13 @@ type evpnMcastState struct {
 	sid   string
 }
 
-// evpnTable holds the EVPN applier's in-memory bookkeeping. peers/fdb/mcast are
-// touched only from the single GoBGP RouteHandler goroutine (like steeredRoutes)
-// and need no locking. esMembers and DF election are the exception: the operator
-// path (es create -> ReelectDF) re-runs election from the RPC goroutine, so
-// esMu serializes esMembers access and electDF across the two goroutines.
+// evpnTable holds the EVPN applier's in-memory bookkeeping. peers/fdb/mcast
+// are touched from the GoBGP RouteHandler goroutine (applyEVPN) and from the
+// RPC-driven ReplayEVPN; both take Applier.evpnMu, and any new accessor must
+// too. esMembers and DF election have their own lock: the operator path
+// (es create -> ReelectDF) re-runs election from the RPC goroutine, so esMu
+// serializes esMembers access and electDF (esMu nests inside evpnMu on the
+// applyEVPN path and is taken alone by ReelectDF -- one direction only).
 type evpnTable struct {
 	peers map[evpnPeerKey]*evpnPeerState
 	fdb   map[evpnFdbKey]evpnFdbState
@@ -213,6 +215,10 @@ func (a *Applier) applyEVPNLocked(r *bgp.EVPNRoute, withdraw bool) {
 // across ListRoutes cannot deadlock: gobgp's watch delivery runs on a
 // dedicated goroutine fed by an unbounded queue, so the mgmt loop ListRoutes
 // waits on never blocks on our callback.
+//
+// The snapshot carries every known path per NLRI (best first), so where two
+// peers advertise the same NLRI with different attributes the last replayed
+// path wins -- the same last-write-wins the live stream has.
 func (a *Applier) ReplayEVPN(snapshot func(bgp.RouteHandler) error) error {
 	a.evpnMu.Lock()
 	defer a.evpnMu.Unlock()
@@ -318,8 +324,8 @@ func (a *Applier) applyEVPNMacIP(r *bgp.EVPNRoute, withdraw bool) {
 }
 
 // withdrawEVPNMac removes the FDB entry recorded for fk and releases its peer
-// reference, deleting the bd_peer when the last MAC stops referencing it. The
-// caller holds the only goroutine that touches evpnTable.
+// reference, deleting the bd_peer when the last MAC stops referencing it.
+// Caller holds evpnMu.
 func (a *Applier) withdrawEVPNMac(fk evpnFdbKey, st evpnFdbState) {
 	if err := a.fdbBd.DeleteFdb(st.bdID, st.mac); err != nil {
 		// The FDB entry is still in the map. Keep the reverse index so a

--- a/pkg/bgp/apply/evpn_test.go
+++ b/pkg/bgp/apply/evpn_test.go
@@ -571,3 +571,73 @@ func TestApplier_EVPNRT4ZeroLocalSkipsElection(t *testing.T) {
 			netip.AddrFrom16(fh.esis[testESI].DfPeSrcAddr))
 	}
 }
+
+// ReplayEVPN re-applies a rib snapshot through the normal EVPN receive
+// path: RT2/RT3 install, withdraw events and non-EVPN events are guarded
+// out, and replaying routes that are already installed stays idempotent.
+func TestApplier_ReplayEVPN(t *testing.T) {
+	a, fh := evpnApplier(t)
+	// One RT2 arrived live before the replay (the idempotency half).
+	a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN, EVPN: rt2("aa:bb:cc:00:00:01", "fd00:2:2:d2::")})
+
+	snapshot := func(h bgp.RouteHandler) error {
+		h(bgp.RouteEvent{Family: bgp.FamilyEVPN, EVPN: rt2("aa:bb:cc:00:00:01", "fd00:2:2:d2::")})
+		h(bgp.RouteEvent{Family: bgp.FamilyEVPN, EVPN: rt2("aa:bb:cc:00:00:02", "fd00:2:2:d2::")})
+		h(bgp.RouteEvent{Family: bgp.FamilyEVPN, EVPN: rt3("fd00:2:2:d3::")})
+		// Guarded out: a withdraw must not tear anything down, and a
+		// non-EVPN event must be ignored.
+		h(bgp.RouteEvent{Family: bgp.FamilyEVPN, IsWithdraw: true, EVPN: rt2("aa:bb:cc:00:00:01", "fd00:2:2:d2::")})
+		h(bgp.RouteEvent{Family: bgp.FamilyVPNv4})
+		return nil
+	}
+	if err := a.ReplayEVPN(snapshot); err != nil {
+		t.Fatalf("ReplayEVPN: %v", err)
+	}
+	if len(fh.fdb) != 2 {
+		t.Errorf("want 2 FDB entries after replay (live + rescued), got %d: %v", len(fh.fdb), fh.fdb)
+	}
+	// Peers: one unicast peer shared by both MACs plus the RT3 flood peer.
+	if len(fh.bdPeers) != 2 {
+		t.Errorf("want 2 bd_peers (shared unicast + flood), got %d: %v", len(fh.bdPeers), fh.bdPeers)
+	}
+	// The replayed duplicate of the live RT2 must not have inflated the
+	// refcount: one withdraw must free the MAC.
+	a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN, IsWithdraw: true, EVPN: rt2("aa:bb:cc:00:00:01", "fd00:2:2:d2::")})
+	if _, ok := fh.fdb[fdbKey{100, "aa:bb:cc:00:00:01"}]; ok {
+		t.Error("replay inflated the RT2 state: one withdraw did not free the MAC")
+	}
+}
+
+// ReplayEVPN surfaces a snapshot error without applying half a replay's
+// bookkeeping incorrectly (events delivered before the error still applied,
+// which is fine -- they are real rib routes).
+func TestApplier_ReplayEVPNSnapshotError(t *testing.T) {
+	a, _ := evpnApplier(t)
+	boom := errors.New("rib boom")
+	if err := a.ReplayEVPN(func(bgp.RouteHandler) error { return boom }); !errors.Is(err, boom) {
+		t.Fatalf("ReplayEVPN error = %v, want wrapped %v", err, boom)
+	}
+}
+
+// The live watch goroutine (Apply) and an RPC-driven replay may run
+// concurrently; evpnMu must serialize them. Run with -race.
+func TestApplier_ReplayEVPNConcurrentWithApply(t *testing.T) {
+	a, _ := evpnApplier(t)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 200; i++ {
+			a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN, EVPN: rt2("aa:bb:cc:00:00:01", "fd00:2:2:d2::")})
+			a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN, IsWithdraw: true, EVPN: rt2("aa:bb:cc:00:00:01", "fd00:2:2:d2::")})
+		}
+	}()
+	for i := 0; i < 200; i++ {
+		if err := a.ReplayEVPN(func(h bgp.RouteHandler) error {
+			h(bgp.RouteEvent{Family: bgp.FamilyEVPN, EVPN: rt2("aa:bb:cc:00:00:02", "fd00:3:3:d2::")})
+			return nil
+		}); err != nil {
+			t.Fatalf("ReplayEVPN: %v", err)
+		}
+	}
+	<-done
+}

--- a/pkg/bgp/bgp.go
+++ b/pkg/bgp/bgp.go
@@ -210,6 +210,17 @@ type RouteSubscriber interface {
 	Subscribe(filter Family, handler RouteHandler) (cancel func(), err error)
 }
 
+// RouteLister reads a snapshot of the current loc-rib for one family and
+// hands each peer-learned route to handler, synchronously on the calling
+// goroutine. Locally originated paths (this node's own advertisements) are
+// skipped -- unlike the live Subscribe stream, the rib holds them too, and
+// re-applying an own EVPN RT3 would install a self-pointing BUM peer.
+// Used to re-apply routes that were dropped fail-closed while their
+// import surface (binding / bridge facet) did not exist yet.
+type RouteLister interface {
+	ListRoutes(family Family, handler RouteHandler) error
+}
+
 // Origin identifies what signaled a candidate path (RFC 9256 §2.4
 // Protocol-Origin). The numeric values are the RFC's recommended
 // defaults; the best-path tie-break prefers the HIGHER value, so a

--- a/pkg/bgp/gobgp/evpn_e2e_test.go
+++ b/pkg/bgp/gobgp/evpn_e2e_test.go
@@ -362,3 +362,154 @@ func TestE2E_EVPNRT3ToBdPeer(t *testing.T) {
 		t.Errorf("no bd_peer carrying the End.DT2M SID %v", wantSID)
 	}
 }
+
+// Ports for the replay-rescue E2E (distinct so it can run alongside the others).
+const (
+	evpnRescuePE1ListenPort = 10193
+	evpnRescuePE2ListenPort = 10194
+)
+
+// TestE2E_EVPNReplayRescuesEarlyRoute pins the rescue composition the daemon
+// wires in main.go (Session.ListRoutes into Applier.ReplayEVPN): an RT2 that
+// arrives while the binding's VRF has no bridge facet is dropped fail-closed
+// and the watch stream never re-delivers it; once the facet exists, replaying
+// the loc-rib installs it into the real BPF maps without any re-advertise
+// from the peer. Requires root for the BPF collection load.
+func TestE2E_EVPNReplayRescuesEarlyRoute(t *testing.T) {
+	ctx := context.Background()
+
+	objs, err := bpf.ReadCollection(nil, nil)
+	if err != nil {
+		t.Fatalf("load BPF collection (needs root): %v", err)
+	}
+	t.Cleanup(func() { _ = objs.Close() })
+	mapOps := bpf.NewMapOperations(objs)
+
+	locMgr := locator.NewManager()
+	if err := locMgr.Add(&locator.Locator{
+		Name: "LOC1", Prefix: netip.MustParsePrefix("fd00:1:1::/48"),
+		BlockLen: 32, NodeLen: 16, FunctionLen: 16, ArgumentLen: 64,
+		Behavior: locator.BehaviorClassic, FunctionAutoStart: 0x10, FunctionAutoEnd: 0xFFFF,
+	}); err != nil {
+		t.Fatalf("locator Add: %v", err)
+	}
+
+	// Binding with the import RT but NO bridge facet: the import surface is
+	// incomplete, so the live route must be dropped.
+	vm := vrfbgp.NewManager()
+	if err := vm.Bind(vrfbgp.Binding{
+		VRFName: "evi-100", Families: map[bgp.Family]vrfbgp.FamilyPolicy{
+			bgp.FamilyEVPN: {RouteTargets: []vrfbgp.RouteTarget{{RT: evpnImportRT, Direction: vrfbgp.DirectionImport}}},
+		},
+	}); err != nil {
+		t.Fatalf("vrf bind: %v", err)
+	}
+	applier := apply.NewApplier(mapOps, locMgr, vm,
+		fib.NewKernelInjector(), "LOC1", 65002, zap.NewNop())
+
+	pe2 := gobgp.NewSession(zap.NewNop())
+	if err := pe2.Start(ctx, bgp.GlobalConfig{
+		LocalASN: 65002, RouterID: "10.0.0.2", ListenPort: evpnRescuePE2ListenPort,
+	}); err != nil {
+		t.Fatalf("PE2 Start: %v", err)
+	}
+	t.Cleanup(func() { _ = pe2.Stop(ctx) })
+	if err := pe2.AddPeer(ctx, bgp.PeerConfig{
+		Neighbor: "127.0.0.1", PeerASN: 65001,
+		HoldTimeSec: 90, KeepaliveSec: 30,
+		Families: []bgp.Family{bgp.FamilyEVPN},
+	}); err != nil {
+		t.Fatalf("PE2 AddPeer: %v", err)
+	}
+	cancelSub, err := pe2.Subscribe("", applier.Apply)
+	if err != nil {
+		t.Fatalf("PE2 Subscribe: %v", err)
+	}
+	t.Cleanup(cancelSub)
+
+	pe1 := gobgpsrv.NewBgpServer()
+	go pe1.Serve()
+	t.Cleanup(func() { pe1.Stop() })
+	if err := pe1.StartBgp(ctx, &gobgpapi.StartBgpRequest{
+		Global: &gobgpapi.Global{Asn: 65001, RouterId: "10.0.0.1", ListenPort: evpnRescuePE1ListenPort},
+	}); err != nil {
+		t.Fatalf("PE1 StartBgp: %v", err)
+	}
+	if err := pe1.AddPeer(ctx, &gobgpapi.AddPeerRequest{Peer: &gobgpapi.Peer{
+		Conf: &gobgpapi.PeerConf{NeighborAddress: "127.0.0.1", PeerAsn: 65002},
+		Transport: &gobgpapi.Transport{
+			RemoteAddress: "127.0.0.1", RemotePort: evpnRescuePE2ListenPort, LocalAddress: "127.0.0.1",
+		},
+		AfiSafis: []*gobgpapi.AfiSafi{{Config: &gobgpapi.AfiSafiConfig{
+			Family: &gobgpapi.Family{Afi: gobgpapi.Family_AFI_L2VPN, Safi: gobgpapi.Family_SAFI_EVPN},
+		}}},
+	}}); err != nil {
+		t.Fatalf("PE1 AddPeer: %v", err)
+	}
+
+	rd := gobgppkt.NewRouteDistinguisherTwoOctetAS(65000, 100)
+	hw, err := net.ParseMAC(evpnMAC)
+	if err != nil {
+		t.Fatalf("parse MAC: %v", err)
+	}
+	nlri := gobgppkt.NewEVPNNLRI(
+		gobgppkt.EVPN_ROUTE_TYPE_MAC_IP_ADVERTISEMENT,
+		&gobgppkt.EVPNMacIPAdvertisementRoute{
+			RD: rd, ETag: 0, MacAddressLength: 48, MacAddress: hw, Labels: []uint32{0},
+		},
+	)
+	infoSubTLV := gobgppkt.NewSRv6InformationSubTLV(netip.MustParseAddr(evpnDT2USID), gobgppkt.END_DT2U)
+	svcTLV := gobgppkt.NewSRv6ServiceTLV(gobgppkt.TLVTypeSRv6L2Service, infoSubTLV)
+	prefixSID := gobgppkt.NewPathAttributePrefixSID(svcTLV)
+	origin := gobgppkt.NewPathAttributeOrigin(0)
+	rt := gobgppkt.NewTwoOctetAsSpecificExtended(gobgppkt.EC_SUBTYPE_ROUTE_TARGET, 65000, 100, true)
+	extComm := gobgppkt.NewPathAttributeExtendedCommunities([]gobgppkt.ExtendedCommunityInterface{rt})
+	mpReach, err := gobgppkt.NewPathAttributeMpReachNLRI(
+		gobgppkt.RF_EVPN, []gobgppkt.PathNLRI{{NLRI: nlri}}, netip.MustParseAddr("2001:db8::1"))
+	if err != nil {
+		t.Fatalf("build MP_REACH_NLRI: %v", err)
+	}
+	if _, err := pe1.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{{
+		Family: gobgppkt.RF_EVPN,
+		Nlri:   nlri,
+		Attrs:  []gobgppkt.PathAttributeInterface{origin, extComm, prefixSID, mpReach},
+	}}}); err != nil {
+		t.Fatalf("PE1 AddPath: %v", err)
+	}
+
+	// Deterministic drop proof: once the RT2 is visible in PE2's loc-rib the
+	// live watch has already delivered (and dropped) it, yet the fdb_map must
+	// still be empty because no facet supplies a bd.
+	waitFor(t, "RT2 visible in PE2's loc-rib", 30*time.Second, func() bool {
+		seen := false
+		if err := pe2.ListRoutes(bgp.FamilyEVPN, func(ev bgp.RouteEvent) {
+			if ev.EVPN != nil && ev.EVPN.Type == bgp.EVPNRouteTypeMACIP && ev.EVPN.MAC == evpnMAC {
+				seen = true
+			}
+		}); err != nil {
+			return false
+		}
+		return seen
+	})
+	if _, err := mapOps.GetFdb(evpnBDID, hw); err == nil {
+		t.Fatal("RT2 installed without a bridge facet: the fail-closed drop is broken")
+	}
+
+	// The facet arrives (what VrfBridgeAttach commits), then the rescue runs
+	// exactly as main.go wires it. No re-advertise from PE1.
+	if _, err := vm.VRF().SetBridge("evi-100", vrf.Bridge{Name: "br100", BdID: evpnBDID, Ifindex: 5}); err != nil {
+		t.Fatalf("SetBridge: %v", err)
+	}
+	if err := applier.ReplayEVPN(func(h bgp.RouteHandler) error {
+		return pe2.ListRoutes(bgp.FamilyEVPN, h)
+	}); err != nil {
+		t.Fatalf("ReplayEVPN: %v", err)
+	}
+	fdb, err := mapOps.GetFdb(evpnBDID, hw)
+	if err != nil {
+		t.Fatalf("rescued RT2 not in fdb_map after the replay: %v", err)
+	}
+	if fdb.IsRemote != 1 || fdb.BdId != evpnBDID {
+		t.Errorf("rescued fdb entry = %+v, want IsRemote=1 BdId=%d", fdb, evpnBDID)
+	}
+}

--- a/pkg/bgp/gobgp/lister.go
+++ b/pkg/bgp/gobgp/lister.go
@@ -1,0 +1,49 @@
+package gobgp
+
+import (
+	"fmt"
+
+	gobgpapi "github.com/osrg/gobgp/v4/api"
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
+	gobgppkt "github.com/osrg/gobgp/v4/pkg/packet/bgp"
+
+	"github.com/takehaya/vinbero/pkg/bgp"
+)
+
+// compile-time assertion that *Session also satisfies RouteLister.
+var _ bgp.RouteLister = (*Session)(nil)
+
+// ListRoutes snapshots the loc-rib for family and hands each peer-learned
+// route to handler on the calling goroutine. Unlike the Subscribe stream
+// (post-policy peer updates only), the rib also holds this node's own
+// advertisements, so locally originated paths are skipped here -- gobgp
+// marks them with an invalid source address, which toPathApiUtil copies
+// into Path.PeerAddress. Re-applying an own EVPN RT3 would otherwise
+// install a self-pointing BUM peer. The decode is the same pathToRouteEvent
+// the live watch uses (ListPath builds paths with the same converter), and
+// rib-resident paths always carry Withdrawal=false.
+func (s *Session) ListRoutes(family bgp.Family, handler bgp.RouteHandler) error {
+	srv := s.bgpServer()
+	if srv == nil {
+		return bgp.ErrSessionNotStarted
+	}
+	rf, err := vinberoFamilyToAPI(family)
+	if err != nil {
+		return fmt.Errorf("list routes: %w", err)
+	}
+	return srv.ListPath(apiutil.ListPathRequest{
+		TableType: gobgpapi.TableType_TABLE_TYPE_GLOBAL,
+		Family:    rf,
+	}, func(_ gobgppkt.NLRI, paths []*apiutil.Path) {
+		for _, p := range paths {
+			if !p.PeerAddress.IsValid() {
+				continue // locally originated (this node's own advertisement)
+			}
+			ev, ok := pathToRouteEvent(p)
+			if !ok || ev.Family != family {
+				continue
+			}
+			handler(ev)
+		}
+	})
+}

--- a/pkg/bgp/gobgp/lister_test.go
+++ b/pkg/bgp/gobgp/lister_test.go
@@ -1,0 +1,163 @@
+package gobgp_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	gobgpapi "github.com/osrg/gobgp/v4/api"
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
+	gobgppkt "github.com/osrg/gobgp/v4/pkg/packet/bgp"
+	gobgpsrv "github.com/osrg/gobgp/v4/pkg/server"
+	"go.uber.org/zap"
+
+	"github.com/takehaya/vinbero/pkg/bgp"
+	"github.com/takehaya/vinbero/pkg/bgp/gobgp"
+)
+
+const (
+	listerPE1ListenPort = 10191 // remote PE (RT2 source, plain gobgp)
+	listerPE2ListenPort = 10192 // Vinbero PE (the ListRoutes side)
+)
+
+// ListRoutes returns peer-learned routes from the loc-rib snapshot, skips
+// this node's own advertisements (which the rib holds but the live watch
+// stream never delivers), and reports ErrSessionNotStarted before Start.
+// No BPF / applier involved -- this pins the lister surface alone.
+func TestListRoutes_PeerLearnedOnlyAndLocalOriginSkipped(t *testing.T) {
+	ctx := context.Background()
+
+	fresh := gobgp.NewSession(zap.NewNop())
+	if err := fresh.ListRoutes(bgp.FamilyEVPN, func(bgp.RouteEvent) {}); !errors.Is(err, bgp.ErrSessionNotStarted) {
+		t.Fatalf("ListRoutes before Start: err = %v, want ErrSessionNotStarted", err)
+	}
+
+	// PE2: the Vinbero session under test.
+	pe2 := gobgp.NewSession(zap.NewNop())
+	if err := pe2.Start(ctx, bgp.GlobalConfig{
+		LocalASN: 65002, RouterID: "10.0.0.2", ListenPort: listerPE2ListenPort,
+	}); err != nil {
+		t.Fatalf("PE2 Start: %v", err)
+	}
+	t.Cleanup(func() { _ = pe2.Stop(ctx) })
+	if err := pe2.AddPeer(ctx, bgp.PeerConfig{
+		Neighbor: "127.0.0.1", PeerASN: 65001,
+		HoldTimeSec: 90, KeepaliveSec: 30,
+		Families: []bgp.Family{bgp.FamilyEVPN},
+	}); err != nil {
+		t.Fatalf("PE2 AddPeer: %v", err)
+	}
+
+	// PE2 advertises its own RT3 (the EVPN exporter's shape): this lands in
+	// PE2's loc-rib as a locally originated path and must NOT come back out
+	// of ListRoutes.
+	if err := pe2.PushEVPNInclusiveMulticast(ctx, bgp.EVPNRoute{
+		Type:    bgp.EVPNRouteTypeInclusiveMulticast,
+		RD:      "65002:100",
+		RTs:     []string{"65000:100"},
+		SRv6SID: "fd00:2:2:d2ff::",
+		NextHop: "2001:db8::2",
+	}); err != nil {
+		t.Fatalf("PE2 PushEVPNInclusiveMulticast: %v", err)
+	}
+
+	// PE1: plain gobgp, advertises the peer-learned RT2.
+	pe1 := gobgpsrv.NewBgpServer()
+	go pe1.Serve()
+	t.Cleanup(func() { pe1.Stop() })
+	if err := pe1.StartBgp(ctx, &gobgpapi.StartBgpRequest{
+		Global: &gobgpapi.Global{Asn: 65001, RouterId: "10.0.0.1", ListenPort: listerPE1ListenPort},
+	}); err != nil {
+		t.Fatalf("PE1 StartBgp: %v", err)
+	}
+	if err := pe1.AddPeer(ctx, &gobgpapi.AddPeerRequest{Peer: &gobgpapi.Peer{
+		Conf: &gobgpapi.PeerConf{NeighborAddress: "127.0.0.1", PeerAsn: 65002},
+		Transport: &gobgpapi.Transport{
+			RemoteAddress: "127.0.0.1", RemotePort: listerPE2ListenPort, LocalAddress: "127.0.0.1",
+		},
+		AfiSafis: []*gobgpapi.AfiSafi{{Config: &gobgpapi.AfiSafiConfig{
+			Family: &gobgpapi.Family{Afi: gobgpapi.Family_AFI_L2VPN, Safi: gobgpapi.Family_SAFI_EVPN},
+		}}},
+	}}); err != nil {
+		t.Fatalf("PE1 AddPeer: %v", err)
+	}
+
+	const mac = "aa:bb:cc:00:00:42"
+	hw, err := net.ParseMAC(mac)
+	if err != nil {
+		t.Fatalf("parse MAC: %v", err)
+	}
+	rd := gobgppkt.NewRouteDistinguisherTwoOctetAS(65000, 100)
+	nlri := gobgppkt.NewEVPNNLRI(
+		gobgppkt.EVPN_ROUTE_TYPE_MAC_IP_ADVERTISEMENT,
+		&gobgppkt.EVPNMacIPAdvertisementRoute{
+			RD:               rd,
+			ETag:             0,
+			MacAddressLength: 48,
+			MacAddress:       hw,
+			Labels:           []uint32{0},
+		},
+	)
+	infoSubTLV := gobgppkt.NewSRv6InformationSubTLV(netip.MustParseAddr("fd00:1:1:d2::"), gobgppkt.END_DT2U)
+	svcTLV := gobgppkt.NewSRv6ServiceTLV(gobgppkt.TLVTypeSRv6L2Service, infoSubTLV)
+	prefixSID := gobgppkt.NewPathAttributePrefixSID(svcTLV)
+	origin := gobgppkt.NewPathAttributeOrigin(0)
+	rt := gobgppkt.NewTwoOctetAsSpecificExtended(gobgppkt.EC_SUBTYPE_ROUTE_TARGET, 65000, 100, true)
+	extComm := gobgppkt.NewPathAttributeExtendedCommunities([]gobgppkt.ExtendedCommunityInterface{rt})
+	mpReach, err := gobgppkt.NewPathAttributeMpReachNLRI(
+		gobgppkt.RF_EVPN, []gobgppkt.PathNLRI{{NLRI: nlri}}, netip.MustParseAddr("2001:db8::1"))
+	if err != nil {
+		t.Fatalf("build MP_REACH_NLRI: %v", err)
+	}
+	if _, err := pe1.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{{
+		Family: gobgppkt.RF_EVPN,
+		Nlri:   nlri,
+		Attrs:  []gobgppkt.PathAttributeInterface{origin, extComm, prefixSID, mpReach},
+	}}}); err != nil {
+		t.Fatalf("PE1 AddPath: %v", err)
+	}
+
+	// The RT2 must appear in the snapshot once the session converges; the
+	// own RT3 must never appear no matter how often we list.
+	list := func() (rt2s, rt3s int) {
+		t.Helper()
+		if err := pe2.ListRoutes(bgp.FamilyEVPN, func(ev bgp.RouteEvent) {
+			if ev.Family != bgp.FamilyEVPN || ev.EVPN == nil {
+				t.Errorf("non-EVPN event from an EVPN list: %+v", ev)
+				return
+			}
+			if ev.IsWithdraw {
+				t.Errorf("rib-resident path delivered as withdraw: %+v", ev.EVPN)
+			}
+			switch ev.EVPN.Type {
+			case bgp.EVPNRouteTypeMACIP:
+				if ev.EVPN.MAC == mac {
+					rt2s++
+				}
+			case bgp.EVPNRouteTypeInclusiveMulticast:
+				rt3s++
+			}
+		}); err != nil {
+			t.Fatalf("ListRoutes: %v", err)
+		}
+		return rt2s, rt3s
+	}
+	waitFor(t, "peer RT2 visible in the loc-rib snapshot", 30*time.Second, func() bool {
+		rt2s, _ := list()
+		return rt2s == 1
+	})
+	if _, rt3s := list(); rt3s != 0 {
+		t.Errorf("own RT3 leaked out of ListRoutes (local-origin filter broken): %d", rt3s)
+	}
+
+	// Family filter: a vpnv4 snapshot of this rib is empty (nothing was
+	// advertised under vpnv4), and never yields EVPN events.
+	if err := pe2.ListRoutes(bgp.FamilyVPNv4, func(ev bgp.RouteEvent) {
+		t.Errorf("vpnv4 list yielded an event: %+v", ev)
+	}); err != nil {
+		t.Fatalf("ListRoutes(vpnv4): %v", err)
+	}
+}

--- a/pkg/bgp/gobgp/subscriber.go
+++ b/pkg/bgp/gobgp/subscriber.go
@@ -55,6 +55,8 @@ func (s *Session) Subscribe(filter bgp.Family, handler bgp.RouteHandler) (func()
 	// applier. A node that both advertises and steers would then act on its
 	// own SR Policy / VPN routes. Preserve the single-boot-subscribe ordering,
 	// or filter local-origin paths here, before relaxing this.
+	// (ListRoutes, the on-demand rib snapshot, does NOT depend on this
+	// ordering: it filters local-origin paths explicitly.)
 	if err := srv.WatchEvent(ctx, cbs, gobgpsrv.WatchPostUpdate(true, "", "")); err != nil {
 		cancel()
 		return nil, fmt.Errorf("watch event: %w", err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -40,6 +40,7 @@ type Server struct {
 	evpnES       EvpnEsHook                 // EVPN RT4 auto-advertise ES hook; nil when off
 	esReElectDF  func(esi [bpf.ESILen]byte) // applier DF re-election; nil when BGP is off
 	mupSrc       MupBindingReconciler       // MUP binding-state reconcile hook; nil when BGP is off
+	evpnReplay   func()                     // EVPN loc-rib replay (import-surface widened); nil when BGP is off
 	logger       *zap.Logger
 	mux          *http.ServeMux
 	server       *http.Server
@@ -55,7 +56,7 @@ type Server struct {
 // enabled, or nil otherwise. Taking the concrete type (not the interface)
 // keeps a typed-nil from leaking into srPolicyCtrl, so the FailedPrecondition
 // guard in SrPolicyServer works.
-func NewServer(cfg *config.Config, mapOps *bpf.MapOperations, resMgr *netresource.ResourceManager, fdbWatcher *netlinkwatch.FDBWatcher, locatorMgr *locator.Manager, vrfBgpMgr *vrfbgp.Manager, advertiser bgp.RouteAdvertiser, srPolicyAdv bgp.SRPolicyController, evpnAdv bgp.EVPNController, mupAdv bgp.MUPController, srPolicyApplier *apply.Applier, vrfExporter VrfExporter, evpnCoord *EvpnCoordinator, evpnES EvpnEsHook, logger *zap.Logger) *Server {
+func NewServer(cfg *config.Config, mapOps *bpf.MapOperations, resMgr *netresource.ResourceManager, fdbWatcher *netlinkwatch.FDBWatcher, locatorMgr *locator.Manager, vrfBgpMgr *vrfbgp.Manager, advertiser bgp.RouteAdvertiser, srPolicyAdv bgp.SRPolicyController, evpnAdv bgp.EVPNController, mupAdv bgp.MUPController, srPolicyApplier *apply.Applier, vrfExporter VrfExporter, evpnCoord *EvpnCoordinator, evpnES EvpnEsHook, evpnReplay func(), logger *zap.Logger) *Server {
 	s := &Server{
 		cfg:         cfg,
 		mapOps:      mapOps,
@@ -70,6 +71,7 @@ func NewServer(cfg *config.Config, mapOps *bpf.MapOperations, resMgr *netresourc
 		vrfExporter: vrfExporter,
 		evpnCoord:   evpnCoord,
 		evpnES:      evpnES,
+		evpnReplay:  evpnReplay,
 		logger:      logger,
 		mux:         http.NewServeMux(),
 	}
@@ -116,7 +118,7 @@ func (s *Server) Setup() {
 	// One mutation mutex shared by VrfBgpService and VrfService: their
 	// facet<->binding cross-checks are check-then-act across two managers.
 	vrfMu := &sync.Mutex{}
-	vrfBgpServer := NewVrfBgpServer(s.vrfBgpMgr, s.vrfExporter, s.evpnCoord, s.mupSrc, vrfMu)
+	vrfBgpServer := NewVrfBgpServer(s.vrfBgpMgr, s.vrfExporter, s.evpnCoord, s.mupSrc, s.evpnReplay, vrfMu)
 	vrfBgpPath, vrfBgpHandler := vinberov1connect.NewVrfBgpServiceHandler(vrfBgpServer)
 	s.mux.Handle(vrfBgpPath, vrfBgpHandler)
 	s.logger.Info("Registered VrfBgpService", zap.String("path", vrfBgpPath))
@@ -209,7 +211,7 @@ func (s *Server) Setup() {
 	// the ingress maps from mapOps, the binding lookups from the vrf-bgp
 	// manager, and the bridge attach lifecycle drives the FDB watcher and (when
 	// auto-advertise is on) the EVPN coordinator.
-	vrfServer := NewVrfServer(s.vrfBgpMgr.VRF(), s.mapOps, s.resMgr, s.mapOps, s.vrfBgpMgr, s.resMgr, s.fdbWatcher, s.evpnCoord, vrfMu)
+	vrfServer := NewVrfServer(s.vrfBgpMgr.VRF(), s.mapOps, s.resMgr, s.mapOps, s.vrfBgpMgr, s.resMgr, s.fdbWatcher, s.evpnCoord, s.evpnReplay, vrfMu)
 	path, handler = vinberov1connect.NewVrfServiceHandler(vrfServer)
 	s.mux.Handle(path, handler)
 	s.logger.Info("Registered VrfService", zap.String("path", path))

--- a/pkg/server/vrf.go
+++ b/pkg/server/vrf.go
@@ -57,6 +57,12 @@ type VrfServer struct {
 	bridges  vrf.BridgeOps
 	fdb      FdbRegistrar
 	evpn     *EvpnCoordinator // nil unless EVPN auto-advertise is on
+	// evpnReplay re-applies the EVPN loc-rib through the applier; nil when
+	// BGP is off. VrfBridgeAttach fires it when the VRF's binding imports
+	// EVPN RTs: the just-attached facet completes the import surface, so
+	// routes dropped fail-closed before the attach are rescued. Failures
+	// are logged inside the hook (best-effort).
+	evpnReplay func()
 	// mu serializes the mutation handlers' mutate+reconcile(+rollback)
 	// sequence and the device / bridge create+delete flows. SetIngressVrf /
 	// SetIngressPolicy replace the maps with a snapshot-then-rollback strategy
@@ -77,11 +83,11 @@ type VrfServer struct {
 // NewVrfServer wires the handler. mu is the mutation mutex, shared with
 // VrfBgpServer so cross-facet invariants hold (see the field comment); nil
 // allocates a private one (tests without a VrfBgpServer).
-func NewVrfServer(mgr *vrf.Manager, prog vrf.Programmer, dev vrf.DeviceOps, sids SidLister, bindings BindingGetter, bridges vrf.BridgeOps, fdb FdbRegistrar, evpn *EvpnCoordinator, mu *sync.Mutex) *VrfServer {
+func NewVrfServer(mgr *vrf.Manager, prog vrf.Programmer, dev vrf.DeviceOps, sids SidLister, bindings BindingGetter, bridges vrf.BridgeOps, fdb FdbRegistrar, evpn *EvpnCoordinator, evpnReplay func(), mu *sync.Mutex) *VrfServer {
 	if mu == nil {
 		mu = &sync.Mutex{}
 	}
-	return &VrfServer{mgr: mgr, prog: prog, resolve: vrf.ResolveByName, dev: dev, sids: sids, bindings: bindings, bridges: bridges, fdb: fdb, evpn: evpn, mu: mu}
+	return &VrfServer{mgr: mgr, prog: prog, resolve: vrf.ResolveByName, dev: dev, sids: sids, bindings: bindings, bridges: bridges, fdb: fdb, evpn: evpn, evpnReplay: evpnReplay, mu: mu}
 }
 
 func (s *VrfServer) reconcile() error {
@@ -336,6 +342,16 @@ func (s *VrfServer) VrfBridgeAttach(
 	if s.evpn != nil {
 		if b, bound := s.bindings.Get(vrfName); bound && len(b.ExportRTsForFamily(bgp.FamilyEVPN)) > 0 {
 			s.evpn.Enable(b)
+		}
+	}
+	// Receive side: the attach completed the import surface (binding with
+	// EVPN import RTs + facet), so replay the loc-rib to rescue routes that
+	// were dropped fail-closed while the facet was missing. The import-RT
+	// gate is deliberately separate from the export-RT gate above: a
+	// receive-only PE imports without advertising.
+	if s.evpnReplay != nil {
+		if b, bound := s.bindings.Get(vrfName); bound && len(importRTsForFamily(b, bgp.FamilyEVPN)) > 0 {
+			s.evpnReplay()
 		}
 	}
 	return connect.NewResponse(&v1.VrfBridgeAttachResponse{Vrf: vrfToProto(attached)}), nil

--- a/pkg/server/vrf_bgp.go
+++ b/pkg/server/vrf_bgp.go
@@ -44,6 +44,13 @@ type VrfBgpServer struct {
 	exporter VrfExporter          // L3VPN auto-advertise hook; nil when off
 	evpn     *EvpnCoordinator     // EVPN BD lifecycle (binding axis); nil when off
 	mupSrc   MupBindingReconciler // MUP binding-state reconcile hook; nil when BGP off
+	// evpnReplay re-applies the EVPN loc-rib through the applier
+	// (apply.Applier.ReplayEVPN over bgp.RouteLister); nil when BGP is off.
+	// commitBinding fires it when a binding's EVPN import surface widens, so
+	// routes dropped fail-closed before the binding could match are rescued.
+	// Failures are logged inside the hook (best-effort: the next peer event
+	// re-delivers anyway).
+	evpnReplay func()
 	// mu serializes a bind/unbind's manager + exporter mutations per call so two
 	// concurrent same-VRF RPCs cannot interleave (the manager Bind/Unbind and the
 	// exporter AddVRF/RemoveVRF are separate registries; the exporter's own opMu
@@ -59,11 +66,11 @@ type VrfBgpServer struct {
 
 // NewVrfBgpServer wires the handler. mu is the mutation mutex, shared with
 // VrfServer; nil allocates a private one (tests without a VrfServer).
-func NewVrfBgpServer(mgr *vrfbgp.Manager, exporter VrfExporter, evpn *EvpnCoordinator, mupSrc MupBindingReconciler, mu *sync.Mutex) *VrfBgpServer {
+func NewVrfBgpServer(mgr *vrfbgp.Manager, exporter VrfExporter, evpn *EvpnCoordinator, mupSrc MupBindingReconciler, evpnReplay func(), mu *sync.Mutex) *VrfBgpServer {
 	if mu == nil {
 		mu = &sync.Mutex{}
 	}
-	return &VrfBgpServer{mgr: mgr, exporter: exporter, evpn: evpn, mupSrc: mupSrc, mu: mu}
+	return &VrfBgpServer{mgr: mgr, exporter: exporter, evpn: evpn, mupSrc: mupSrc, evpnReplay: evpnReplay, mu: mu}
 }
 
 // protoToBinding converts a wire VrfBgpBinding into the runtime Binding.
@@ -220,6 +227,21 @@ func (s *VrfBgpServer) commitBinding(updated vrfbgp.Binding) error {
 			s.evpn.Enable(updated)
 		}
 	}
+	// Replay the EVPN loc-rib when this mutation widened the binding's
+	// import surface (a new binding with import RTs, or import RTs added):
+	// routes that arrived while nothing matched them were dropped fail-closed
+	// and the watch stream never re-delivers them. Gated on the bridge facet
+	// -- without it the replayed routes would just drop again -- and on the
+	// import direction, which is independent of the coordinator's export-RT
+	// gate above (a receive-only PE imports without advertising).
+	if s.evpnReplay != nil {
+		imp := importRTsForFamily(updated, bgp.FamilyEVPN)
+		if len(imp) > 0 && (!existed || !slices.Equal(importRTsForFamily(prev, bgp.FamilyEVPN), imp)) {
+			if v, ok := s.mgr.VRF().Get(updated.VRFName); ok && v.Bridge != nil {
+				s.evpnReplay()
+			}
+		}
+	}
 	if s.mupSrc != nil && mupGTP4SrcFieldsChanged(existed, prev, updated) {
 		// The manager already holds the updated binding, so the reconcile
 		// resolves the new prefix; this hook fires only on the success path
@@ -239,9 +261,9 @@ func (s *VrfBgpServer) commitBinding(updated vrfbgp.Binding) error {
 	return nil
 }
 
-// mupImportRTs returns the import-direction route targets a binding declares
-// under fam, sorted so two declarations compare structurally.
-func mupImportRTs(b vrfbgp.Binding, fam bgp.Family) []string {
+// importRTsForFamily returns the import-direction route targets a binding
+// declares under fam, sorted so two declarations compare structurally.
+func importRTsForFamily(b vrfbgp.Binding, fam bgp.Family) []string {
 	fp, has := b.Families[fam]
 	if !has {
 		return nil
@@ -266,7 +288,7 @@ func mupImportRTs(b vrfbgp.Binding, fam bgp.Family) []string {
 // considered here — VrfService drives that reconcile separately.)
 func mupUplinkFieldsChanged(prev, updated vrfbgp.Binding) bool {
 	for _, fam := range []bgp.Family{bgp.FamilyMUPIPv4, bgp.FamilyMUPIPv6} {
-		if !slices.Equal(mupImportRTs(prev, fam), mupImportRTs(updated, fam)) {
+		if !slices.Equal(importRTsForFamily(prev, fam), importRTsForFamily(updated, fam)) {
 			return true
 		}
 	}
@@ -416,7 +438,7 @@ func (s *VrfBgpServer) VrfBgpUnbind(
 				s.mupSrc.ReconcileMUPGTP4SrcForRD(prev.RD)
 			}
 			if s.mupSrc != nil && existed &&
-				(len(mupImportRTs(prev, bgp.FamilyMUPIPv4)) > 0 || len(mupImportRTs(prev, bgp.FamilyMUPIPv6)) > 0) {
+				(len(importRTsForFamily(prev, bgp.FamilyMUPIPv4)) > 0 || len(importRTsForFamily(prev, bgp.FamilyMUPIPv6)) > 0) {
 				// The removed binding imported MUP RTs, so a T2ST it matched may
 				// now match a different binding (different VRF) or none (global
 				// VRF). Re-key the affected sessions. The VRF objects and the

--- a/pkg/server/vrf_bgp.go
+++ b/pkg/server/vrf_bgp.go
@@ -228,18 +228,17 @@ func (s *VrfBgpServer) commitBinding(updated vrfbgp.Binding) error {
 		}
 	}
 	// Replay the EVPN loc-rib when this mutation widened the binding's
-	// import surface (a new binding with import RTs, or import RTs added):
+	// import surface (a new binding with import RTs, or an import RT added):
 	// routes that arrived while nothing matched them were dropped fail-closed
-	// and the watch stream never re-delivers them. Gated on the bridge facet
-	// -- without it the replayed routes would just drop again -- and on the
+	// and the watch stream never re-delivers them. Strictly widen-only -- an
+	// import RT removed rescues nothing and would only rescan the rib into
+	// per-route "matches no binding" warns. Gated on the bridge facet
+	// (without it the replayed routes would just drop again) and on the
 	// import direction, which is independent of the coordinator's export-RT
 	// gate above (a receive-only PE imports without advertising).
-	if s.evpnReplay != nil {
-		imp := importRTsForFamily(updated, bgp.FamilyEVPN)
-		if len(imp) > 0 && (!existed || !slices.Equal(importRTsForFamily(prev, bgp.FamilyEVPN), imp)) {
-			if v, ok := s.mgr.VRF().Get(updated.VRFName); ok && v.Bridge != nil {
-				s.evpnReplay()
-			}
+	if s.evpnReplay != nil && hasNewImportRT(prev, updated, bgp.FamilyEVPN) {
+		if v, ok := s.mgr.VRF().Get(updated.VRFName); ok && v.Bridge != nil {
+			s.evpnReplay()
 		}
 	}
 	if s.mupSrc != nil && mupGTP4SrcFieldsChanged(existed, prev, updated) {
@@ -259,6 +258,24 @@ func (s *VrfBgpServer) commitBinding(updated vrfbgp.Binding) error {
 		s.mupSrc.ReconcileMUPUplinkInstances()
 	}
 	return nil
+}
+
+// hasNewImportRT reports whether updated declares an import-direction RT
+// under fam that prev did not: the import surface widened, so previously
+// unmatched routes may now match. A removed RT does not count -- shrinking
+// rescues nothing. A brand-new binding (prev is the zero Binding) counts
+// whenever updated imports anything.
+func hasNewImportRT(prev, updated vrfbgp.Binding, fam bgp.Family) bool {
+	had := make(map[string]struct{})
+	for _, rt := range importRTsForFamily(prev, fam) {
+		had[rt] = struct{}{}
+	}
+	for _, rt := range importRTsForFamily(updated, fam) {
+		if _, ok := had[rt]; !ok {
+			return true
+		}
+	}
+	return false
 }
 
 // importRTsForFamily returns the import-direction route targets a binding

--- a/pkg/server/vrf_bgp_test.go
+++ b/pkg/server/vrf_bgp_test.go
@@ -114,7 +114,7 @@ func (f *fakeVrfExporter) RemoveVRF(name string) {
 // A successful bind drives the exporter's AddVRF, and an unbind its RemoveVRF.
 func TestVrfBgpBind_DrivesExporter(t *testing.T) {
 	exp := &fakeVrfExporter{}
-	s := NewVrfBgpServer(vrfbgp.NewManager(), exp, nil, nil, nil)
+	s := NewVrfBgpServer(vrfbgp.NewManager(), exp, nil, nil, nil, nil)
 	resp, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
 		Bindings: []*v1.VrfBgpBinding{
 			{VrfName: "vrf1", Rd: "65100:200", ExportRts: []string{"65000:200"}, DefaultLocator: "LOC1", Redistribute: []string{"static"}},
@@ -141,7 +141,7 @@ func TestVrfBgpBind_DrivesExporter(t *testing.T) {
 // registry and the exporter stay consistent.
 func TestVrfBgpBind_AddVRFFailureRollsBack(t *testing.T) {
 	mgr := vrfbgp.NewManager()
-	s := NewVrfBgpServer(mgr, &fakeVrfExporter{addErr: errors.New("boom")}, nil, nil, nil)
+	s := NewVrfBgpServer(mgr, &fakeVrfExporter{addErr: errors.New("boom")}, nil, nil, nil, nil)
 	resp, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
 		Bindings: []*v1.VrfBgpBinding{
 			{VrfName: "vrf1", Rd: "65100:200", DefaultLocator: "LOC1", Redistribute: []string{"static"}},
@@ -163,7 +163,7 @@ func TestVrfBgpBind_AddVRFFailureRollsBack(t *testing.T) {
 func TestVrfBgpBind_RebindFailureRestoresPrior(t *testing.T) {
 	mgr := vrfbgp.NewManager()
 	exp := &fakeVrfExporter{failOnRD: "65100:999"}
-	s := NewVrfBgpServer(mgr, exp, nil, nil, nil)
+	s := NewVrfBgpServer(mgr, exp, nil, nil, nil, nil)
 
 	// Initial bind succeeds.
 	if _, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
@@ -206,7 +206,7 @@ func TestVrfBgpBind_ConcurrentSameVRFStaysConsistent(t *testing.T) {
 	for i := range 300 {
 		mgr := vrfbgp.NewManager()
 		exp := &fakeVrfExporter{failOnRD: "fail"}
-		s := NewVrfBgpServer(mgr, exp, nil, nil, nil)
+		s := NewVrfBgpServer(mgr, exp, nil, nil, nil, nil)
 		var wg sync.WaitGroup
 		wg.Add(2)
 		go func() {
@@ -233,7 +233,7 @@ func TestVrfBgpBind_ConcurrentSameVRFStaysConsistent(t *testing.T) {
 // The new rd / redistribute / max_prefixes fields survive a bind -> list round
 // trip through protoToBinding and back, and import/export RTs are not swapped.
 func TestVrfBgpList_RoundTripsNewFields(t *testing.T) {
-	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, nil, nil)
+	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, nil, nil, nil)
 	if _, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
 		Bindings: []*v1.VrfBgpBinding{
 			{
@@ -293,7 +293,7 @@ func (f *fakeMupSrc) ReconcileMUPUplinkInstances()       { f.uplinkRecycles++ }
 // unrelated mutation of the same binding.
 func TestVrfBgpBind_DrivesMupSrcReconcile(t *testing.T) {
 	hook := &fakeMupSrc{}
-	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, hook, nil)
+	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, hook, nil, nil)
 
 	bind := func(b *v1.VrfBgpBinding) {
 		t.Helper()
@@ -344,7 +344,7 @@ func TestVrfBgpBind_DrivesMupSrcReconcile(t *testing.T) {
 // the installed downlinks revert to the plain encap source.
 func TestVrfBgpUnbind_DrivesMupSrcReconcile(t *testing.T) {
 	hook := &fakeMupSrc{}
-	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, hook, nil)
+	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, hook, nil, nil)
 	if _, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
 		Bindings: []*v1.VrfBgpBinding{
 			{VrfName: "mup1", Rd: "65001:1", MupGtp4SourcePrefix: "fd00:d::/64"},
@@ -369,7 +369,7 @@ func TestVrfBgpUnbind_DrivesMupSrcReconcile(t *testing.T) {
 // set without an rd — is a per-item bind error, and UpdateBinding surfaces
 // it as InvalidArgument.
 func TestVrfBgpBind_MupGtp4SourcePrefixValidation(t *testing.T) {
-	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, nil, nil)
+	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, nil, nil, nil)
 	bad := []*v1.VrfBgpBinding{
 		{VrfName: "v1", Rd: "65001:1", MupGtp4SourcePrefix: "not-a-prefix"},
 		{VrfName: "v2", Rd: "65001:2", MupGtp4SourcePrefix: "10.0.0.0/24"},
@@ -399,7 +399,7 @@ func TestVrfBgpBind_EnablesEvpnOnlyWhenBridgeUp(t *testing.T) {
 		"evi-up": {Name: "br100", BdID: 100, Ifindex: 5},
 	})
 	coord := newEvpnCoordForTest(hook, mgr)
-	s := NewVrfBgpServer(mgr, nil, coord, nil, nil)
+	s := NewVrfBgpServer(mgr, nil, coord, nil, nil, nil)
 
 	if _, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
 		Bindings: []*v1.VrfBgpBinding{
@@ -437,7 +437,7 @@ func TestVrfBgpUnbind_DisablesEvpn(t *testing.T) {
 		"evi": {Name: "br100", BdID: 100, Ifindex: 5},
 	})
 	coord := newEvpnCoordForTest(hook, mgr)
-	s := NewVrfBgpServer(mgr, nil, coord, nil, nil)
+	s := NewVrfBgpServer(mgr, nil, coord, nil, nil, nil)
 
 	if _, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
 		Bindings: []*v1.VrfBgpBinding{{VrfName: "evi", Rd: "65100:100", Families: map[string]*v1.VrfBgpFamily{
@@ -472,7 +472,7 @@ func TestVrfBgpBind_NoExportRTsKeepsEvpnGated(t *testing.T) {
 		"evi-ok":       {Name: "br102", BdID: 102, Ifindex: 7},
 	})
 	coord := newEvpnCoordForTest(hook, mgr)
-	s := NewVrfBgpServer(mgr, nil, coord, nil, nil)
+	s := NewVrfBgpServer(mgr, nil, coord, nil, nil, nil)
 
 	if _, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
 		Bindings: []*v1.VrfBgpBinding{
@@ -504,7 +504,7 @@ func TestVrfBgpBind_NoExportRTsKeepsEvpnGated(t *testing.T) {
 // initial state".
 func bindForRPC(t *testing.T, vrfName string, families map[string]*v1.VrfBgpFamily) *VrfBgpServer {
 	t.Helper()
-	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, nil, nil)
+	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, nil, nil, nil)
 	if _, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
 		Bindings: []*v1.VrfBgpBinding{{VrfName: vrfName, Rd: "65100:1", Families: families}},
 	})); err != nil {
@@ -587,7 +587,7 @@ func TestAddRouteTarget_UndeclaredFamilyIsNotFound(t *testing.T) {
 // AddRouteTarget on an unknown vrf_name returns NotFound per the error code
 // table (the design's "vrf_name 無し" column).
 func TestAddRouteTarget_UnknownVRFIsNotFound(t *testing.T) {
-	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, nil, nil)
+	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, nil, nil, nil)
 	_, err := s.AddRouteTarget(context.Background(), connect.NewRequest(&v1.AddRouteTargetRequest{
 		VrfName:     "missing",
 		Family:      "vpnv4",
@@ -832,7 +832,7 @@ func TestBatchModifyRouteTargets_RollbackOnMidFailure(t *testing.T) {
 // BatchModifyRouteTargets on an unknown vrf_name is NotFound per the error
 // code table.
 func TestBatchModifyRouteTargets_UnknownVRFIsNotFound(t *testing.T) {
-	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, nil, nil)
+	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, nil, nil, nil)
 	_, err := s.BatchModifyRouteTargets(context.Background(), connect.NewRequest(&v1.BatchModifyRouteTargetsRequest{
 		VrfName: "missing",
 		Ops:     []*v1.RouteTargetOp{{Kind: v1.RouteTargetOp_KIND_ADD, Family: "vpnv4", RouteTarget: &v1.VrfBgpRouteTarget{Rt: "65000:1"}}},
@@ -851,7 +851,7 @@ func TestBatchModifyRouteTargets_UnknownVRFIsNotFound(t *testing.T) {
 // dereferences and panics. Pin that contract here.
 func TestVrfBgp_RPCNilEntriesDoNotPanic(t *testing.T) {
 	// (1) families with a nil VrfBgpFamily value.
-	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, nil, nil)
+	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, nil, nil, nil)
 	if _, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
 		Bindings: []*v1.VrfBgpBinding{{
 			VrfName:  "vrf-nil-fam",
@@ -895,7 +895,7 @@ func TestVrfBgp_RPCNilEntriesDoNotPanic(t *testing.T) {
 // VrfBgpBind is the only verb that may register a new binding; an Update verb
 // against a typo must surface as NotFound so the operator notices.
 func TestUpdateBinding_UnknownVRFIsNotFound(t *testing.T) {
-	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, nil, nil)
+	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, nil, nil, nil)
 	_, err := s.UpdateBinding(context.Background(), connect.NewRequest(&v1.UpdateBindingRequest{
 		Binding: &v1.VrfBgpBinding{VrfName: "missing", Rd: "65100:1"},
 	}))
@@ -1002,7 +1002,7 @@ func TestRemoveFamily_EVPNDisablesBridgeDomain(t *testing.T) {
 		"evi": {Name: "br100", BdID: 100, Ifindex: 5},
 	})
 	coord := newEvpnCoordForTest(hook, mgr)
-	s := NewVrfBgpServer(mgr, nil, coord, nil, nil)
+	s := NewVrfBgpServer(mgr, nil, coord, nil, nil, nil)
 	if _, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
 		Bindings: []*v1.VrfBgpBinding{{
 			VrfName: "evi", Rd: "65100:100",
@@ -1036,7 +1036,7 @@ func TestAddRouteTarget_OnVPNv4FamilyDoesNotReFireEVPN(t *testing.T) {
 		"evi-mixed": {Name: "br100", BdID: 100, Ifindex: 5},
 	})
 	coord := newEvpnCoordForTest(hook, mgr)
-	s := NewVrfBgpServer(mgr, nil, coord, nil, nil)
+	s := NewVrfBgpServer(mgr, nil, coord, nil, nil, nil)
 	if _, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
 		Bindings: []*v1.VrfBgpBinding{{
 			VrfName: "evi-mixed", Rd: "65100:100",
@@ -1068,7 +1068,7 @@ func TestAddRouteTarget_OnEVPNFamilyReFiresEVPN(t *testing.T) {
 		"evi": {Name: "br100", BdID: 100, Ifindex: 5},
 	})
 	coord := newEvpnCoordForTest(hook, mgr)
-	s := NewVrfBgpServer(mgr, nil, coord, nil, nil)
+	s := NewVrfBgpServer(mgr, nil, coord, nil, nil, nil)
 	if _, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
 		Bindings: []*v1.VrfBgpBinding{{
 			VrfName: "evi", Rd: "65100:100",
@@ -1101,7 +1101,7 @@ func TestVrfBgpBind_FacetWithoutEvpnFamilySkipsEnable(t *testing.T) {
 		"evi-no-evpn-rt": {Name: "br100", BdID: 100, Ifindex: 5},
 	})
 	coord := newEvpnCoordForTest(hook, mgr)
-	s := NewVrfBgpServer(mgr, nil, coord, nil, nil)
+	s := NewVrfBgpServer(mgr, nil, coord, nil, nil, nil)
 	if _, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
 		Bindings: []*v1.VrfBgpBinding{{
 			VrfName: "evi-no-evpn-rt", Rd: "65100:100",
@@ -1128,7 +1128,7 @@ func TestUpdateBinding_MaxPrefixesAloneSkipsEVPNReFire(t *testing.T) {
 		"evi": {Name: "br100", BdID: 100, Ifindex: 5},
 	})
 	coord := newEvpnCoordForTest(hook, mgr)
-	s := NewVrfBgpServer(mgr, nil, coord, nil, nil)
+	s := NewVrfBgpServer(mgr, nil, coord, nil, nil, nil)
 	if _, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
 		Bindings: []*v1.VrfBgpBinding{{
 			VrfName: "evi", Rd: "65100:100",
@@ -1194,7 +1194,7 @@ func TestSameRouteTargets_OrderInsensitive(t *testing.T) {
 func TestVrfBgpBind_DoubleAddVRFFailureKeepsManagerPrev(t *testing.T) {
 	mgr := vrfbgp.NewManager()
 	exp := &fakeVrfExporter{}
-	s := NewVrfBgpServer(mgr, exp, nil, nil, nil)
+	s := NewVrfBgpServer(mgr, exp, nil, nil, nil, nil)
 	// Initial bind: prev lands in both manager and exporter.
 	if _, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
 		Bindings: []*v1.VrfBgpBinding{{VrfName: "vrf1", Rd: "65100:200", DefaultLocator: "LOC1"}},
@@ -1227,7 +1227,7 @@ func TestVrfBgpBind_DoubleAddVRFFailureKeepsManagerPrev(t *testing.T) {
 // it never drives this hook (VrfService reconciles ingress separately).
 func TestVrfBgpBind_DrivesMupUplinkReconcile(t *testing.T) {
 	hook := &fakeMupSrc{}
-	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, hook, nil)
+	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, hook, nil, nil)
 
 	mupFamily := func(rt string) map[string]*v1.VrfBgpFamily {
 		return map[string]*v1.VrfBgpFamily{
@@ -1291,7 +1291,7 @@ func TestVrfBgpBind_DrivesMupUplinkReconcile(t *testing.T) {
 // is silent.
 func TestVrfBgpUnbind_DrivesMupUplinkReconcile(t *testing.T) {
 	hook := &fakeMupSrc{}
-	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, hook, nil)
+	s := NewVrfBgpServer(vrfbgp.NewManager(), nil, nil, hook, nil, nil)
 	bindReq := &v1.VrfBgpBindRequest{Bindings: []*v1.VrfBgpBinding{
 		{VrfName: "mup1", Rd: "65001:1", Families: map[string]*v1.VrfBgpFamily{
 			"mup_ipv4": {RouteTargets: []*v1.VrfBgpRouteTarget{{Rt: "100:1", Direction: "import"}}},
@@ -1329,3 +1329,82 @@ func TestVrfBgpUnbind_DrivesMupUplinkReconcile(t *testing.T) {
 	}
 }
 
+
+// commitBinding fires the EVPN loc-rib replay only when the mutation widened
+// the binding's import surface AND the VRF carries a bridge facet: a new
+// binding with import RTs replays, an import RT added replays, an unrelated
+// vpnv4 mutation or an export-only change does not, and without a facet the
+// replayed routes would just drop again so nothing fires.
+func TestVrfBgpBind_FiresEvpnReplayOnImportSurface(t *testing.T) {
+	newServer := func(facets map[string]vrf.Bridge) (*VrfBgpServer, *int) {
+		mgr := newEvpnTestMgr(t, facets)
+		replays := 0
+		s := NewVrfBgpServer(mgr, nil, nil, nil, func() { replays++ }, nil)
+		return s, &replays
+	}
+	bind := func(t *testing.T, s *VrfBgpServer, families map[string]*v1.VrfBgpFamily) {
+		t.Helper()
+		if _, err := s.VrfBgpBind(context.Background(), connect.NewRequest(&v1.VrfBgpBindRequest{
+			Bindings: []*v1.VrfBgpBinding{{VrfName: "evi", Rd: "65100:100", Families: families}},
+		})); err != nil {
+			t.Fatalf("VrfBgpBind: %v", err)
+		}
+	}
+	// vpnv4 is declared alongside so the later "unrelated vpnv4 RT add" step
+	// mutates an existing family rather than erroring on an undeclared one.
+	evpnImport := map[string]*v1.VrfBgpFamily{
+		"evpn":  {RouteTargets: []*v1.VrfBgpRouteTarget{{Rt: "65000:100", Direction: "import"}}},
+		"vpnv4": {RouteTargets: []*v1.VrfBgpRouteTarget{{Rt: "65000:200", Direction: "both"}}},
+	}
+
+	// New binding with an EVPN import RT on a facet-carrying VRF: fires once.
+	s, replays := newServer(map[string]vrf.Bridge{"evi": {Name: "br100", BdID: 100, Ifindex: 5}})
+	bind(t, s, evpnImport)
+	if *replays != 1 {
+		t.Errorf("bind with import RT + facet: replays = %d, want 1", *replays)
+	}
+
+	// Unchanged re-bind: the import surface did not widen.
+	bind(t, s, evpnImport)
+	if *replays != 1 {
+		t.Errorf("unchanged re-bind: replays = %d, want still 1", *replays)
+	}
+
+	// An import RT added via AddRouteTarget on the evpn family: fires again.
+	if _, err := s.AddRouteTarget(context.Background(), connect.NewRequest(&v1.AddRouteTargetRequest{
+		VrfName: "evi", Family: "evpn",
+		RouteTarget: &v1.VrfBgpRouteTarget{Rt: "65000:101", Direction: "import"},
+	})); err != nil {
+		t.Fatalf("AddRouteTarget: %v", err)
+	}
+	if *replays != 2 {
+		t.Errorf("evpn import RT add: replays = %d, want 2", *replays)
+	}
+
+	// An unrelated vpnv4 RT add must not rescan the rib.
+	if _, err := s.AddRouteTarget(context.Background(), connect.NewRequest(&v1.AddRouteTargetRequest{
+		VrfName: "evi", Family: "vpnv4",
+		RouteTarget: &v1.VrfBgpRouteTarget{Rt: "65000:999", Direction: "both"},
+	})); err != nil {
+		t.Fatalf("AddRouteTarget vpnv4: %v", err)
+	}
+	if *replays != 2 {
+		t.Errorf("vpnv4 RT add: replays = %d, want still 2", *replays)
+	}
+
+	// Export-only EVPN binding: no import surface, no replay.
+	s, replays = newServer(map[string]vrf.Bridge{"evi": {Name: "br100", BdID: 100, Ifindex: 5}})
+	bind(t, s, map[string]*v1.VrfBgpFamily{
+		"evpn": {RouteTargets: []*v1.VrfBgpRouteTarget{{Rt: "65000:100", Direction: "export"}}},
+	})
+	if *replays != 0 {
+		t.Errorf("export-only bind: replays = %d, want 0", *replays)
+	}
+
+	// Facet-less VRF: the replayed routes would drop again; no replay.
+	s, replays = newServer(nil)
+	bind(t, s, evpnImport)
+	if *replays != 0 {
+		t.Errorf("bind without a facet: replays = %d, want 0", *replays)
+	}
+}

--- a/pkg/server/vrf_bgp_test.go
+++ b/pkg/server/vrf_bgp_test.go
@@ -1381,6 +1381,16 @@ func TestVrfBgpBind_FiresEvpnReplayOnImportSurface(t *testing.T) {
 		t.Errorf("evpn import RT add: replays = %d, want 2", *replays)
 	}
 
+	// An import RT REMOVED shrinks the surface: rescues nothing, no replay.
+	if _, err := s.RemoveRouteTarget(context.Background(), connect.NewRequest(&v1.RemoveRouteTargetRequest{
+		VrfName: "evi", Family: "evpn", Rt: "65000:101",
+	})); err != nil {
+		t.Fatalf("RemoveRouteTarget: %v", err)
+	}
+	if *replays != 2 {
+		t.Errorf("evpn import RT remove: replays = %d, want still 2", *replays)
+	}
+
 	// An unrelated vpnv4 RT add must not rescan the rib.
 	if _, err := s.AddRouteTarget(context.Background(), connect.NewRequest(&v1.AddRouteTargetRequest{
 		VrfName: "evi", Family: "vpnv4",

--- a/pkg/server/vrf_test.go
+++ b/pkg/server/vrf_test.go
@@ -189,7 +189,7 @@ func newTestVrfServerFull() (*VrfServer, *fakeProgrammer, *fakeVrfDeviceOps) {
 	events := []string{}
 	s := NewVrfServer(vrf.NewManager(), prog, dev, &fakeSidTable{}, &fakeBindings{},
 		&fakeServerBridgeOps{ifindexes: map[string]uint32{}, events: &events},
-		&fakeFdbRegistrar{events: &events}, nil, nil)
+		&fakeFdbRegistrar{events: &events}, nil, nil, nil)
 	s.resolve = fakeResolver
 	return s, prog, dev
 }
@@ -208,7 +208,7 @@ func newTestVrfServerBridge(hook EvpnBridgeHook) (*VrfServer, *fakeServerBridgeO
 	if hook != nil {
 		evpn = NewEvpnCoordinator(hook, testFacetResolver(mgr), func(int) error { return nil }, zap.NewNop())
 	}
-	s := NewVrfServer(mgr, &fakeProgrammer{}, &fakeVrfDeviceOps{}, &fakeSidTable{}, bindings, bridges, fdb, evpn, nil)
+	s := NewVrfServer(mgr, &fakeProgrammer{}, &fakeVrfDeviceOps{}, &fakeSidTable{}, bindings, bridges, fdb, evpn, nil, nil)
 	s.resolve = fakeResolver
 	return s, bridges, fdb, bindings, &events
 }
@@ -824,5 +824,57 @@ func TestVrfServer_DeleteRefusesWithBridge(t *testing.T) {
 	}
 	if len(resp.Msg.Errors) != 1 {
 		t.Fatalf("delete with bridge facet: want refusal, got %+v", resp.Msg)
+	}
+}
+
+// VrfBridgeAttach fires the EVPN loc-rib replay only when the VRF's binding
+// imports EVPN RTs: the attach completes the import surface, so routes
+// dropped fail-closed while the facet was missing get rescued. A binding
+// without EVPN import RTs (or no binding) must not trigger a rib scan.
+func TestVrfServer_BridgeAttachFiresEvpnReplay(t *testing.T) {
+	newServer := func() (*VrfServer, *fakeBindings, *int) {
+		events := []string{}
+		bindings := &fakeBindings{bindings: map[string]vrfbgp.Binding{}}
+		replays := 0
+		s := NewVrfServer(vrf.NewManager(), &fakeProgrammer{}, &fakeVrfDeviceOps{}, &fakeSidTable{}, bindings,
+			&fakeServerBridgeOps{ifindexes: map[string]uint32{"br100": 42}, events: &events},
+			&fakeFdbRegistrar{events: &events}, nil, func() { replays++ }, nil)
+		s.resolve = fakeResolver
+		return s, bindings, &replays
+	}
+	attach := func(t *testing.T, s *VrfServer) {
+		t.Helper()
+		if _, err := s.VrfBridgeAttach(context.Background(), connect.NewRequest(&v1.VrfBridgeAttachRequest{
+			VrfName: "evi-100", Bridge: &v1.Bridge{Name: "br100", BdId: 100},
+		})); err != nil {
+			t.Fatalf("VrfBridgeAttach: %v", err)
+		}
+	}
+
+	// Binding with an EVPN import RT: replay fires once.
+	s, bindings, replays := newServer()
+	bindings.bindings["evi-100"] = vrfbgp.Binding{VRFName: "evi-100", Families: map[bgp.Family]vrfbgp.FamilyPolicy{
+		bgp.FamilyEVPN: {RouteTargets: []vrfbgp.RouteTarget{{RT: "65000:100", Direction: vrfbgp.DirectionImport}}},
+	}}
+	attach(t, s)
+	if *replays != 1 {
+		t.Errorf("attach with an EVPN import RT: replays = %d, want 1", *replays)
+	}
+
+	// Export-only EVPN binding: the receive surface did not widen.
+	s, bindings, replays = newServer()
+	bindings.bindings["evi-100"] = vrfbgp.Binding{VRFName: "evi-100", Families: map[bgp.Family]vrfbgp.FamilyPolicy{
+		bgp.FamilyEVPN: {RouteTargets: []vrfbgp.RouteTarget{{RT: "65000:100", Direction: vrfbgp.DirectionExport}}},
+	}}
+	attach(t, s)
+	if *replays != 0 {
+		t.Errorf("attach with an export-only binding: replays = %d, want 0", *replays)
+	}
+
+	// No binding at all: nothing can match, no replay.
+	s, _, replays = newServer()
+	attach(t, s)
+	if *replays != 0 {
+		t.Errorf("attach without a binding: replays = %d, want 0", *replays)
 	}
 }


### PR DESCRIPTION
## Summary

Closes the deferred window from #98: an EVPN route that arrives while its import surface (a vrf-bgp binding with EVPN import RTs + the VRF's bridge facet) does not exist yet is dropped fail-closed, and the watch stream never re-delivers it. Now `VrfBridgeAttach` and `commitBinding` re-apply the gobgp loc-rib snapshot through the normal receive path whenever the import surface widens, so the drop self-heals without waiting for the peer to re-advertise. The attach-before-bind ordering in the scenarios becomes a preference, not a correctness requirement.

## Design

- **`bgp.RouteLister` / `Session.ListRoutes`** (first loc-rib read in the tree): gobgp `ListPath` over the global table, decoded by the same `pathToRouteEvent` the live watch uses. Locally originated paths are skipped — the rib holds this node's own RT2/RT3 (unlike the watch stream), and re-applying an own RT3 would install a self-pointing BUM peer. gobgp marks local paths with an invalid source address, surfaced as an invalid `Path.PeerAddress` (pinned by the lister test against a real session pair).
- **`Applier.ReplayEVPN` + `evpnMu`**: the EVPN receive state was single-goroutine by contract; the replay runs on an RPC goroutine, so `applyEVPN` now takes `evpnMu` (the `mupMu` pattern) and the replay holds it across the snapshot AND the re-applies. That span is what makes every interleaving with the live stream converge — a withdraw racing the replay blocks and lands after, overwriting the re-install. It cannot deadlock: gobgp delivers watch events on a dedicated goroutine fed by an unbounded queue, so the mgmt loop that `ListPath` waits on never blocks on our callback (verified in the fork source).
- **Gates**: attach fires when the binding has EVPN import RTs; commitBinding fires strictly widen-only (a new binding with import RTs or an import RT added — never on removal, export-only changes, or other-family mutations) and only when the facet exists. Import direction is deliberately separate from the coordinator's export-RT gate: a receive-only PE imports without advertising. Every install is idempotent, so replaying already-applied routes is a no-op (existing refcount tests).

## Verification

- unit: lister against a real gobgp session pair (peer route visible, own advertisement filtered, pre-start error), `ReplayEVPN` install/guards/`-race` concurrency, server gate matrix (import present / export-only / no binding / no facet / unchanged re-bind / RT add fires / RT remove and vpnv4 mutations do not).
- sudo E2E (new): an RT2 delivered before the facet is provably dropped (asserted after the route is visible in the loc-rib), then a facet arrival + the exact main.go composition installs it into the real BPF maps with no re-advertise.
- suites: `go test ./...` + golangci-lint 0 + sudo (bpf 209s / gobgp / netresource / fib / netlinkwatch) all pass.
- containerlab: evpn-2site 13/13, evpn-multihoming 7/7. Live rescue check on a deployed evpn-2site: detach + unbind on pe-tokyo, re-bind import-first, pe-osaka advertises a new MAC → confirmed absent from fdb (fail-closed), `vrf bridge-attach` → the MAC appears in fdb with no re-advertise.

## Notes

- Scope is EVPN only; `ListRoutes` is family-parameterized so a later L3VPN/MUP late-bind rescue is a `ReplayVPN` away (those apply paths are already idempotent, but share the same single-goroutine contract and would need the same lock treatment).
- While a replay runs, live EVPN events queue behind `evpnMu` (gobgp's queue is unbounded) and other Vrf RPCs wait on the shared mutation mutex — bounded by rib size, which is small at EVPN scales.