### PR TITLE
feat(examples): headend ECMP path-group netns example with fast-reroute demo

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -144,6 +144,7 @@ jobs:
           - headend-v4
           - headend-v6
           - headend-l2
+          - headend-ecmp
           - gtp4-encap
           - gtp6-encap
           - gtp6-drop-in

--- a/cmd/vinbero-ecmpdemo/main.go
+++ b/cmd/vinbero-ecmpdemo/main.go
@@ -252,8 +252,9 @@ func main() {
 	groupFlag := &cli.UintFlag{Name: "group-id", Usage: "ECMP group id (non-zero)", Required: true}
 
 	app := &cli.App{
-		Name:  "vinbero-ecmpdemo",
-		Usage: "demo/test writer for the vinberod ECMP path-group maps",
+		Name:    "vinbero-ecmpdemo",
+		Usage:   "demo/test writer for the vinberod ECMP path-group maps",
+		Version: "dev", // enables -v, which `make test-runnable` probes on every cmd binary
 		Commands: []*cli.Command{
 			{
 				Name:  "group-put",

--- a/cmd/vinbero-ecmpdemo/main.go
+++ b/cmd/vinbero-ecmpdemo/main.go
@@ -115,11 +115,21 @@ func parsePathSpec(spec string) ([]string, uint16, error) {
 	return segs, weight, nil
 }
 
-func groupPut(c *cli.Context) error {
-	pid := c.Int("pid")
+// groupIDArg validates the shared --group-id flag: 0 is the no-group
+// sentinel (ECMP_GROUP_NONE) and never a legal operation target.
+func groupIDArg(c *cli.Context) (uint32, error) {
 	groupID := uint32(c.Uint("group-id"))
 	if groupID == bpf.EcmpGroupNone {
-		return fmt.Errorf("group-id 0 is the no-group sentinel")
+		return 0, fmt.Errorf("group-id 0 is the no-group sentinel")
+	}
+	return groupID, nil
+}
+
+func groupPut(c *cli.Context) error {
+	pid := c.Int("pid")
+	groupID, err := groupIDArg(c)
+	if err != nil {
+		return err
 	}
 	pathSpecs := c.StringSlice("path")
 	if len(pathSpecs) < 1 || len(pathSpecs) > bpf.EcmpMaxPaths {
@@ -177,7 +187,10 @@ func groupPut(c *cli.Context) error {
 }
 
 func attach(c *cli.Context) error {
-	groupID := uint32(c.Uint("group-id"))
+	groupID, err := groupIDArg(c)
+	if err != nil {
+		return err
+	}
 	maps, err := daemonMaps(c.Int("pid"), mapHeadendV4)
 	if err != nil {
 		return err
@@ -199,7 +212,10 @@ func attach(c *cli.Context) error {
 }
 
 func liveSet(c *cli.Context) error {
-	groupID := uint32(c.Uint("group-id"))
+	groupID, err := groupIDArg(c)
+	if err != nil {
+		return err
+	}
 	bitmap, err := strconv.ParseUint(c.String("bitmap"), 0, 64)
 	if err != nil {
 		return fmt.Errorf("parse bitmap %q: %w", c.String("bitmap"), err)
@@ -216,7 +232,10 @@ func liveSet(c *cli.Context) error {
 }
 
 func liveClear(c *cli.Context) error {
-	groupID := uint32(c.Uint("group-id"))
+	groupID, err := groupIDArg(c)
+	if err != nil {
+		return err
+	}
 	maps, err := daemonMaps(c.Int("pid"), mapEcmpLive)
 	if err != nil {
 		return err

--- a/cmd/vinbero-ecmpdemo/main.go
+++ b/cmd/vinbero-ecmpdemo/main.go
@@ -109,8 +109,14 @@ func parsePathSpec(spec string) ([]string, uint16, error) {
 		segsPart = spec[:at]
 	}
 	segs := strings.Split(segsPart, "+")
-	if len(segs) == 0 || segs[0] == "" {
-		return nil, 0, fmt.Errorf("path %q: at least one segment required", spec)
+	for i, s := range segs {
+		// Reject empty segments explicitly: ParseIPv6("") yields the
+		// all-zero address instead of an error, which would silently
+		// program :: as a SID.
+		segs[i] = strings.TrimSpace(s)
+		if segs[i] == "" {
+			return nil, 0, fmt.Errorf("path %q: empty segment", spec)
+		}
 	}
 	return segs, weight, nil
 }

--- a/cmd/vinbero-ecmpdemo/main.go
+++ b/cmd/vinbero-ecmpdemo/main.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -168,7 +169,7 @@ func groupPut(c *cli.Context) error {
 	if err := maps[mapEcmpGroup].Put(&groupID, &info); err != nil {
 		return fmt.Errorf("put ecmp_group_map[%d]: %w", groupID, err)
 	}
-	if err := maps[mapEcmpLive].Delete(&groupID); err != nil && !strings.Contains(err.Error(), "key does not exist") {
+	if err := maps[mapEcmpLive].Delete(&groupID); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
 		return fmt.Errorf("reset ecmp_live_map[%d]: %w", groupID, err)
 	}
 	fmt.Printf("group %d installed with %d paths\n", groupID, len(pathSpecs))
@@ -220,7 +221,7 @@ func liveClear(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := maps[mapEcmpLive].Delete(&groupID); err != nil && !strings.Contains(err.Error(), "key does not exist") {
+	if err := maps[mapEcmpLive].Delete(&groupID); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
 		return fmt.Errorf("delete ecmp_live_map[%d]: %w", groupID, err)
 	}
 	fmt.Printf("group %d liveness cleared (fail-open: all paths live)\n", groupID)

--- a/cmd/vinbero-ecmpdemo/main.go
+++ b/cmd/vinbero-ecmpdemo/main.go
@@ -1,0 +1,272 @@
+// vinbero-ecmpdemo drives the ECMP path-group data plane of a running
+// vinberod for demos and the netns example. The BGP applier is the intended
+// writer of ECMP groups and no operator-facing RPC exists yet, so this tool
+// writes the group tables directly through the daemon's map file descriptors
+// (found via /proc/<pid>/fdinfo). It is a test harness, not a management
+// interface: it bypasses the daemon's owner-tag bookkeeping on purpose and
+// will be superseded by the HeadendGroupService.
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/ebpf"
+	"github.com/urfave/cli/v2"
+
+	"github.com/takehaya/vinbero/pkg/bpf"
+)
+
+const (
+	mapHeadendV4 = "headend_v4_map"
+	mapEcmpGroup = "ecmp_group_map"
+	mapEcmpPath  = "ecmp_path_map"
+	mapEcmpLive  = "ecmp_live_map"
+)
+
+// daemonMaps opens the named BPF maps through the daemon's open file
+// descriptors. Matching by name alone via MapGetNextID would be ambiguous
+// when several vinberod instances (or other loaded collections) coexist on
+// the same kernel, so membership in the target process pins the instance.
+func daemonMaps(pid int, names ...string) (map[string]*ebpf.Map, error) {
+	wanted := make(map[string]bool, len(names))
+	for _, n := range names {
+		wanted[n] = true
+	}
+	found := make(map[string]*ebpf.Map, len(names))
+
+	fdinfoDir := fmt.Sprintf("/proc/%d/fdinfo", pid)
+	entries, err := os.ReadDir(fdinfoDir)
+	if err != nil {
+		return nil, fmt.Errorf("read %s (is %d the vinberod pid, and are we root?): %w", fdinfoDir, pid, err)
+	}
+	for _, e := range entries {
+		data, err := os.ReadFile(fdinfoDir + "/" + e.Name())
+		if err != nil {
+			continue // fd raced away
+		}
+		var mapID uint64
+		for line := range strings.SplitSeq(string(data), "\n") {
+			if v, ok := strings.CutPrefix(line, "map_id:"); ok {
+				mapID, _ = strconv.ParseUint(strings.TrimSpace(v), 10, 32)
+				break
+			}
+		}
+		if mapID == 0 {
+			continue
+		}
+		m, err := ebpf.NewMapFromID(ebpf.MapID(mapID))
+		if err != nil {
+			continue
+		}
+		info, err := m.Info()
+		if err != nil || !wanted[info.Name] || found[info.Name] != nil {
+			_ = m.Close()
+			continue
+		}
+		found[info.Name] = m
+	}
+	for _, n := range names {
+		if found[n] == nil {
+			return nil, fmt.Errorf("map %q not found among pid %d's file descriptors", n, pid)
+		}
+	}
+	return found, nil
+}
+
+// lpmKeyV4 builds the headend_v4_map trigger key from a CIDR.
+func lpmKeyV4(cidr string) (*bpf.LpmKeyV4, error) {
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, fmt.Errorf("parse trigger prefix %q: %w", cidr, err)
+	}
+	v4 := ipnet.IP.To4()
+	if v4 == nil {
+		return nil, fmt.Errorf("trigger prefix %q is not IPv4", cidr)
+	}
+	ones, _ := ipnet.Mask.Size()
+	key := &bpf.LpmKeyV4{Prefixlen: uint32(ones)}
+	copy(key.Addr[:], v4)
+	return key, nil
+}
+
+// parsePathSpec parses "sid1+sid2[@weight]" into segments and a weight.
+// Segments join with "+" because urfave/cli splits repeated string-slice
+// flags on commas.
+func parsePathSpec(spec string) ([]string, uint16, error) {
+	segsPart := spec
+	weight := uint16(1)
+	if at := strings.LastIndex(spec, "@"); at >= 0 {
+		w, err := strconv.ParseUint(spec[at+1:], 10, 16)
+		if err != nil || w == 0 {
+			return nil, 0, fmt.Errorf("path %q: weight must be a positive integer", spec)
+		}
+		weight = uint16(w)
+		segsPart = spec[:at]
+	}
+	segs := strings.Split(segsPart, "+")
+	if len(segs) == 0 || segs[0] == "" {
+		return nil, 0, fmt.Errorf("path %q: at least one segment required", spec)
+	}
+	return segs, weight, nil
+}
+
+func groupPut(c *cli.Context) error {
+	pid := c.Int("pid")
+	groupID := uint32(c.Uint("group-id"))
+	if groupID == bpf.EcmpGroupNone {
+		return fmt.Errorf("group-id 0 is the no-group sentinel")
+	}
+	pathSpecs := c.StringSlice("path")
+	if len(pathSpecs) < 1 || len(pathSpecs) > bpf.EcmpMaxPaths {
+		return fmt.Errorf("need 1..%d --path specs, got %d", bpf.EcmpMaxPaths, len(pathSpecs))
+	}
+
+	maps, err := daemonMaps(pid, mapHeadendV4, mapEcmpGroup, mapEcmpPath, mapEcmpLive)
+	if err != nil {
+		return err
+	}
+
+	// Paths inherit mode / src_addr / policy_id from the trigger entry so the
+	// tool only has to vary the segment lists.
+	key, err := lpmKeyV4(c.String("from-trigger"))
+	if err != nil {
+		return err
+	}
+	var parent bpf.HeadendEntry
+	if err := maps[mapHeadendV4].Lookup(key, &parent); err != nil {
+		return fmt.Errorf("lookup trigger %s: %w", c.String("from-trigger"), err)
+	}
+
+	// Write order per the ECMP design: path slots first, then group info, so
+	// a reader never sees num_paths pointing at an unwritten slot. Redefining
+	// a group also resets its liveness bitmap: the old bits index the old
+	// path set.
+	info := bpf.EcmpGroupInfo{NumPaths: uint8(len(pathSpecs))}
+	for i, spec := range pathSpecs {
+		segs, weight, err := parsePathSpec(spec)
+		if err != nil {
+			return err
+		}
+		segments, numSegments, err := bpf.ParseSegments(segs)
+		if err != nil {
+			return fmt.Errorf("path %q: %w", spec, err)
+		}
+		entry := parent
+		entry.Segments = segments
+		entry.NumSegments = numSegments
+		entry.GroupId = bpf.EcmpGroupNone // a path is terminal, never a group ref
+		pk := bpf.EcmpPathKey{GroupId: groupID, PathIndex: uint32(i)}
+		if err := maps[mapEcmpPath].Put(&pk, &entry); err != nil {
+			return fmt.Errorf("put ecmp_path_map[%d,%d]: %w", groupID, i, err)
+		}
+		info.Weight[i] = weight
+	}
+	if err := maps[mapEcmpGroup].Put(&groupID, &info); err != nil {
+		return fmt.Errorf("put ecmp_group_map[%d]: %w", groupID, err)
+	}
+	if err := maps[mapEcmpLive].Delete(&groupID); err != nil && !strings.Contains(err.Error(), "key does not exist") {
+		return fmt.Errorf("reset ecmp_live_map[%d]: %w", groupID, err)
+	}
+	fmt.Printf("group %d installed with %d paths\n", groupID, len(pathSpecs))
+	return nil
+}
+
+func attach(c *cli.Context) error {
+	groupID := uint32(c.Uint("group-id"))
+	maps, err := daemonMaps(c.Int("pid"), mapHeadendV4)
+	if err != nil {
+		return err
+	}
+	key, err := lpmKeyV4(c.String("trigger"))
+	if err != nil {
+		return err
+	}
+	var entry bpf.HeadendEntry
+	if err := maps[mapHeadendV4].Lookup(key, &entry); err != nil {
+		return fmt.Errorf("lookup trigger %s: %w", c.String("trigger"), err)
+	}
+	entry.GroupId = groupID
+	if err := maps[mapHeadendV4].Put(key, &entry); err != nil {
+		return fmt.Errorf("update trigger %s: %w", c.String("trigger"), err)
+	}
+	fmt.Printf("trigger %s now references group %d\n", c.String("trigger"), groupID)
+	return nil
+}
+
+func liveSet(c *cli.Context) error {
+	groupID := uint32(c.Uint("group-id"))
+	bitmap, err := strconv.ParseUint(c.String("bitmap"), 0, 64)
+	if err != nil {
+		return fmt.Errorf("parse bitmap %q: %w", c.String("bitmap"), err)
+	}
+	maps, err := daemonMaps(c.Int("pid"), mapEcmpLive)
+	if err != nil {
+		return err
+	}
+	if err := maps[mapEcmpLive].Put(&groupID, &bitmap); err != nil {
+		return fmt.Errorf("put ecmp_live_map[%d]: %w", groupID, err)
+	}
+	fmt.Printf("group %d liveness bitmap set to %#x\n", groupID, bitmap)
+	return nil
+}
+
+func liveClear(c *cli.Context) error {
+	groupID := uint32(c.Uint("group-id"))
+	maps, err := daemonMaps(c.Int("pid"), mapEcmpLive)
+	if err != nil {
+		return err
+	}
+	if err := maps[mapEcmpLive].Delete(&groupID); err != nil && !strings.Contains(err.Error(), "key does not exist") {
+		return fmt.Errorf("delete ecmp_live_map[%d]: %w", groupID, err)
+	}
+	fmt.Printf("group %d liveness cleared (fail-open: all paths live)\n", groupID)
+	return nil
+}
+
+func main() {
+	pidFlag := &cli.IntFlag{Name: "pid", Usage: "pid of the target vinberod", Required: true}
+	groupFlag := &cli.UintFlag{Name: "group-id", Usage: "ECMP group id (non-zero)", Required: true}
+
+	app := &cli.App{
+		Name:  "vinbero-ecmpdemo",
+		Usage: "demo/test writer for the vinberod ECMP path-group maps",
+		Commands: []*cli.Command{
+			{
+				Name:  "group-put",
+				Usage: "install or replace an ECMP group; paths clone the trigger entry with their own segment list",
+				Flags: []cli.Flag{
+					pidFlag, groupFlag,
+					&cli.StringFlag{Name: "from-trigger", Usage: "existing headend v4 trigger prefix to clone mode/src from", Required: true},
+					&cli.StringSliceFlag{Name: "path", Usage: "path spec \"sid1+sid2[@weight]\" (repeatable, 1..8)", Required: true},
+				},
+				Action: groupPut,
+			},
+			{
+				Name:   "attach",
+				Usage:  "point an existing headend v4 trigger entry at a group",
+				Flags:  []cli.Flag{pidFlag, groupFlag, &cli.StringFlag{Name: "trigger", Usage: "headend v4 trigger prefix", Required: true}},
+				Action: attach,
+			},
+			{
+				Name:   "live-set",
+				Usage:  "write a group's liveness bitmap (bit i = path i up)",
+				Flags:  []cli.Flag{pidFlag, groupFlag, &cli.StringFlag{Name: "bitmap", Usage: "bitmap value, e.g. 0x2", Required: true}},
+				Action: liveSet,
+			},
+			{
+				Name:   "live-clear",
+				Usage:  "delete a group's liveness entry (falls back to fail-open)",
+				Flags:  []cli.Flag{pidFlag, groupFlag},
+				Action: liveClear,
+			},
+		},
+	}
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -78,6 +78,7 @@ sudo ./teardown.sh # クリーンアップ
 | `headend-v4/` | H.Encaps (IPv4) | IPv4パケットのSRv6カプセル化 |
 | `headend-v6/` | H.Encaps (IPv6) | IPv6パケットのSRv6カプセル化 |
 | `headend-l2/` | H.Encaps.L2 | L2フレームのSRv6カプセル化 |
+| `headend-ecmp/` | H.Encaps + ECMP | headend ECMP path group と liveness fast reroute |
 
 ### Mobile (GTP-U)
 | ディレクトリ | 機能 | 説明 |

--- a/examples/headend-ecmp/README.ja.md
+++ b/examples/headend-ecmp/README.ja.md
@@ -1,0 +1,58 @@
+# headend-ecmp — Headend ECMP path group と liveness fast reroute
+
+*(English: [README.md](./README.md))*
+
+headend の ECMP path group データプレーンを実演します。1 つの HeadendV4 trigger prefix を per-flow の weighted hash で 2 本の SRv6 path に分散し、liveness bitmap への 1 word の書き込みだけで、group 定義に触れずに全フローを生存 path へ切り替えます。
+
+設計は [`docs/design/ja/ecmp.md`](../../docs/design/ja/ecmp.md) を参照してください。
+
+## トポロジ
+
+```mermaid
+graph LR
+    host1 --- router1
+    router1 -- "path 0: fc00:a::2 (End)" --- router2a
+    router1 -- "path 1: fc00:b::2 (End)" --- router2b
+    router2a --- router3
+    router2b --- router3
+    router3 --- host2
+```
+
+- `router1` は Vinbero (XDP H.Encaps) を実行します。trigger prefix `172.0.2.0/24` が等重みの 2 path を持つ ECMP group 1 を参照します。
+- `router2a` / `router2b` は Linux ネイティブの SRv6 transit ノード (`End`) です。
+- `router3` は `End.DX4` で `host2` へ終端します。
+- 復路 (`host2` → `host1`) は `router2a` 経由の Linux ネイティブ encap 1 本です。
+
+## テストで検証する内容
+
+1. ベースライン: path A 経由の Linux ネイティブ encap が end-to-end で通ること。
+2. Vinbero 単一 path: 従来どおりの HeadendV4 エントリ (group_id 0) が変わらず動くこと。
+3. ECMP 分散: source port が異なる 100 本の UDP flow が両 path に分かれること。transit ルータのインタフェースカウンタで測定します。
+4. fast reroute: liveness bitmap に `0x2` を書く (path 0 down) と全フローが path B へ移り、エントリを消すと fail-open で分散が戻ること。
+
+## group の設定方法
+
+ECMP group の本来の書き手は BGP applier で、operator 向け RPC はまだ無いため、この example では `vinbero-ecmpdemo` を使います。`make build` で `out/bin/` にビルドされるデモ用ツールで、daemon の map file descriptor 経由で group テーブルを書きます。
+
+```bash
+# trigger エントリから mode/src を引き継いで 2 path の group を作る
+vinbero-ecmpdemo group-put --pid <vinberod-pid> --group-id 1 \
+  --from-trigger 172.0.2.0/24 \
+  --path "fc00:a::2+fc00:3::3@1" \
+  --path "fc00:b::2+fc00:3::3@1"
+
+# trigger エントリを group に向ける
+vinbero-ecmpdemo attach --pid <vinberod-pid> --trigger 172.0.2.0/24 --group-id 1
+
+# path 0 を down にする / 復旧する
+vinbero-ecmpdemo live-set --pid <vinberod-pid> --group-id 1 --bitmap 0x2
+vinbero-ecmpdemo live-clear --pid <vinberod-pid> --group-id 1
+```
+
+## 実行方法
+
+```bash
+sudo ./setup.sh
+sudo ./test.sh
+sudo ./teardown.sh
+```

--- a/examples/headend-ecmp/README.md
+++ b/examples/headend-ecmp/README.md
@@ -1,0 +1,69 @@
+# headend-ecmp — Headend ECMP path group + liveness fast reroute
+
+*(日本語: [README.ja.md](./README.ja.md))*
+
+Demonstrates the headend ECMP path group data plane: one HeadendV4 trigger
+prefix fans out over two SRv6 paths by per-flow weighted hashing, and a
+one-word write to the liveness bitmap reroutes every flow to the surviving
+path without touching the group definition.
+
+See [`docs/design/ja/ecmp.md`](../../docs/design/ja/ecmp.md) for the design.
+
+## Topology
+
+```mermaid
+graph LR
+    host1 --- router1
+    router1 -- "path 0: fc00:a::2 (End)" --- router2a
+    router1 -- "path 1: fc00:b::2 (End)" --- router2b
+    router2a --- router3
+    router2b --- router3
+    router3 --- host2
+```
+
+- `router1` runs Vinbero (XDP H.Encaps). The trigger prefix `172.0.2.0/24`
+  references ECMP group 1 with two equal-weight paths.
+- `router2a` / `router2b` are plain Linux SRv6 transit nodes (`End`).
+- `router3` terminates with `End.DX4` towards `host2`.
+- The return path (`host2` → `host1`) is a single Linux native encap via
+  `router2a`.
+
+## What the test verifies
+
+1. Baseline: Linux native encap over path A works end-to-end.
+2. Vinbero single path: a plain HeadendV4 entry (group_id 0) still behaves
+   as before.
+3. ECMP spread: 100 UDP flows (distinct source ports) split across both
+   paths, measured by the transit routers' interface counters.
+4. Fast reroute: writing liveness bitmap `0x2` (path 0 down) moves all
+   flows to path B; clearing the entry fails open and restores the spread.
+
+## Configuring the group
+
+The BGP applier is the intended writer of ECMP groups and no operator RPC
+exists yet, so this example uses `vinbero-ecmpdemo` (built by `make build`
+into `out/bin/`), a demo tool that writes the daemon's group tables through
+its map file descriptors:
+
+```bash
+# Install a 2-path group, cloning mode/src from the trigger entry
+vinbero-ecmpdemo group-put --pid <vinberod-pid> --group-id 1 \
+  --from-trigger 172.0.2.0/24 \
+  --path "fc00:a::2+fc00:3::3@1" \
+  --path "fc00:b::2+fc00:3::3@1"
+
+# Point the trigger entry at the group
+vinbero-ecmpdemo attach --pid <vinberod-pid> --trigger 172.0.2.0/24 --group-id 1
+
+# Mark path 0 down / recover
+vinbero-ecmpdemo live-set --pid <vinberod-pid> --group-id 1 --bitmap 0x2
+vinbero-ecmpdemo live-clear --pid <vinberod-pid> --group-id 1
+```
+
+## Run
+
+```bash
+sudo ./setup.sh
+sudo ./test.sh
+sudo ./teardown.sh
+```

--- a/examples/headend-ecmp/setup.sh
+++ b/examples/headend-ecmp/setup.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# examples/headend-ecmp/setup.sh
+# Setup for the headend ECMP path-group demonstration: a diamond topology
+# with two parallel SRv6 paths between the Vinbero headend and the egress.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Set namespace prefix for this example (allows parallel execution)
+# Note: Linux interface names are limited to 15 chars, so use short prefix "hec-"
+export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-hec-}"
+
+source "${SCRIPT_DIR}/../common/netns.sh"
+source "${SCRIPT_DIR}/../common/veth.sh"
+source "${SCRIPT_DIR}/../common/test_utils.sh"
+
+ns_host1="${TOPO_NS_PREFIX}host1"
+ns_host2="${TOPO_NS_PREFIX}host2"
+ns_router1="${TOPO_NS_PREFIX}router1"   # Vinbero headend (H.Encaps + ECMP group)
+ns_router2a="${TOPO_NS_PREFIX}router2a" # transit path A (End)
+ns_router2b="${TOPO_NS_PREFIX}router2b" # transit path B (End)
+ns_router3="${TOPO_NS_PREFIX}router3"   # egress (End.DX4)
+
+veth_h1_rt1="${TOPO_NS_PREFIX}h1rt1"
+veth_rt1_h1="${TOPO_NS_PREFIX}rt1h1"
+veth_rt1_r2a="${TOPO_NS_PREFIX}rt1r2a"
+veth_r2a_rt1="${TOPO_NS_PREFIX}r2art1"
+veth_rt1_r2b="${TOPO_NS_PREFIX}rt1r2b"
+veth_r2b_rt1="${TOPO_NS_PREFIX}r2brt1"
+veth_r2a_rt3="${TOPO_NS_PREFIX}r2art3"
+veth_rt3_r2a="${TOPO_NS_PREFIX}rt3r2a"
+veth_r2b_rt3="${TOPO_NS_PREFIX}r2brt3"
+veth_rt3_r2b="${TOPO_NS_PREFIX}rt3r2b"
+veth_rt3_h2="${TOPO_NS_PREFIX}rt3h2"
+veth_h2_rt3="${TOPO_NS_PREFIX}h2rt3"
+
+check_root
+
+run() { echo "+ $*"; "$@"; }
+
+print_info "Creating namespaces..."
+for ns in "$ns_host1" "$ns_host2" "$ns_router1" "$ns_router2a" "$ns_router2b" "$ns_router3"; do
+    create_netns "$ns"
+done
+
+print_info "Wiring the diamond topology..."
+create_veth_pair "$veth_h1_rt1" "$ns_host1" "$veth_rt1_h1" "$ns_router1"
+create_veth_pair "$veth_rt1_r2a" "$ns_router1" "$veth_r2a_rt1" "$ns_router2a"
+create_veth_pair "$veth_rt1_r2b" "$ns_router1" "$veth_r2b_rt1" "$ns_router2b"
+create_veth_pair "$veth_r2a_rt3" "$ns_router2a" "$veth_rt3_r2a" "$ns_router3"
+create_veth_pair "$veth_r2b_rt3" "$ns_router2b" "$veth_rt3_r2b" "$ns_router3"
+create_veth_pair "$veth_rt3_h2" "$ns_router3" "$veth_h2_rt3" "$ns_host2"
+
+print_info "Assigning addresses..."
+configure_veth "$ns_host1" "$veth_h1_rt1" 172.0.1.1/24
+configure_veth "$ns_router1" "$veth_rt1_h1" 172.0.1.254/24
+configure_veth "$ns_router1" "$veth_rt1_r2a" fc00:12a::1/64
+configure_veth "$ns_router2a" "$veth_r2a_rt1" fc00:12a::2/64
+configure_veth "$ns_router1" "$veth_rt1_r2b" fc00:12b::1/64
+configure_veth "$ns_router2b" "$veth_r2b_rt1" fc00:12b::2/64
+configure_veth "$ns_router2a" "$veth_r2a_rt3" fc00:2a3::2/64
+configure_veth "$ns_router3" "$veth_rt3_r2a" fc00:2a3::3/64
+configure_veth "$ns_router2b" "$veth_r2b_rt3" fc00:2b3::2/64
+configure_veth "$ns_router3" "$veth_rt3_r2b" fc00:2b3::3/64
+configure_veth "$ns_router3" "$veth_rt3_h2" 172.0.2.254/24
+configure_veth "$ns_host2" "$veth_h2_rt3" 172.0.2.1/24
+
+print_info "Enabling forwarding and SRv6..."
+for ns in "$ns_router1" "$ns_router2a" "$ns_router2b" "$ns_router3"; do
+    ns_sysctl "$ns" net.ipv4.ip_forward 1
+    ns_sysctl "$ns" net.ipv6.conf.all.forwarding 1
+    ns_sysctl "$ns" net.ipv6.conf.all.seg6_enabled 1
+    ns_sysctl "$ns" net.ipv6.conf.default.seg6_enabled 1
+done
+for dev in "$veth_rt1_h1" "$veth_rt1_r2a" "$veth_rt1_r2b"; do
+    ns_sysctl "$ns_router1" net.ipv6.conf.${dev}.seg6_enabled 1
+    ns_sysctl "$ns_router1" net.ipv4.conf.${dev}.rp_filter 0
+done
+# The effective rp_filter is max(all, device), and a new netns inherits the
+# host's conf.all value on some systems. The decapped return traffic has no
+# matching IPv4 route on the decap routers, so force it off entirely.
+ns_sysctl "$ns_router1" net.ipv4.conf.all.rp_filter 0
+ns_sysctl "$ns_router3" net.ipv4.conf.all.rp_filter 0
+ns_sysctl "$ns_router2a" net.ipv6.conf.${veth_r2a_rt1}.seg6_enabled 1
+ns_sysctl "$ns_router2b" net.ipv6.conf.${veth_r2b_rt1}.seg6_enabled 1
+ns_sysctl "$ns_router3" net.ipv6.conf.${veth_rt3_r2a}.seg6_enabled 1
+ns_sysctl "$ns_router3" net.ipv6.conf.${veth_rt3_r2b}.seg6_enabled 1
+ns_sysctl "$ns_router3" net.ipv4.conf.${veth_rt3_h2}.rp_filter 0
+ns_sysctl "$ns_router3" net.ipv4.conf.${veth_rt3_r2a}.rp_filter 0
+ns_sysctl "$ns_router3" net.ipv4.conf.${veth_rt3_r2b}.rp_filter 0
+
+print_info "Configuring hosts..."
+run ip netns exec "$ns_host1" ip route add default via 172.0.1.254
+run ip netns exec "$ns_host2" ip route add default via 172.0.2.254
+
+print_info "Configuring router1 (Vinbero headend)..."
+# Underlay routes towards each path's first SID (used by the XDP FIB lookup)
+run ip netns exec "$ns_router1" ip -6 route add fc00:a::/64 via fc00:12a::2 dev "$veth_rt1_r2a"
+run ip netns exec "$ns_router1" ip -6 route add fc00:b::/64 via fc00:12b::2 dev "$veth_rt1_r2b"
+# Baseline Linux native encap over path A (replaced by Vinbero in test.sh)
+run ip netns exec "$ns_router1" ip route add 172.0.2.0/24 encap seg6 mode encap segs fc00:a::2,fc00:3::3 dev "$veth_rt1_r2a"
+# Return path terminator: host2 -> host1
+run ip netns exec "$ns_router1" ip -6 route add local fc00:1::1/128 encap seg6local action End.DX4 nh4 172.0.1.1 dev "$veth_rt1_h1"
+
+print_info "Configuring router2a (transit, path A)..."
+run ip netns exec "$ns_router2a" ip -6 route add local fc00:a::2/128 encap seg6local action End dev lo
+run ip netns exec "$ns_router2a" ip -6 route add fc00:3::/64 via fc00:2a3::3 dev "$veth_r2a_rt3"
+run ip netns exec "$ns_router2a" ip -6 route add fc00:1::/64 via fc00:12a::1 dev "$veth_r2a_rt1"
+
+print_info "Configuring router2b (transit, path B)..."
+run ip netns exec "$ns_router2b" ip -6 route add local fc00:b::2/128 encap seg6local action End dev lo
+run ip netns exec "$ns_router2b" ip -6 route add fc00:3::/64 via fc00:2b3::3 dev "$veth_r2b_rt3"
+run ip netns exec "$ns_router2b" ip -6 route add fc00:1::/64 via fc00:12b::1 dev "$veth_r2b_rt1"
+
+print_info "Configuring router3 (egress End.DX4)..."
+run ip netns exec "$ns_router3" ip -6 route add local fc00:3::3/128 encap seg6local action End.DX4 nh4 172.0.2.1 dev "$veth_rt3_h2"
+# Return path: host2 -> host1 rides a single-SID encap through path A
+run ip netns exec "$ns_router3" ip route add 172.0.1.0/24 encap seg6 mode encap segs fc00:1::1 dev "$veth_rt3_r2a"
+run ip netns exec "$ns_router3" ip -6 route add fc00:1::/64 via fc00:2a3::2 dev "$veth_rt3_r2a"
+
+echo ""
+echo "=========================================="
+echo "SRv6 Headend ECMP Setup Complete!"
+echo "=========================================="
+echo "Topology (diamond):"
+echo "                    router2a (fc00:a::2, End)"
+echo "                   /                          \\"
+echo "  host1 -- router1 (Vinbero H.Encaps + group)  router3 (fc00:3::3, End.DX4) -- host2"
+echo "                   \\                          /"
+echo "                    router2b (fc00:b::2, End)"
+echo ""
+echo "ECMP path group (installed in test.sh):"
+echo "  path 0: fc00:a::2, fc00:3::3  (via router2a)"
+echo "  path 1: fc00:b::2, fc00:3::3  (via router2b)"
+echo ""
+print_success "Ready for testing!"

--- a/examples/headend-ecmp/teardown.sh
+++ b/examples/headend-ecmp/teardown.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# examples/headend-ecmp/teardown.sh
+# Cleanup the headend ECMP demonstration environment
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Set namespace prefix (must match setup.sh)
+export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-hec-}"
+
+source "${SCRIPT_DIR}/../common/netns.sh"
+
+for ns in host1 host2 router1 router2a router2b router3; do
+    delete_netns "${TOPO_NS_PREFIX}${ns}"
+done
+
+echo "Teardown complete"

--- a/examples/headend-ecmp/test.sh
+++ b/examples/headend-ecmp/test.sh
@@ -117,8 +117,8 @@ wait_vinbero_ready "$ns_router1" "127.0.0.1:8082" 10
 # Resolve NDP towards both next hops first: bpf_fib_lookup returns NO_NEIGH
 # for unresolved neighbors and the headend would drop the first flows.
 print_info "Pre-resolving NDP to both next hops..."
-ip netns exec "$ns_router1" ping6 -c 2 -W 2 fc00:12a::2 > /dev/null
-ip netns exec "$ns_router1" ping6 -c 2 -W 2 fc00:12b::2 > /dev/null
+ip netns exec "$ns_router1" ping6 -c 2 -W 2 fc00:12a::2 > /dev/null || true
+ip netns exec "$ns_router1" ping6 -c 2 -W 2 fc00:12b::2 > /dev/null || true
 
 print_info "Registering HeadendV4 trigger entry (path A as its segment list)..."
 ip netns exec "$ns_router1" ${VINBERO_BIN} -s http://127.0.0.1:8082 hv4 create \

--- a/examples/headend-ecmp/test.sh
+++ b/examples/headend-ecmp/test.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+# examples/headend-ecmp/test.sh
+# Test the headend ECMP path group: per-flow spread over two paths and
+# liveness-driven fast reroute.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../common/test_utils.sh"
+
+check_root
+
+VINBEROD_BIN="${SCRIPT_DIR}/../../out/bin/vinberod"
+VINBERO_BIN="${SCRIPT_DIR}/../../out/bin/vinbero"
+ECMPDEMO_BIN="${SCRIPT_DIR}/../../out/bin/vinbero-ecmpdemo"
+VINBERO_CONFIG="${SCRIPT_DIR}/vinbero_router1.yaml"
+
+# Set namespace prefix (must match setup.sh)
+export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-hec-}"
+ns_host1="${TOPO_NS_PREFIX}host1"
+ns_host2="${TOPO_NS_PREFIX}host2"
+ns_router1="${TOPO_NS_PREFIX}router1"
+ns_router2a="${TOPO_NS_PREFIX}router2a"
+ns_router2b="${TOPO_NS_PREFIX}router2b"
+if_path_a="${TOPO_NS_PREFIX}r2art1"  # router2a's interface facing router1
+if_path_b="${TOPO_NS_PREFIX}r2brt1"  # router2b's interface facing router1
+
+GROUP_ID=1
+NUM_FLOWS=100
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+VINBERO_PID=""
+
+if [ ! -x "$ECMPDEMO_BIN" ]; then
+    print_error "vinbero-ecmpdemo not found at ${ECMPDEMO_BIN}. Build it first from the repo root: make build"
+    exit 1
+fi
+
+cleanup() {
+    # Guard against PID reuse: only kill if the PID is still our vinberod.
+    if [ -n "$VINBERO_PID" ] && [ "$(ps -o comm= -p "$VINBERO_PID" 2>/dev/null)" = "vinberod" ]; then
+        kill "$VINBERO_PID" 2>/dev/null || true
+        wait "$VINBERO_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+# rx_packets of the router1-facing interface on each transit router. Forward
+# traffic is the only bulk stream in that direction, so deltas isolate the
+# per-path load.
+rx_path_a() { ip netns exec "$ns_router2a" cat "/sys/class/net/${if_path_a}/statistics/rx_packets"; }
+rx_path_b() { ip netns exec "$ns_router2b" cat "/sys/class/net/${if_path_b}/statistics/rx_packets"; }
+
+# Send NUM_FLOWS single-datagram UDP flows from host1 to host2. Every
+# datagram uses a fresh ephemeral source port, so each one is a distinct
+# 5-tuple for the headend's flow hash.
+send_flows() {
+    for _ in $(seq 1 "$NUM_FLOWS"); do
+        ip netns exec "$ns_host1" bash -c 'echo -n x > /dev/udp/172.0.2.1/33434' 2>/dev/null || true
+    done
+}
+
+# assert_spread <label> <min_a> <min_b> <max_a> — sends flows, then checks
+# the per-path packet deltas against the bounds ("" = unbounded).
+assert_spread() {
+    local label="$1" min_a="$2" min_b="$3" max_a="${4:-}"
+    local a0 b0 a1 b1 da db
+    a0=$(rx_path_a); b0=$(rx_path_b)
+    send_flows
+    sleep 0.5
+    a1=$(rx_path_a); b1=$(rx_path_b)
+    da=$((a1 - a0)); db=$((b1 - b0))
+    print_info "$label: path A carried $da packets, path B carried $db packets (of $NUM_FLOWS flows)"
+    local ok=1
+    [ "$da" -ge "$min_a" ] || { print_error "$label: path A carried $da packets, want >= $min_a"; ok=0; }
+    [ "$db" -ge "$min_b" ] || { print_error "$label: path B carried $db packets, want >= $min_b"; ok=0; }
+    if [ -n "$max_a" ] && [ "$da" -gt "$max_a" ]; then
+        print_error "$label: path A carried $da packets, want <= $max_a"
+        ok=0
+    fi
+    if [ "$ok" -eq 1 ]; then
+        print_success "$label: PASS"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+echo "=========================================="
+echo "SRv6 Headend ECMP Path Group Test"
+echo "=========================================="
+echo ""
+
+# Phase 1: Linux native single-path baseline
+echo "=========================================="
+echo "Phase 1: Linux Native SRv6 (Baseline, path A only)"
+echo "=========================================="
+
+test_ping_with_counter "$ns_host1" 172.0.2.1 "host1 -> host2 (Linux native T.Encaps via path A)"
+
+print_info "Removing Linux native encap route from $ns_router1..."
+ip netns exec "$ns_router1" ip route del 172.0.2.0/24 2>/dev/null || true
+
+echo ""
+
+# Phase 2: Vinbero single-path headend
+echo "=========================================="
+echo "Phase 2: Vinbero XDP H.Encaps (single path)"
+echo "=========================================="
+
+print_info "Starting Vinbero on $ns_router1..."
+start_vinbero "$ns_router1" "${VINBERO_CONFIG}" "/tmp/vinbero_ecmp_test.log"
+VINBERO_PID=$VINBERO_LAST_PID
+wait_vinbero_ready "$ns_router1" "127.0.0.1:8082" 10
+
+# Resolve NDP towards both next hops first: bpf_fib_lookup returns NO_NEIGH
+# for unresolved neighbors and the headend would drop the first flows.
+print_info "Pre-resolving NDP to both next hops..."
+ip netns exec "$ns_router1" ping6 -c 2 -W 2 fc00:12a::2 > /dev/null
+ip netns exec "$ns_router1" ping6 -c 2 -W 2 fc00:12b::2 > /dev/null
+
+print_info "Registering HeadendV4 trigger entry (path A as its segment list)..."
+ip netns exec "$ns_router1" ${VINBERO_BIN} -s http://127.0.0.1:8082 hv4 create \
+  --trigger-prefix 172.0.2.0/24 --src-addr fc00:1::1 --segments fc00:a::2,fc00:3::3 > /dev/null
+print_success "HeadendV4 entry registered"
+sleep 1
+
+test_ping_with_counter "$ns_host1" 172.0.2.1 "host1 -> host2 (Vinbero XDP, single path)"
+test_ping_with_counter "$ns_host2" 172.0.1.1 "host2 -> host1 (return path)"
+
+echo ""
+
+# Phase 3: ECMP path group
+echo "=========================================="
+echo "Phase 3: ECMP path group (2 equal-weight paths)"
+echo "=========================================="
+
+print_info "Installing ECMP group ${GROUP_ID} and attaching the trigger entry..."
+"$ECMPDEMO_BIN" group-put --pid "$VINBERO_PID" --group-id "$GROUP_ID" \
+  --from-trigger 172.0.2.0/24 \
+  --path "fc00:a::2+fc00:3::3@1" \
+  --path "fc00:b::2+fc00:3::3@1"
+"$ECMPDEMO_BIN" attach --pid "$VINBERO_PID" --trigger 172.0.2.0/24 --group-id "$GROUP_ID"
+
+test_ping_with_counter "$ns_host1" 172.0.2.1 "host1 -> host2 (via ECMP group)"
+
+# jhash over 100 distinct 5-tuples: each equal-weight path must take a
+# substantial share. 15% is far below the binomial mean (50%) but far above
+# what a broken constant hash would yield.
+assert_spread "flow spread across both paths" 15 15
+
+echo ""
+
+# Phase 4: liveness-driven fast reroute
+echo "=========================================="
+echo "Phase 4: Fast reroute via the liveness bitmap"
+echo "=========================================="
+
+print_info "Marking path 0 (via router2a) down: bitmap 0x2..."
+"$ECMPDEMO_BIN" live-set --pid "$VINBERO_PID" --group-id "$GROUP_ID" --bitmap 0x2
+
+# All flows must shift to path B; a small allowance on path A absorbs
+# unrelated control traffic (NDP) on the counter.
+assert_spread "all flows on surviving path B" 0 80 5
+test_ping_with_counter "$ns_host1" 172.0.2.1 "host1 -> host2 (rerouted to path B)"
+
+print_info "Clearing the liveness entry (fail-open: all paths live)..."
+"$ECMPDEMO_BIN" live-clear --pid "$VINBERO_PID" --group-id "$GROUP_ID"
+
+assert_spread "spread restored after live-clear" 15 15
+
+print_info "Stopping Vinbero..."
+kill $VINBERO_PID 2>/dev/null || true
+wait $VINBERO_PID 2>/dev/null || true
+
+echo ""
+echo "=========================================="
+echo "Test Summary"
+echo "=========================================="
+echo "Passed: $TESTS_PASSED"
+echo "Failed: $TESTS_FAILED"
+echo ""
+
+if [ $TESTS_FAILED -gt 0 ]; then
+    print_error "Some tests failed"
+    exit 1
+else
+    print_success "All tests passed!"
+    exit 0
+fi

--- a/examples/headend-ecmp/vinbero_router1.yaml
+++ b/examples/headend-ecmp/vinbero_router1.yaml
@@ -1,0 +1,27 @@
+internal:
+  devices:
+    - hec-rt1h1   # Interface towards host1
+    - hec-rt1r2a  # Interface towards router2a (path A)
+    - hec-rt1r2b  # Interface towards router2b (path B)
+  bpf:
+    device_mode: generic  # Required for veth pairs
+    verifier_log_level: 2
+    verifier_log_size: 1073741823
+  server:
+    bind: "127.0.0.1:8082"
+  logger:
+    level: debug
+    format: text
+    no_color: false
+    add_caller: true
+
+settings:
+  entries:
+    sid_function:
+      capacity: 1024
+    headendv4:
+      capacity: 1024
+    headendv6:
+      capacity: 1024
+    ecmp_group:
+      capacity: 64


### PR DESCRIPTION
## Summary

A diamond-topology netns example (`examples/headend-ecmp/`) for the ECMP path group data plane merged in #101, following the e2e verification item in the ECMP plan:

- one HeadendV4 trigger prefix fans 100 UDP flows (distinct source ports) out over two SRv6 paths by per-flow weighted hashing; the spread is asserted via the transit routers' interface counters (measured locally: 47/53)
- writing liveness bitmap `0x2` (path 0 down) moves every flow to the surviving path (measured: 0/100) without touching the group definition; clearing the entry fails open and restores the spread
- phases 1-2 keep the usual baseline structure: Linux native encap, then a plain single-path Vinbero headend entry (`group_id` 0)

## vinbero-ecmpdemo

The BGP applier is the intended writer of ECMP groups and no operator RPC exists yet (`HeadendGroupService` is a later phase), so the example drives the group tables with a small demo tool, `cmd/vinbero-ecmpdemo`:

- reaches the running daemon's maps through `/proc/<pid>` file descriptors — name matching alone cannot pin the instance when several loaded collections coexist on one kernel
- `group-put` clones mode/src from the trigger entry, follows the paths-then-info write order, and resets the liveness bitmap on redefine, mirroring `PutEcmpGroup`
- `attach` / `live-set` / `live-clear` cover trigger binding and the prober's one-word reroute
- it is a test harness by design (it bypasses owner-tag bookkeeping) and will be superseded by the HeadendGroupService

## Notes

- setup forces `net.ipv4.conf.all.rp_filter=0` on the decap routers: the effective check is max(all, device), a fresh netns can inherit a nonzero conf.all from the host, and the decapped return traffic has no matching IPv4 route
- added to the CI `Integration Test` matrix and the examples README table

## Testing

- `sudo ./setup.sh && sudo ./test.sh && sudo ./teardown.sh`: 8/8 PASS locally
- `golangci-lint run cmd/vinbero-ecmpdemo/`: clean