### PR TITLE
fix(netresource): atomic state writes, error propagation, fail-closed reconcile

### DIFF
--- a/docs/design/ja/persistence.md
+++ b/docs/design/ja/persistence.md
@@ -24,12 +24,18 @@ Vinbero が daemon 内部で持つ状態のうち **永続化されるのは Net
 `pkg/netresource/manager.go` の ResourceManager が:
 1. 起動時に `state.json` を読み込み、記録されていた Bridge / VRF デバイスを netlink で確認
 2. 欠けていれば再作成 (`ip link add` 相当)
-3. 存在するものは ifindex を state に書き直して更新
+3. 存在するものは Create と同じ検証と収束で adopt する (link 種別の確認、up、不足 member の enslave、ifindex の更新)
 4. 稼働中に `vinbero vrf create` や `vinbero vrf bridge-attach` で変更があれば都度 disk に flush (VRF device も bridge も VrfService 経由で、vrf_id を持つ一級 VRF object の facet として管理される。bridge の state record は owning VRF 名も持つ)
 
 これにより、`sudo reboot` した後でも `vinbero vrf show` の BRIDGE / BD_ID 列に以前と同じ Bridge が見えます (daemon が自動で restore する)。
 
-state.json フォーマットは内部実装扱いで、手編集は非推奨です。`vinbero` CLI 経由で操作してください。
+堅牢性は次の 3 点で担保します。
+
+- 書き込みは atomic です。同一ディレクトリの temp file に書いて fsync してから rename するので、書き込み途中の crash や ENOSPC でも直前の state.json が無傷で残ります。
+- 保存の失敗は RPC エラーとして返ります (旧実装は warn に落として成功を返していた)。kernel device とメモリ上の記録は巻き戻さず、次に成功した保存が全量を書き直して収束します。
+- boot の reconcile は fail-closed です。state の entry が実体化できない場合 (member NIC の消失、名前を別種の link に取られた等) は、entry 名と修復手順 (デバイスの復旧か entry の削除) を示すエラーで起動を拒否します。stale な ifindex のまま続行すると FDB watcher / EVPN / SID 参照ガードが誤った index で動くためです。parse できない state.json も同様に起動を拒否します (空 state で始めると管理下のデバイスを黙って放棄することになるため)。
+
+state.json フォーマットは内部実装扱いで、手編集は非推奨です。`vinbero` CLI 経由で操作してください (例外は上記の修復手順と、bridge record の owning VRF 付け替え)。
 
 ## BPF マップ: in-memory vs pinned
 

--- a/docs/design/ja/vrf.md
+++ b/docs/design/ja/vrf.md
@@ -96,7 +96,7 @@ facet ごとに入口が違っても、name が同じなら同じ VRF に集ま�
 
 kernel device facet は `settings.state_path` の JSON state に永続化され、restart を跨いで生き残ります。boot 順序は次のとおりです。
 
-1. `netresource.Reconcile` が state の device と bridge を kernel と突き合わせ、消えていれば再作成します
+1. `netresource.Reconcile` が state の device と bridge を kernel と突き合わせ、消えていれば再作成し、存在するものは Create と同じ検証と収束で adopt します。実体化できない entry があれば fail-closed で起動を拒否します (stale な ifindex を FDB watcher / EVPN / SID 参照ガードに渡さない。エラーに修復手順が出ます)
 2. `seedVrfDevices` / `seedVrfBridges` が state を VRF オブジェクトに mirror します (restart 後も facet 付きの一級 VRF として見える)。facet 化以前の bridge record は owning VRF を持たないので、bridge 名を仮の VRF 名として seed します (state file の `vrf` フィールドを書いて再起動すれば本来の VRF に移せます)
 3. `loadVRFs` が config の `vrfs:` を適用します (device / bridge は adopt 冪等、AC、policy、最後に ingress reconcile と bridge facet の FDBWatcher 登録 sweep)
 

--- a/pkg/netresource/bridge.go
+++ b/pkg/netresource/bridge.go
@@ -9,15 +9,13 @@ import (
 	"go.uber.org/zap"
 )
 
