### PR TITLE
docs(readme): scope the interop bullet to the CI scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 
 ### 🔧 Miscellaneous Chores
 
-* **interop-clab:** keep proprietary MUP interop assets out of the public repo ([#92](https://github.com/takehaya/Vinbero/issues/92)) ([9e07595](https://github.com/takehaya/Vinbero/commit/9e07595216cbcb7e302174973cb8f7dcd26595d6))
+* **interop-clab:** move the license-restricted interop assets to a private overlay repo ([#92](https://github.com/takehaya/Vinbero/issues/92)) ([9e07595](https://github.com/takehaya/Vinbero/commit/9e07595216cbcb7e302174973cb8f7dcd26595d6))
 * **interop-clab:** neutral overlay paths in .gitignore ([#93](https://github.com/takehaya/Vinbero/issues/93)) ([1ff91de](https://github.com/takehaya/Vinbero/commit/1ff91de02c5ff05eb81c5947f65e99c48fec29e4))
 
 ## [0.0.9](https://github.com/takehaya/Vinbero/compare/v0.0.8...v0.0.9) (2026-06-03)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://github.com/takehaya/Vinbero-legacy/tree/master) has become outdated, so 
 - **eBPF/XDP + TC fast path** — kernel-resident packet forwarding, the only open-source SRv6 stack that does EVPN L2VPN on eBPF.
 - **In-process BGP** — GoBGP v4 inside `vinberod`, no sidecar. VPNv4/VPNv6, EVPN (SRv6), MUP, SR Policy.
 - **Unified VRF binding** — one `vbctl vrf-bgp bind --rt FAMILY:RT:DIRECTION` drives import/export policy and auto-advertise across every AF.
-- **Interop tested** — FRR (L3VPN/EVPN) in CI under `examples/interop-clab/scenarios/`; MUP additionally validated against a third-party commercial router.
+- **Interop tested** — FRR (L3VPN/EVPN) in CI under `examples/interop-clab/scenarios/`.
 - **Custom XDP plugins** — reserved tail-call slots, runtime register via `vinbero plugin`. SDK in `sdk/`.
 - **Connect RPC + gRPC** — every primitive reachable over HTTP/2.
 


### PR DESCRIPTION
The interop bullet claimed validation beyond what the public repo reproduces. Narrow it to the FRR scenarios that actually run in CI under `examples/interop-clab/scenarios/`.