### PR TITLE
ci(bpf): add kernel 7.0 to BPF load test matrix

### DIFF
--- a/.github/workflows/bpf_load_test.yaml
+++ b/.github/workflows/bpf_load_test.yaml
@@ -29,6 +29,7 @@ jobs:
           - "6.1"
           - "6.6"
           - "6.12"
+          - "7.0"
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
## Summary

BPF load test の kernel matrix に 7.0 を追加します。

- `ghcr.io/cilium/ci-kernels` に `7.0` タグが公開されているのを確認済みです
- ローカルで `make test-bpf-load VIMTO_KERNEL=7.0` を実行し、`TestBpfLoad` と `TestBpfLoad_PinMapsRoundTrip` の両方が PASS することを確認しました

## Test plan

- [x] ローカル vimto + QEMU で kernel 7.0 の load test が PASS
- [x] CI の `BPF load test (kernel 7.0)` job が green