+// CreateBridge creates (or idempotently adopts) the kernel bridge and
+// persists it. On a persist failure the kernel device and the in-memory
+// record are NOT rolled back: the error is returned so the caller sees the
+// divergence, a retry re-adopts and converges, and the next successful
+// persist writes the whole state anyway.
 func (m *ResourceManager) CreateBridge(name string, bdID uint16, members []string, ownerVRF string) (uint32, error) {
-	// Idempotent adopt: an existing link is taken over only when it really is
-	// a bridge device. A bare name match must not adopt — otherwise a typo
-	// like --name eth1 would put the NIC into the state file and a later
-	// detach would LinkDel it.
 	if existing, err := netlink.LinkByName(name); err == nil {
-		if _, ok := existing.(*netlink.Bridge); !ok {
-			return 0, fmt.Errorf("link %s exists but is %s, not a bridge device", name, existing.Type())
-		}
 		// bd_id and the owning VRF are not kernel attributes, so identity is
 		// verified against the state entry: a tracked bridge cannot silently
 		// change bd_id (the data-plane FDB scope) or move to another VRF.
@@ -29,23 +27,13 @@ func (m *ResourceManager) CreateBridge(name string, bdID uint16, members []strin
 				return 0, fmt.Errorf("bridge %s is owned by vrf %q, requested %q", name, tracked.VRF, ownerVRF)
 			}
 		}
-		// Converge the adopted device on the request: bring it up (an
-		// operator-created admin-DOWN bridge would blackhole End.DT2 decap
-		// behind a successful attach) and enslave any members it is missing
-		// (LinkSetMaster is idempotent for already-enslaved links), so an
-		// adopt is not silently weaker than a fresh create.
-		if err := netlink.LinkSetUp(existing); err != nil {
-			return 0, fmt.Errorf("set bridge %s up: %w", name, err)
+		ifindex, err := adoptBridgeDevice(existing, name, members)
+		if err != nil {
+			return 0, err
 		}
-		for _, member := range members {
-			if err := enslaveInterface(member, existing); err != nil {
-				return 0, err
-			}
-		}
-		ifindex := uint32(existing.Attrs().Index)
 		m.ensureBridgeInState(name, bdID, members, ifindex, ownerVRF)
-		if err := saveState(m.statePath, m.state); err != nil {
-			m.logger.Warn("failed to save state after bridge idempotent update", zap.Error(err))
+		if err := m.persist(); err != nil {
+			return 0, fmt.Errorf("persist state after adopting bridge %s: %w", name, err)
 		}
 		return ifindex, nil
 	}
@@ -59,14 +47,39 @@ func (m *ResourceManager) CreateBridge(name string, bdID uint16, members []strin
 	// would have failed on LinkAdd), so the upsert takes its append branch.
 	m.ensureBridgeInState(name, bdID, members, ifindex, ownerVRF)
 
-	if err := saveState(m.statePath, m.state); err != nil {
-		m.logger.Warn("failed to save state after bridge creation", zap.Error(err))
+	if err := m.persist(); err != nil {
+		return 0, fmt.Errorf("persist state after creating bridge %s: %w", name, err)
 	}
 
 	m.logger.Info("Created bridge",
 		zap.String("name", name), zap.Uint16("bd_id", bdID), zap.Uint32("ifindex", ifindex),
 		zap.String("vrf", ownerVRF))
 	return ifindex, nil
+}
+
+// adoptBridgeDevice takes over an existing link as the managed bridge. The
+// link is adopted only when it really is a bridge device -- a bare name
+// match must not adopt, or a typo like --name eth1 would put the NIC into
+// the state file and a later detach would LinkDel it. The adopted device is
+// converged on the request: brought up (an operator-created admin-DOWN
+// bridge would blackhole End.DT2 decap behind a successful attach) and
+// missing members enslaved (LinkSetMaster is idempotent), so an adopt is
+// not silently weaker than a fresh create. Reconcile adopts state entries
+// through the same path; identity (bd_id / owner VRF) is checked by the
+// caller against the tracked entry, since it is not a kernel attribute.
+func adoptBridgeDevice(link netlink.Link, name string, members []string) (uint32, error) {
+	if _, ok := link.(*netlink.Bridge); !ok {
+		return 0, fmt.Errorf("link %s exists but is %s, not a bridge device", name, link.Type())
+	}
+	if err := netlink.LinkSetUp(link); err != nil {
+		return 0, fmt.Errorf("set bridge %s up: %w", name, err)
+	}
+	for _, member := range members {
+		if err := enslaveInterface(member, link); err != nil {
+			return 0, err
+		}
+	}
+	return uint32(link.Attrs().Index), nil
 }
 
 func (m *ResourceManager) DeleteBridge(name string) error {
@@ -104,8 +117,11 @@ func (m *ResourceManager) DeleteBridge(name string) error {
 	m.state.Bridges = filtered
 	m.mu.Unlock()
 
-	if err := saveState(m.statePath, m.state); err != nil {
-		m.logger.Warn("failed to save state after bridge deletion", zap.Error(err))
+	if err := m.persist(); err != nil {
+		// The kernel device is gone and the record is removed in memory; the
+		// next successful persist flushes it from disk too. Surface the error
+		// so the operator knows disk state is momentarily behind.
+		return fmt.Errorf("persist state after deleting bridge %s: %w", name, err)
 	}
 
 	m.logger.Info("Deleted bridge", zap.String("name", name))
@@ -117,6 +133,11 @@ func (m *ResourceManager) ListBridges() []ManagedBridge {
 	defer m.mu.RUnlock()
 	result := make([]ManagedBridge, len(m.state.Bridges))
 	copy(result, m.state.Bridges)
+	for i := range result {
+		// Deep-copy Members: the shallow struct copy would alias the
+		// state-owned backing array, which ensureBridgeInState appends to.
+		result[i].Members = slices.Clone(result[i].Members)
+	}
 	return result
 }
 

--- a/pkg/netresource/manager.go
+++ b/pkg/netresource/manager.go
@@ -2,6 +2,7 @@ package netresource
 
 import (
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/vishvananda/netlink"
@@ -28,12 +29,20 @@ func NewResourceManager(statePath string, logger *zap.Logger) (*ResourceManager,
 	}, nil
 }
 
-// Reconcile checks that all managed resources exist and recreates any that are missing.
-// Called once at startup before any API requests, so no lock contention.
+// Reconcile makes every state entry real: a missing device is recreated, an
+// existing one is adopted with the same validation and convergence the Create
+// paths apply (type check, up, missing members enslaved). Fail-closed: an
+// entry that cannot be materialized aborts the boot with a repair hint --
+// continuing would persist a stale ifindex that the FDB watcher, the EVPN
+// enable/replay machinery, and the SID-reference delete guards all key on,
+// so they would silently operate on a dead (or kernel-reused) index.
+// Called once at startup before any API requests.
 func (m *ResourceManager) Reconcile() error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	fix := func(name string, err error) error {
+		return fmt.Errorf("reconcile %s from state %s: %w (restore the device / its members, or remove the entry from the state file, then restart)", name, m.statePath, err)
+	}
 
+	m.mu.Lock()
 	for i := range m.state.Bridges {
 		b := &m.state.Bridges[i]
 		link, err := netlink.LinkByName(b.Name)
@@ -42,14 +51,18 @@ func (m *ResourceManager) Reconcile() error {
 				zap.String("name", b.Name), zap.Uint16("bd_id", b.BdID))
 			ifindex, err := createBridgeNetlink(b.Name, b.Members)
 			if err != nil {
-				m.logger.Error("Reconcile: failed to recreate bridge",
-					zap.String("name", b.Name), zap.Error(err))
-				continue
+				m.mu.Unlock()
+				return fix("bridge "+b.Name, err)
 			}
 			b.Ifindex = ifindex
-		} else {
-			b.Ifindex = uint32(link.Attrs().Index)
+			continue
 		}
+		ifindex, err := adoptBridgeDevice(link, b.Name, b.Members)
+		if err != nil {
+			m.mu.Unlock()
+			return fix("bridge "+b.Name, err)
+		}
+		b.Ifindex = ifindex
 	}
 
 	for i := range m.state.VRFs {
@@ -60,37 +73,46 @@ func (m *ResourceManager) Reconcile() error {
 				zap.String("name", v.Name), zap.Uint32("table_id", v.TableID))
 			ifindex, err := createVrfNetlink(v.Name, v.TableID, v.Members, v.EnableL3mdevRule)
 			if err != nil {
-				m.logger.Error("Reconcile: failed to recreate VRF",
-					zap.String("name", v.Name), zap.Error(err))
-				continue
+				m.mu.Unlock()
+				return fix("vrf "+v.Name, err)
 			}
 			v.Ifindex = ifindex
-		} else {
-			v.Ifindex = uint32(link.Attrs().Index)
+			continue
 		}
+		ifindex, err := adoptVrfDevice(link, v.Name, v.TableID, v.Members, v.EnableL3mdevRule)
+		if err != nil {
+			m.mu.Unlock()
+			return fix("vrf "+v.Name, err)
+		}
+		v.Ifindex = ifindex
 	}
+	m.mu.Unlock()
 
-	return saveState(m.statePath, m.state)
+	return m.persist()
 }
 
-// GetBridgeByName returns the managed bridge info by name.
+// GetBridgeByName returns the managed bridge info by name. Members is a copy
+// so the caller cannot alias the state-owned backing array.
 func (m *ResourceManager) GetBridgeByName(name string) (ManagedBridge, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	for _, b := range m.state.Bridges {
 		if b.Name == name {
+			b.Members = slices.Clone(b.Members)
 			return b, true
 		}
 	}
 	return ManagedBridge{}, false
 }
 
-// GetVrfByName returns the managed VRF info by name.
+// GetVrfByName returns the managed VRF info by name. Members is a copy so
+// the caller cannot alias the state-owned backing array.
 func (m *ResourceManager) GetVrfByName(name string) (ManagedVrf, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	for _, v := range m.state.VRFs {
 		if v.Name == name {
+			v.Members = slices.Clone(v.Members)
 			return v, true
 		}
 	}

--- a/pkg/netresource/manager.go
+++ b/pkg/netresource/manager.go
@@ -42,52 +42,66 @@ func (m *ResourceManager) Reconcile() error {
 		return fmt.Errorf("reconcile %s from state %s: %w (restore the device / its members, or remove the entry from the state file, then restart)", name, m.statePath, err)
 	}
 
-	m.mu.Lock()
-	for i := range m.state.Bridges {
-		b := &m.state.Bridges[i]
-		link, err := netlink.LinkByName(b.Name)
-		if err != nil {
-			m.logger.Info("Reconcile: recreating bridge",
-				zap.String("name", b.Name), zap.Uint16("bd_id", b.BdID))
-			ifindex, err := createBridgeNetlink(b.Name, b.Members)
+	// The locked section is a closure so the unlock is deferred (panic-safe)
+	// while persist still runs outside the lock (RWMutex is not reentrant).
+	empty := false
+	err := func() error {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		empty = len(m.state.Bridges) == 0 && len(m.state.VRFs) == 0
+
+		for i := range m.state.Bridges {
+			b := &m.state.Bridges[i]
+			link, err := netlink.LinkByName(b.Name)
 			if err != nil {
-				m.mu.Unlock()
+				m.logger.Info("Reconcile: recreating bridge",
+					zap.String("name", b.Name), zap.Uint16("bd_id", b.BdID))
+				ifindex, err := createBridgeNetlink(b.Name, b.Members)
+				if err != nil {
+					return fix("bridge "+b.Name, err)
+				}
+				b.Ifindex = ifindex
+				continue
+			}
+			ifindex, err := adoptBridgeDevice(link, b.Name, b.Members)
+			if err != nil {
 				return fix("bridge "+b.Name, err)
 			}
 			b.Ifindex = ifindex
-			continue
 		}
-		ifindex, err := adoptBridgeDevice(link, b.Name, b.Members)
-		if err != nil {
-			m.mu.Unlock()
-			return fix("bridge "+b.Name, err)
-		}
-		b.Ifindex = ifindex
-	}
 
-	for i := range m.state.VRFs {
-		v := &m.state.VRFs[i]
-		link, err := netlink.LinkByName(v.Name)
-		if err != nil {
-			m.logger.Info("Reconcile: recreating VRF",
-				zap.String("name", v.Name), zap.Uint32("table_id", v.TableID))
-			ifindex, err := createVrfNetlink(v.Name, v.TableID, v.Members, v.EnableL3mdevRule)
+		for i := range m.state.VRFs {
+			v := &m.state.VRFs[i]
+			link, err := netlink.LinkByName(v.Name)
 			if err != nil {
-				m.mu.Unlock()
+				m.logger.Info("Reconcile: recreating VRF",
+					zap.String("name", v.Name), zap.Uint32("table_id", v.TableID))
+				ifindex, err := createVrfNetlink(v.Name, v.TableID, v.Members, v.EnableL3mdevRule)
+				if err != nil {
+					return fix("vrf "+v.Name, err)
+				}
+				v.Ifindex = ifindex
+				continue
+			}
+			ifindex, err := adoptVrfDevice(link, v.Name, v.TableID, v.Members, v.EnableL3mdevRule)
+			if err != nil {
 				return fix("vrf "+v.Name, err)
 			}
 			v.Ifindex = ifindex
-			continue
 		}
-		ifindex, err := adoptVrfDevice(link, v.Name, v.TableID, v.Members, v.EnableL3mdevRule)
-		if err != nil {
-			m.mu.Unlock()
-			return fix("vrf "+v.Name, err)
-		}
-		v.Ifindex = ifindex
+		return nil
+	}()
+	if err != nil {
+		return err
 	}
-	m.mu.Unlock()
-
+	if empty {
+		// Nothing to protect and nothing to refresh: skipping the persist
+		// keeps a deployment that uses no VRF/bridge features booting even
+		// when the state directory is unwritable (read-only /var/lib, a
+		// container without the volume). With entries present a persist
+		// failure IS boot-fatal -- their refreshed ifindexes must land.
+		return nil
+	}
 	return m.persist()
 }
 

--- a/pkg/netresource/reconcile_test.go
+++ b/pkg/netresource/reconcile_test.go
@@ -221,8 +221,11 @@ func TestConcurrentBridgeAccess(t *testing.T) {
 		t.Fatalf("CreateBridge: %v", err)
 	}
 	inNs := func(work func()) {
+		// Deliberately NO UnlockOSThread: the goroutine exits still locked,
+		// which destroys the thread instead of returning a netns-pinned
+		// (poisoned) thread to the scheduler pool where a later goroutine
+		// could silently run in this dead namespace.
 		runtime.LockOSThread()
-		defer runtime.UnlockOSThread()
 		if err := netns.Set(testNs); err != nil {
 			t.Errorf("netns.Set: %v", err)
 			return

--- a/pkg/netresource/reconcile_test.go
+++ b/pkg/netresource/reconcile_test.go
@@ -1,0 +1,228 @@
+package netresource
+
+import (
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+	"go.uber.org/zap"
+)
+
+// Reconcile recreates a state entry whose device vanished (the reboot case)
+// and refreshes its ifindex on disk.
+func TestReconcile_RecreatesMissingBridge(t *testing.T) {
+	withTestNetns(t)
+	m := newTestManager(t)
+	if _, err := m.CreateBridge("br-rec", 100, nil, "evi-rec"); err != nil {
+		t.Fatalf("CreateBridge: %v", err)
+	}
+	link, err := netlink.LinkByName("br-rec")
+	if err != nil {
+		t.Fatalf("LinkByName: %v", err)
+	}
+	if err := netlink.LinkDel(link); err != nil {
+		t.Fatalf("LinkDel: %v", err)
+	}
+
+	// Fresh manager over the same state file = the post-reboot load.
+	m2, err := NewResourceManager(m.statePath, zap.NewNop())
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if err := m2.Reconcile(); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	relink, err := netlink.LinkByName("br-rec")
+	if err != nil {
+		t.Fatalf("bridge not recreated: %v", err)
+	}
+	got, ok := m2.GetBridgeByName("br-rec")
+	if !ok || got.Ifindex != uint32(relink.Attrs().Index) {
+		t.Errorf("state ifindex = %+v, want the recreated device's %d", got, relink.Attrs().Index)
+	}
+}
+
+// Reconcile is fail-closed: an entry whose name was stolen by a different
+// link type, or whose recreation fails, aborts with a repair hint and does
+// NOT write a stale ifindex back to disk.
+func TestReconcile_FailsClosed(t *testing.T) {
+	withTestNetns(t)
+
+	t.Run("name stolen by a non-bridge link", func(t *testing.T) {
+		m := newTestManager(t)
+		if _, err := m.CreateBridge("br-stolen", 100, nil, ""); err != nil {
+			t.Fatalf("CreateBridge: %v", err)
+		}
+		link, err := netlink.LinkByName("br-stolen")
+		if err != nil {
+			t.Fatalf("LinkByName: %v", err)
+		}
+		if err := netlink.LinkDel(link); err != nil {
+			t.Fatalf("LinkDel: %v", err)
+		}
+		if err := netlink.LinkAdd(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "br-stolen"}}); err != nil {
+			t.Fatalf("dummy add: %v", err)
+		}
+
+		before, err := os.ReadFile(m.statePath)
+		if err != nil {
+			t.Fatalf("read state: %v", err)
+		}
+		m2, err := NewResourceManager(m.statePath, zap.NewNop())
+		if err != nil {
+			t.Fatalf("reload: %v", err)
+		}
+		err = m2.Reconcile()
+		if err == nil {
+			t.Fatal("Reconcile must refuse a name stolen by a non-bridge link")
+		}
+		if !strings.Contains(err.Error(), "br-stolen") || !strings.Contains(err.Error(), "remove the entry") {
+			t.Errorf("error should name the entry and the repair hint, got: %v", err)
+		}
+		after, err := os.ReadFile(m.statePath)
+		if err != nil {
+			t.Fatalf("re-read state: %v", err)
+		}
+		if string(before) != string(after) {
+			t.Error("a failed Reconcile must not rewrite the state file")
+		}
+	})
+
+	t.Run("recreation fails on a missing member", func(t *testing.T) {
+		m := newTestManager(t)
+		// Seed a state entry whose recreation cannot succeed: the member NIC
+		// does not exist in this netns (a renamed/removed NIC after reboot).
+		m.ensureBridgeInState("br-lost", 200, []string{"ghost0"}, 7, "evi-lost")
+		if err := m.persist(); err != nil {
+			t.Fatalf("persist: %v", err)
+		}
+		before, err := os.ReadFile(m.statePath)
+		if err != nil {
+			t.Fatalf("read state: %v", err)
+		}
+
+		m2, err := NewResourceManager(m.statePath, zap.NewNop())
+		if err != nil {
+			t.Fatalf("reload: %v", err)
+		}
+		err = m2.Reconcile()
+		if err == nil {
+			t.Fatal("Reconcile must fail when a state entry cannot be recreated")
+		}
+		if !strings.Contains(err.Error(), "br-lost") || !strings.Contains(err.Error(), m.statePath) {
+			t.Errorf("error should carry the entry and the state path, got: %v", err)
+		}
+		after, err := os.ReadFile(m.statePath)
+		if err != nil {
+			t.Fatalf("re-read state: %v", err)
+		}
+		if string(before) != string(after) {
+			t.Error("a failed Reconcile must not persist the stale ifindex")
+		}
+	})
+}
+
+// Reconcile adopt converges like Create: an existing device is brought up
+// and its missing members enslaved, not just its ifindex read back.
+func TestReconcile_AdoptConverges(t *testing.T) {
+	withTestNetns(t)
+	m := newTestManager(t)
+	if err := netlink.LinkAdd(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "mem-rec0"}}); err != nil {
+		t.Fatalf("dummy add: %v", err)
+	}
+	if _, err := m.CreateBridge("br-adopt", 300, []string{"mem-rec0"}, ""); err != nil {
+		t.Fatalf("CreateBridge: %v", err)
+	}
+	// Un-enslave and down the bridge out-of-band; Reconcile must converge both.
+	mem, err := netlink.LinkByName("mem-rec0")
+	if err != nil {
+		t.Fatalf("member lookup: %v", err)
+	}
+	if err := netlink.LinkSetNoMaster(mem); err != nil {
+		t.Fatalf("unenslave: %v", err)
+	}
+	br, err := netlink.LinkByName("br-adopt")
+	if err != nil {
+		t.Fatalf("bridge lookup: %v", err)
+	}
+	if err := netlink.LinkSetDown(br); err != nil {
+		t.Fatalf("set down: %v", err)
+	}
+
+	m2, err := NewResourceManager(m.statePath, zap.NewNop())
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if err := m2.Reconcile(); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	br, err = netlink.LinkByName("br-adopt")
+	if err != nil {
+		t.Fatalf("bridge lookup: %v", err)
+	}
+	if br.Attrs().Flags&net.FlagUp == 0 {
+		t.Error("Reconcile adopt did not bring the bridge up")
+	}
+	mem, err = netlink.LinkByName("mem-rec0")
+	if err != nil {
+		t.Fatalf("member lookup: %v", err)
+	}
+	if mem.Attrs().MasterIndex != br.Attrs().Index {
+		t.Error("Reconcile adopt did not re-enslave the missing member")
+	}
+}
+
+// A persist failure surfaces to the CreateBridge caller instead of being
+// demoted to a warning behind a success return.
+func TestCreateBridge_PersistFailurePropagates(t *testing.T) {
+	withTestNetns(t)
+	m := newTestManager(t)
+	if _, err := m.CreateBridge("br-pf", 400, nil, ""); err != nil {
+		t.Fatalf("CreateBridge: %v", err)
+	}
+	// Make the rename step unable to win: the state path becomes a directory.
+	if err := os.Remove(m.statePath); err != nil {
+		t.Fatalf("remove state: %v", err)
+	}
+	if err := os.Mkdir(m.statePath, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if _, err := m.CreateBridge("br-pf", 400, nil, ""); err == nil {
+		t.Fatal("CreateBridge with a failing persist must return the error")
+	}
+	if err := m.DeleteBridge("br-pf"); err == nil {
+		t.Fatal("DeleteBridge with a failing persist must return the error")
+	}
+}
+
+// The manager's own locking keeps concurrent mutation and reads race-free
+// (run with -race); the RPC layer serializes mutations today, but the
+// invariant must hold inside the package that owns the data.
+func TestConcurrentBridgeAccess(t *testing.T) {
+	withTestNetns(t)
+	m := newTestManager(t)
+	if _, err := m.CreateBridge("br-race", 500, nil, ""); err != nil {
+		t.Fatalf("CreateBridge: %v", err)
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 25; j++ {
+				_, _ = m.CreateBridge("br-race", 500, nil, "") // idempotent adopt
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 25; j++ {
+				_ = m.ListBridges()
+				_, _ = m.GetBridgeByName("br-race")
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/netresource/reconcile_test.go
+++ b/pkg/netresource/reconcile_test.go
@@ -3,11 +3,13 @@ package netresource
 import (
 	"net"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
 
 	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
 	"go.uber.org/zap"
 )
 
@@ -48,10 +50,13 @@ func TestReconcile_RecreatesMissingBridge(t *testing.T) {
 // Reconcile is fail-closed: an entry whose name was stolen by a different
 // link type, or whose recreation fails, aborts with a repair hint and does
 // NOT write a stale ifindex back to disk.
+//
+// withTestNetns runs INSIDE each subtest: t.Run subtests execute on their
+// own goroutines, so a parent-scope netns (which pins only the parent's OS
+// thread) would leave them in the host namespace and leak devices there.
 func TestReconcile_FailsClosed(t *testing.T) {
-	withTestNetns(t)
-
 	t.Run("name stolen by a non-bridge link", func(t *testing.T) {
+		withTestNetns(t)
 		m := newTestManager(t)
 		if _, err := m.CreateBridge("br-stolen", 100, nil, ""); err != nil {
 			t.Fatalf("CreateBridge: %v", err)
@@ -92,6 +97,7 @@ func TestReconcile_FailsClosed(t *testing.T) {
 	})
 
 	t.Run("recreation fails on a missing member", func(t *testing.T) {
+		withTestNetns(t)
 		m := newTestManager(t)
 		// Seed a state entry whose recreation cannot succeed: the member NIC
 		// does not exist in this netns (a renamed/removed NIC after reboot).
@@ -200,21 +206,39 @@ func TestCreateBridge_PersistFailurePropagates(t *testing.T) {
 
 // The manager's own locking keeps concurrent mutation and reads race-free
 // (run with -race); the RPC layer serializes mutations today, but the
-// invariant must hold inside the package that owns the data.
+// invariant must hold inside the package that owns the data. Each spawned
+// goroutine pins its OS thread into the test netns -- netns membership is
+// per-thread, so without the pin the workers would touch the host namespace.
 func TestConcurrentBridgeAccess(t *testing.T) {
 	withTestNetns(t)
+	testNs, err := netns.Get()
+	if err != nil {
+		t.Fatalf("netns.Get: %v", err)
+	}
+	defer func() { _ = testNs.Close() }()
 	m := newTestManager(t)
 	if _, err := m.CreateBridge("br-race", 500, nil, ""); err != nil {
 		t.Fatalf("CreateBridge: %v", err)
+	}
+	inNs := func(work func()) {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		if err := netns.Set(testNs); err != nil {
+			t.Errorf("netns.Set: %v", err)
+			return
+		}
+		work()
 	}
 	var wg sync.WaitGroup
 	for i := 0; i < 4; i++ {
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
-			for j := 0; j < 25; j++ {
-				_, _ = m.CreateBridge("br-race", 500, nil, "") // idempotent adopt
-			}
+			inNs(func() {
+				for j := 0; j < 25; j++ {
+					_, _ = m.CreateBridge("br-race", 500, nil, "") // idempotent adopt
+				}
+			})
 		}()
 		go func() {
 			defer wg.Done()

--- a/pkg/netresource/state.go
+++ b/pkg/netresource/state.go
@@ -2,6 +2,7 @@ package netresource
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -43,18 +44,67 @@ func loadState(path string) (*ManagedState, error) {
 	}
 	var state ManagedState
 	if err := json.Unmarshal(data, &state); err != nil {
-		return nil, err
+		// Refuse to guess which kernel devices the daemon owns: starting with
+		// an empty state would silently abandon every managed VRF / bridge.
+		return nil, fmt.Errorf("parse state: %w (repair the file or move it aside and restart)", err)
 	}
 	return &state, nil
 }
 
-func saveState(path string, state *ManagedState) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return err
-	}
-	data, err := json.MarshalIndent(state, "", "  ")
+// persist snapshots the state under the read lock and writes it to the state
+// file atomically. Callers must NOT hold m.mu (RWMutex is not reentrant); the
+// file I/O happens outside the lock so a slow disk does not stall readers.
+func (m *ResourceManager) persist() error {
+	m.mu.RLock()
+	data, err := json.MarshalIndent(m.state, "", "  ")
+	m.mu.RUnlock()
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0644)
+	return writeFileAtomic(m.statePath, data)
+}
+
+// writeFileAtomic writes data to path through a same-directory temp file and
+// a rename, fsyncing both the file and the directory. A crash or an ENOSPC
+// mid-write leaves the previous file intact instead of a truncated one --
+// the old os.WriteFile (O_TRUNC in place) turned exactly that crash window
+// into a state file the next boot refuses to parse.
+func writeFileAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup on every early return; a no-op once the rename won.
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	// CreateTemp uses 0600; the state file is device names / table IDs, kept
+	// world-readable like the old direct write.
+	if err := os.Chmod(tmpName, 0644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	// fsync the directory so the rename itself survives a crash.
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = d.Close() }()
+	return d.Sync()
 }

--- a/pkg/netresource/state_test.go
+++ b/pkg/netresource/state_test.go
@@ -118,3 +118,32 @@ func TestPersist_FailurePropagates(t *testing.T) {
 		t.Fatal("persist onto a directory must fail")
 	}
 }
+
+// A deployment that uses no VRF/bridge features must keep booting even when
+// the state directory is unwritable: Reconcile skips the persist when there
+// is nothing to protect. With entries present a persist failure IS fatal.
+func TestReconcile_EmptyStateSkipsPersist(t *testing.T) {
+	// Failure injection that root cannot bypass: a directory occupying the
+	// state path makes the atomic write's rename step fail. It also breaks
+	// loadState (ReadFile hits EISDIR), so the manager is created while the
+	// path is free and the blocker is installed afterwards.
+	path := filepath.Join(t.TempDir(), "state.json")
+	m, err := NewResourceManager(path, zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewResourceManager: %v", err)
+	}
+	if err := os.Mkdir(path, 0755); err != nil {
+		t.Fatalf("mkdir blocker: %v", err)
+	}
+	if err := m.Reconcile(); err != nil {
+		t.Fatalf("empty-state Reconcile must not require a writable state dir: %v", err)
+	}
+	// With an entry the persist failure is fatal (the refreshed ifindex must
+	// land). The entry uses a device-less seed so no netns/netlink is needed:
+	// the lookup fails, the recreation fails on the missing member, and the
+	// error surfaces before persist -- so drive the persist path directly.
+	m.ensureBridgeInState("br-x", 1, nil, 9, "")
+	if err := m.persist(); err == nil {
+		t.Fatal("persist into an unwritable state dir must fail")
+	}
+}

--- a/pkg/netresource/state_test.go
+++ b/pkg/netresource/state_test.go
@@ -1,0 +1,120 @@
+package netresource
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// A missing state file is a fresh install, not an error.
+func TestLoadState_MissingFileStartsEmpty(t *testing.T) {
+	m, err := NewResourceManager(filepath.Join(t.TempDir(), "state.json"), zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewResourceManager on a missing file: %v", err)
+	}
+	if len(m.ListVrfs()) != 0 || len(m.ListBridges()) != 0 {
+		t.Errorf("fresh state not empty: vrfs=%v bridges=%v", m.ListVrfs(), m.ListBridges())
+	}
+}
+
+// A state file that exists but does not parse must refuse the boot with the
+// path and a repair hint -- starting empty would silently abandon every
+// managed device.
+func TestNewResourceManager_CorruptStateFails(t *testing.T) {
+	for name, content := range map[string]string{
+		"empty":     "",
+		"truncated": `{"vrfs": [{"name": "vrf1", "tab`,
+		"garbage":   "not json at all",
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "state.json")
+			if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+				t.Fatalf("write fixture: %v", err)
+			}
+			_, err := NewResourceManager(path, zap.NewNop())
+			if err == nil {
+				t.Fatal("corrupt state must fail NewResourceManager")
+			}
+			if !strings.Contains(err.Error(), path) {
+				t.Errorf("error should name the file, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), "repair") {
+				t.Errorf("error should carry the repair hint, got: %v", err)
+			}
+		})
+	}
+}
+
+// The atomic write leaves the exact content and no temp-file droppings.
+func TestWriteFileAtomic_SuccessLeavesNoTemp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	for _, content := range []string{`{"a":1}`, `{"a":2,"b":3}`} {
+		if err := writeFileAtomic(path, []byte(content)); err != nil {
+			t.Fatalf("writeFileAtomic: %v", err)
+		}
+		got, err := os.ReadFile(path)
+		if err != nil || string(got) != content {
+			t.Fatalf("content = %q (err %v), want %q", got, err, content)
+		}
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "state.json" {
+		t.Errorf("temp droppings left behind: %v", entries)
+	}
+}
+
+// A failed write leaves the previous file byte-identical -- the property the
+// temp+rename construction exists for. The old O_TRUNC write destroyed the
+// file first and wrote second.
+func TestWriteFileAtomic_FailurePreservesOldContent(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission-based failure injection is bypassed by root (CAP_DAC_OVERRIDE)")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	const old = `{"vrfs":[],"bridges":[]}`
+	if err := writeFileAtomic(path, []byte(old)); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	if err := os.Chmod(dir, 0555); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0755) })
+	if err := writeFileAtomic(path, []byte(`{"new":true}`)); err == nil {
+		t.Fatal("write into a read-only directory must fail")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != old {
+		t.Errorf("old content damaged by a failed write: %q (err %v)", got, err)
+	}
+}
+
+// persist failures surface as errors (works under root too: renaming a file
+// onto a directory fails regardless of privileges).
+func TestPersist_FailurePropagates(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	m, err := NewResourceManager(path, zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewResourceManager: %v", err)
+	}
+	if err := m.persist(); err != nil {
+		t.Fatalf("initial persist: %v", err)
+	}
+	// Replace the state file with a directory: the rename step cannot win.
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if err := os.Mkdir(path, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := m.persist(); err == nil {
+		t.Fatal("persist onto a directory must fail")
+	}
+}

--- a/pkg/netresource/vrf.go
+++ b/pkg/netresource/vrf.go
@@ -11,42 +11,20 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// CreateVrf creates (or idempotently adopts) the kernel VRF device and
+// persists it. On a persist failure the kernel device and the in-memory
+// record are NOT rolled back: the error is returned so the caller sees the
+// divergence, a retry re-adopts and converges, and the next successful
+// persist writes the whole state anyway.
 func (m *ResourceManager) CreateVrf(name string, tableID uint32, members []string, enableL3mdevRule bool) (uint32, error) {
-	// Idempotent adopt: an existing link is taken over only when it really is
-	// a VRF device on the requested table. A bare name match must not adopt —
-	// otherwise a typo like --name eth1 would put the NIC into the state file
-	// and a later delete would LinkDel it.
 	if existing, err := netlink.LinkByName(name); err == nil {
-		vrfLink, ok := existing.(*netlink.Vrf)
-		if !ok {
-			return 0, fmt.Errorf("link %s exists but is %s, not a VRF device", name, existing.Type())
+		ifindex, err := adoptVrfDevice(existing, name, tableID, members, enableL3mdevRule)
+		if err != nil {
+			return 0, err
 		}
-		if vrfLink.Table != tableID {
-			return 0, fmt.Errorf("VRF %s exists with table %d, requested %d (delete it first to change tables)", name, vrfLink.Table, tableID)
-		}
-		// Converge the adopted device on the request: bring it up (an
-		// operator-created admin-DOWN device would blackhole End.DT* decap
-		// behind a successful create), enslave any members it is missing
-		// (LinkSetMaster is idempotent for already-enslaved links) and add
-		// the l3mdev rule when asked, so an adopt is not silently weaker
-		// than a fresh create.
-		if err := netlink.LinkSetUp(existing); err != nil {
-			return 0, fmt.Errorf("set VRF %s up: %w", name, err)
-		}
-		for _, member := range members {
-			if err := enslaveInterface(member, existing); err != nil {
-				return 0, err
-			}
-		}
-		if enableL3mdevRule {
-			if err := ensureL3mdevRule(); err != nil {
-				return 0, fmt.Errorf("add l3mdev rule: %w", err)
-			}
-		}
-		ifindex := uint32(existing.Attrs().Index)
 		m.ensureVrfInState(name, tableID, members, enableL3mdevRule, ifindex)
-		if err := saveState(m.statePath, m.state); err != nil {
-			m.logger.Warn("failed to save state after VRF idempotent update", zap.Error(err))
+		if err := m.persist(); err != nil {
+			return 0, fmt.Errorf("persist state after adopting VRF %s: %w", name, err)
 		}
 		return ifindex, nil
 	}
@@ -60,13 +38,46 @@ func (m *ResourceManager) CreateVrf(name string, tableID uint32, members []strin
 	// would have failed on LinkAdd), so the upsert takes its append branch.
 	m.ensureVrfInState(name, tableID, members, enableL3mdevRule, ifindex)
 
-	if err := saveState(m.statePath, m.state); err != nil {
-		m.logger.Warn("failed to save state after VRF creation", zap.Error(err))
+	if err := m.persist(); err != nil {
+		return 0, fmt.Errorf("persist state after creating VRF %s: %w", name, err)
 	}
 
 	m.logger.Info("Created VRF",
 		zap.String("name", name), zap.Uint32("table_id", tableID), zap.Uint32("ifindex", ifindex))
 	return ifindex, nil
+}
+
+// adoptVrfDevice takes over an existing link as the managed VRF device. The
+// link is adopted only when it really is a VRF on the requested table -- a
+// bare name match must not adopt, or a typo like --name eth1 would put the
+// NIC into the state file and a later delete would LinkDel it. The adopted
+// device is converged on the request: brought up (an operator-created
+// admin-DOWN device would blackhole End.DT* decap behind a successful
+// create), missing members enslaved (LinkSetMaster is idempotent) and the
+// l3mdev rule added when asked, so an adopt is not silently weaker than a
+// fresh create. Reconcile adopts state entries through the same path.
+func adoptVrfDevice(link netlink.Link, name string, tableID uint32, members []string, enableL3mdevRule bool) (uint32, error) {
+	vrfLink, ok := link.(*netlink.Vrf)
+	if !ok {
+		return 0, fmt.Errorf("link %s exists but is %s, not a VRF device", name, link.Type())
+	}
+	if vrfLink.Table != tableID {
+		return 0, fmt.Errorf("VRF %s exists with table %d, requested %d (delete it first to change tables)", name, vrfLink.Table, tableID)
+	}
+	if err := netlink.LinkSetUp(link); err != nil {
+		return 0, fmt.Errorf("set VRF %s up: %w", name, err)
+	}
+	for _, member := range members {
+		if err := enslaveInterface(member, link); err != nil {
+			return 0, err
+		}
+	}
+	if enableL3mdevRule {
+		if err := ensureL3mdevRule(); err != nil {
+			return 0, fmt.Errorf("add l3mdev rule: %w", err)
+		}
+	}
+	return uint32(link.Attrs().Index), nil
 }
 
 func (m *ResourceManager) DeleteVrf(name string) error {
@@ -104,8 +115,11 @@ func (m *ResourceManager) DeleteVrf(name string) error {
 	m.state.VRFs = filtered
 	m.mu.Unlock()
 
-	if err := saveState(m.statePath, m.state); err != nil {
-		m.logger.Warn("failed to save state after VRF deletion", zap.Error(err))
+	if err := m.persist(); err != nil {
+		// The kernel device is gone and the record is removed in memory; the
+		// next successful persist flushes it from disk too. Surface the error
+		// so the operator knows disk state is momentarily behind.
+		return fmt.Errorf("persist state after deleting VRF %s: %w", name, err)
 	}
 
 	m.logger.Info("Deleted VRF", zap.String("name", name))
@@ -117,6 +131,11 @@ func (m *ResourceManager) ListVrfs() []ManagedVrf {
 	defer m.mu.RUnlock()
 	result := make([]ManagedVrf, len(m.state.VRFs))
 	copy(result, m.state.VRFs)
+	for i := range result {
+		// Deep-copy Members: the shallow struct copy would alias the
+		// state-owned backing array, which ensureVrfInState appends to.
+		result[i].Members = slices.Clone(result[i].Members)
+	}
 	return result
 }
 

--- a/pkg/vinbero/vinbero.go
+++ b/pkg/vinbero/vinbero.go
@@ -107,8 +107,12 @@ func (v *Vinbero) InitResourceManager() error {
 		return fmt.Errorf("init resource manager: %w", err)
 	}
 
+	// Fail-closed: a state entry that cannot be materialized aborts the boot
+	// (the error carries a repair hint). Continuing with a phantom entry
+	// would hand its stale ifindex to the FDB watcher, the EVPN machinery
+	// and the SID-reference delete guards, which then silently mis-key.
 	if err := resMgr.Reconcile(); err != nil {
-		v.logger.Warn("resource reconciliation had issues", zap.Error(err))
+		return fmt.Errorf("reconcile managed resources: %w", err)
 	}
 
 	v.resMgr = resMgr


### PR DESCRIPTION
## Summary

Hardens the JSON state persistence (`settings.state_path`) that backs the VRF/bridge facets. Three real bugs, carried as deferred items since the VRF series reviews:

- **Non-atomic writes**: the state file was written with `os.WriteFile` (O_TRUNC in place). A crash or ENOSPC between the truncate and the write destroyed it — and a destroyed file refuses the next boot, so the crash window manufactured a boot loop. Writes now go through a same-directory temp file with fsync and rename (plus a directory fsync); a failed write leaves the previous file byte-identical.
- **Persist errors demoted to warnings**: all six runtime call sites logged the save error and returned success. ENOSPC silently wiped state behind a successful RPC; a failed save after a delete resurrected the device on the next boot. Persist failures now surface as errors. The kernel device and the in-memory record are deliberately not rolled back — a retry re-adopts, and the next successful persist writes the whole state (the retry-convergence trace for detach-after-kernel-delete is in the review notes).
- **Phantom reconcile entries**: a boot reconcile that failed to recreate an entry kept it, persisted its pre-reboot ifindex, and only warned. The FDB watcher, the EVPN enable/replay machinery, and the SID-reference delete guards all key on that ifindex and silently mis-keyed. Reconcile is now fail-closed with a repair hint (restore the device or remove the entry, then restart), and adopts existing devices through the same validation and convergence as the Create paths — previously any link holding the name was accepted with a bare ifindex refresh.

Hardening on top: state marshals happen under the manager's own lock (previously six of seven save sites marshaled unlocked, serialized only by another package's mutex), List/Get return deep copies of Members, and a corrupt state file's boot refusal now carries the repair hint. An empty state skips the persist entirely, so an SRv6-only deployment with a read-only state directory keeps booting.

## Verification

- unit: new state-level tests (corrupt/truncated/empty refusal with the hint, atomic-write no-droppings, failure-preserves-old-content, persist-failure propagation, empty-state skip) and netns tests (recreate-missing, fail-closed on a stolen name / failed recreation with state-file-unchanged assertions, adopt convergence, `-race` concurrency). The netns tests pin subtest/worker threads into the test namespace — t.Run subtests run on their own goroutines and netns membership is per OS thread.
- suites: `go test ./...` + golangci-lint 0 + sudo (bpf 207s / gobgp / netresource -race / fib / netlinkwatch) all pass.
- containerlab: l3vpn-2site 8/8, evpn-2site 13/13. Live checks on the deployed lab: daemon restart restores the facet from state (regression); a ghost-member bridge entry injected into state.json refuses the boot with the exact repair-hint message and the boot recovers once the entry is removed; a truncated state.json refuses the boot with the parse hint and recovers when repaired.

## Notes

- Boot behavior change: an unmaterializable state entry (or unparseable state file) now refuses to boot instead of degrading silently — consistent with `loadVRFs`' misconfiguration-at-startup policy. The error names the entry and the repair steps.
- A recreation that fails on a missing member leaves the half-created kernel device behind (pre-existing; the retry adopts it and fails on the same member, so the error is stable).