### PR TITLE
fix(server): proxy circuit lifecycle (OCR review follow-up 2)

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -158,7 +158,7 @@ func (s *Server) Setup() {
 	s.logger.Info("Registered LocatorService", zap.String("path", path))
 
 	// SidFunction service
-	sidFunctionServer := NewSidFunctionServer(s.mapOps, pluginServer, s.locatorMgr)
+	sidFunctionServer := NewSidFunctionServer(s.mapOps, pluginServer, s.locatorMgr, s.logger.Named("sid_function"))
 	path, handler = vinberov1connect.NewSidFunctionServiceHandler(sidFunctionServer)
 	s.mux.Handle(path, handler)
 	s.logger.Info("Registered SidFunctionService", zap.String("path", path))

--- a/pkg/server/sid_function.go
+++ b/pkg/server/sid_function.go
@@ -9,9 +9,11 @@ import (
 	"net"
 	"net/netip"
 	"strings"
+	"sync"
 
 	"connectrpc.com/connect"
 	"github.com/cilium/ebpf/btf"
+	"go.uber.org/zap"
 
 	v1 "github.com/takehaya/vinbero/api/vinbero/v1"
 	"github.com/takehaya/vinbero/pkg/bpf"
@@ -61,15 +63,25 @@ type SidFunctionServer struct {
 	mapOps     *bpf.MapOperations
 	pluginAux  AuxTypeLookup
 	locatorMgr *locator.Manager
+	logger     *zap.Logger
+	// mu serializes the create/delete/flush mutation handlers so the
+	// proxy return-circuit lifecycle stays consistent: the same-SID
+	// re-bind in CreateServiceIngress is a read-then-write, and the
+	// capture-then-delete / capture-then-flush ordering would otherwise
+	// race a concurrent unbind. Zero value is usable.
+	mu sync.Mutex
 }
 
 // NewSidFunctionServer creates a new SidFunctionServer. pluginAux may be
 // nil (plugin_aux_json then fails loudly). locatorMgr may also be nil,
 // in which case any SidFunctionCreate carrying a locator_ref is rejected
 // with a clear error -- legacy direct trigger_prefix requests still go
-// through.
-func NewSidFunctionServer(mapOps *bpf.MapOperations, pluginAux AuxTypeLookup, locatorMgr *locator.Manager) *SidFunctionServer {
-	return &SidFunctionServer{mapOps: mapOps, pluginAux: pluginAux, locatorMgr: locatorMgr}
+// through. logger may be nil (a no-op logger is used).
+func NewSidFunctionServer(mapOps *bpf.MapOperations, pluginAux AuxTypeLookup, locatorMgr *locator.Manager, logger *zap.Logger) *SidFunctionServer {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &SidFunctionServer{mapOps: mapOps, pluginAux: pluginAux, locatorMgr: locatorMgr, logger: logger}
 }
 
 // SidFunctionCreate creates SID function entries
@@ -81,6 +93,9 @@ func (s *SidFunctionServer) SidFunctionCreate(
 		Created: make([]*v1.SidFunction, 0),
 		Errors:  make([]*v1.OperationError, 0),
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	for _, sidFunc := range req.Msg.SidFunctions {
 		if err := s.createOneSidFunction(sidFunc); err != nil {
@@ -124,6 +139,14 @@ func (s *SidFunctionServer) createOneSidFunction(sidFunc *v1.SidFunction) error 
 	if err != nil {
 		return err
 	}
+
+	// Capture the circuit the existing entry for this trigger_prefix (if
+	// any) already owns. CreateSidFunction is an upsert, so a re-create
+	// that moves the SID to a different circuit — or turns it into a
+	// non-proxy action — must unbind the old circuit or it is orphaned
+	// forever (a permanent black-hole on that port, surviving restart via
+	// the pinned map).
+	oldIf, oldVlan, hadOldCircuit := s.captureProxyCircuit(sidFunc.TriggerPrefix)
 
 	// Proxy SIDs bind their return circuit before the SID goes live so the
 	// draft's one-proxy-per-IFACE-IN rule is enforced atomically
@@ -172,6 +195,24 @@ func (s *SidFunctionServer) createOneSidFunction(sidFunc *v1.SidFunction) error 
 		}
 	}
 	committed = true
+
+	// The SID is live on its new circuit. If it previously owned a
+	// different circuit (moved, or became a non-proxy action), drop the
+	// stale binding now. Skip when the circuit is unchanged: the bind
+	// above already replaced it (same-SID re-bind).
+	if hadOldCircuit {
+		newProxy := isProxyAction(v1.Srv6LocalAction(entry.Action))
+		newIf := sidFunc.GetIfaceIn()
+		newVlan := uint16(sidFunc.GetVlanIn())
+		if !newProxy || oldIf != newIf || oldVlan != newVlan {
+			if err := s.mapOps.DeleteServiceIngress(oldIf, oldVlan); err != nil {
+				s.logger.Warn("failed to unbind the superseded proxy return circuit",
+					zap.String("trigger_prefix", sidFunc.TriggerPrefix),
+					zap.Uint32("iface_in", oldIf), zap.Uint32("vlan_in", uint32(oldVlan)),
+					zap.Error(err))
+			}
+		}
+	}
 	return nil
 }
 
@@ -241,33 +282,51 @@ func (s *SidFunctionServer) SidFunctionDelete(
 		Errors:                 make([]*v1.OperationError, 0),
 	}
 
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	for _, prefix := range req.Msg.TriggerPrefixes {
-		// Capture the proxy return circuit before the SID (and its aux)
-		// disappears; unbind it only after the delete succeeds.
-		circuitIf, circuitVlan, hasCircuit := s.captureProxyCircuit(prefix)
-		if err := s.mapOps.DeleteSidFunction(prefix, bpf.OwnerRPC); err != nil {
+		if err := s.deleteOneSidFunction(prefix); err != nil {
 			resp.Errors = append(resp.Errors, &v1.OperationError{
 				TriggerPrefix: prefix,
 				Reason:        err.Error(),
 			})
 			continue
 		}
-		// Locator-minted SIDs return their function value to the pool.
-		// Bindings for direct trigger_prefix SIDs simply miss the lookup
-		// (Manager.ReleaseSID is a no-op for unknown sids).
-		if s.locatorMgr != nil {
-			if sid, err := parseLocatorSID(prefix); err == nil {
-				s.locatorMgr.ReleaseSID(sid)
-			}
-		}
-		// End.B6 policy is cleaned up automatically with aux entry
-		if hasCircuit {
-			_ = s.mapOps.DeleteServiceIngress(circuitIf, circuitVlan)
-		}
 		resp.DeletedTriggerPrefixes = append(resp.DeletedTriggerPrefixes, prefix)
 	}
 
 	return connect.NewResponse(resp), nil
+}
+
+// deleteOneSidFunction removes one SID and unbinds its proxy return
+// circuit. The circuit is captured before the delete (the aux that holds
+// iface_in/vlan_in is gone afterwards) and unbound only after the delete
+// succeeds, so a non-RPC-owned SID (which DeleteSidFunction refuses) keeps
+// its circuit. Caller holds s.mu.
+func (s *SidFunctionServer) deleteOneSidFunction(prefix string) error {
+	circuitIf, circuitVlan, hasCircuit := s.captureProxyCircuit(prefix)
+	if err := s.mapOps.DeleteSidFunction(prefix, bpf.OwnerRPC); err != nil {
+		return err
+	}
+	// Locator-minted SIDs return their function value to the pool.
+	// Bindings for direct trigger_prefix SIDs simply miss the lookup
+	// (Manager.ReleaseSID is a no-op for unknown sids).
+	if s.locatorMgr != nil {
+		if sid, err := parseLocatorSID(prefix); err == nil {
+			s.locatorMgr.ReleaseSID(sid)
+		}
+	}
+	// End.B6 policy is cleaned up automatically with the aux entry.
+	if hasCircuit {
+		if err := s.mapOps.DeleteServiceIngress(circuitIf, circuitVlan); err != nil {
+			s.logger.Warn("failed to unbind the proxy return circuit on delete",
+				zap.String("trigger_prefix", prefix),
+				zap.Uint32("iface_in", circuitIf), zap.Uint32("vlan_in", uint32(circuitVlan)),
+				zap.Error(err))
+		}
+	}
+	return nil
 }
 
 // SidFunctionList lists all SID function entries
@@ -314,27 +373,31 @@ func (s *SidFunctionServer) SidFunctionFlush(
 	ctx context.Context,
 	req *connect.Request[v1.SidFunctionFlushRequest],
 ) (*connect.Response[v1.SidFunctionFlushResponse], error) {
-	// Collect proxy return circuits before the SIDs (and their aux
-	// entries) are gone, then unbind them after the flush.
-	type circuit struct {
-		ifaceIn uint32
-		vlanIn  uint16
-	}
-	var circuits []circuit
-	if entries, err := s.mapOps.ListSidFunctions(); err == nil {
-		for prefix := range entries {
-			if ifaceIn, vlanIn, ok := s.captureProxyCircuit(prefix); ok {
-				circuits = append(circuits, circuit{ifaceIn, vlanIn})
-			}
-		}
-	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-	count, err := s.mapOps.FlushSidFunctions(bpf.OwnerRPC)
+	// Flush per-prefix through the same owner-scoped delete the Delete RPC
+	// uses, so a circuit is unbound only for a SID actually flushed. The
+	// previous implementation collected circuits from every owner's SIDs
+	// and unbound them all, which orphaned nothing but stole the return
+	// circuit of a still-live BGP-owned proxy SID (a plaintext-leaking
+	// fail-open). It also swallowed a ListSidFunctions failure, silently
+	// leaking every circuit; that is now a hard error.
+	entries, err := s.mapOps.ListSidFunctions()
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	for _, c := range circuits {
-		_ = s.mapOps.DeleteServiceIngress(c.ifaceIn, c.vlanIn)
+	var count uint32
+	for prefix := range entries {
+		err := s.deleteOneSidFunction(prefix)
+		if err == nil {
+			count++
+			continue
+		}
+		if errors.Is(err, bpf.ErrEntryOwnerMismatch) {
+			continue // not RPC-owned: leave the SID and its circuit alone
+		}
+		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	return connect.NewResponse(&v1.SidFunctionFlushResponse{DeletedCount: count}), nil
 }
@@ -346,6 +409,9 @@ func (s *SidFunctionServer) protoToEntry(sidFunc *v1.SidFunction) (*bpf.SidFunct
 	// with the action used to derive the plugin owner tag. Reject up front.
 	if sidFunc.Action < 0 || sidFunc.Action > 255 {
 		return nil, nil, fmt.Errorf("action %d out of uint8 range [0, 255]", sidFunc.Action)
+	}
+	if err := validateProxyFieldScope(sidFunc); err != nil {
+		return nil, nil, err
 	}
 	entry := &bpf.SidFunctionEntry{
 		Action: uint8(sidFunc.Action),
@@ -547,6 +613,28 @@ func (s *SidFunctionServer) protoToEntry(sidFunc *v1.SidFunction) (*bpf.SidFunct
 	return entry, aux, nil
 }
 
+// validateProxyFieldScope rejects behavior-specific fields set on the
+// wrong action, instead of silently accepting and dropping them. The
+// nearby buildServiceIngress already rejects segments / src_addr on the
+// dynamic behaviors with a teaching message; these three fields were the
+// remaining ones that a caller could set with no effect and no error
+// (hop_limit_margin is echoed only for AD, service_name only for AN, so a
+// Get→Create round-trip would silently lose them — the exact
+// protoToEntry/entryToProto asymmetry the project forbids).
+func validateProxyFieldScope(sidFunc *v1.SidFunction) error {
+	action := v1.Srv6LocalAction(sidFunc.Action)
+	if sidFunc.HopLimitMargin != nil && action != v1.Srv6LocalAction_SRV6_LOCAL_ACTION_END_AD {
+		return fmt.Errorf("hop_limit_margin applies to END_AD only (the dynamic cache refresh threshold)")
+	}
+	if sidFunc.ServiceName != nil && action != v1.Srv6LocalAction_SRV6_LOCAL_ACTION_END_AN {
+		return fmt.Errorf("service_name applies to END_AN only (the NF-catalog metadata)")
+	}
+	if sidFunc.InnerType != v1.Srv6ProxyInnerType_SRV6_PROXY_INNER_TYPE_UNSPECIFIED && !isProxyAction(action) {
+		return fmt.Errorf("inner_type applies to the proxy actions (END_AS / END_AD / END_AM) only")
+	}
+	return nil
+}
+
 // isProxyAction reports whether the action is a service-programming proxy
 // that owns a return circuit in service_ingress_map.
 func isProxyAction(action v1.Srv6LocalAction) bool {
@@ -678,7 +766,7 @@ func (s *SidFunctionServer) buildServiceIngress(sidFunc *v1.SidFunction) (*bpf.S
 		entry.Behavior = bpf.SvcRetAM
 		return entry, nil
 
-	default: // END_AS
+	case v1.Srv6LocalAction_SRV6_LOCAL_ACTION_END_AS:
 		if len(sidFunc.Segments) == 0 {
 			return nil, fmt.Errorf("END_AS requires segments (the static CACHE the return path re-encapsulates with)")
 		}
@@ -701,6 +789,12 @@ func (s *SidFunctionServer) buildServiceIngress(sidFunc *v1.SidFunction) (*bpf.S
 			Segments:    segments,
 		}
 		return entry, nil
+
+	default:
+		// isProxyAction gates the call to exactly AS/AD/AM today; a new
+		// proxy behavior added there but not here must fail loudly, not
+		// fall through to an AS-shaped binding with a wrong-slot tail call.
+		return nil, fmt.Errorf("action %s is not a service-programming proxy", v1.Srv6LocalAction(sidFunc.Action))
 	}
 }
 
@@ -853,10 +947,20 @@ func (s *SidFunctionServer) entryToProto(prefix string, entry *bpf.SidFunctionEn
 				case v1.Srv6LocalAction_SRV6_LOCAL_ACTION_END_AS:
 					// End.AS only: the static CACHE lives in the return-
 					// circuit binding (AD learns it per-chain, AM carries
-					// the state inside the packet — nothing to show).
+					// the state inside the packet — nothing to show). A
+					// live End.AS SID always has a binding with segments
+					// (buildServiceIngress requires them), so a lookup
+					// failure here is an inconsistency, not empty data —
+					// log it rather than returning a SID that reads as
+					// "no segments".
 					if ing, err := s.mapOps.GetServiceIngress(svc.IfaceIn, svc.VlanIn); err == nil {
 						sf.Segments = bpf.FormatSegments(ing.Encap.Segments, ing.Encap.NumSegments)
 						sf.SrcAddr = bpf.FormatIPv6(ing.Encap.SrcAddr)
+					} else {
+						s.logger.Warn("END_AS SID has no return-circuit binding (its static CACHE is unreadable)",
+							zap.String("trigger_prefix", prefix),
+							zap.Uint32("iface_in", svc.IfaceIn), zap.Uint32("vlan_in", uint32(svc.VlanIn)),
+							zap.Error(err))
 					}
 				}
 

--- a/pkg/server/sid_function_circuit_test.go
+++ b/pkg/server/sid_function_circuit_test.go
@@ -1,0 +1,139 @@
+package server
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	v1 "github.com/takehaya/vinbero/api/vinbero/v1"
+	"github.com/takehaya/vinbero/pkg/bpf"
+)
+
+// newLiveSidServer builds a SidFunctionServer backed by a real BPF map
+// collection. Requires sudo (the CI Unit Test job runs `go test -exec
+// "sudo -E"`); loading is skipped with a clear message otherwise.
+func newLiveSidServer(t *testing.T) (*SidFunctionServer, *bpf.MapOperations) {
+	t.Helper()
+	objs, err := bpf.ReadCollection(nil, nil)
+	if err != nil {
+		t.Skipf("BPF collection load failed (needs sudo): %v", err)
+	}
+	t.Cleanup(func() { _ = objs.Close() })
+	mapOps := bpf.NewMapOperations(objs)
+	return NewSidFunctionServer(mapOps, nil, nil, nil), mapOps
+}
+
+func adProxy(prefix string, ifaceIn, oif uint32) *v1.SidFunction {
+	in := ifaceIn
+	return &v1.SidFunction{
+		Action:        v1.Srv6LocalAction_SRV6_LOCAL_ACTION_END_AD,
+		TriggerPrefix: prefix,
+		Oif:           oif,
+		IfaceIn:       &in,
+		InnerType:     v1.Srv6ProxyInnerType_SRV6_PROXY_INNER_TYPE_IPV4,
+	}
+}
+
+func createSid(t *testing.T, s *SidFunctionServer, sf *v1.SidFunction) {
+	t.Helper()
+	resp, err := s.SidFunctionCreate(context.Background(),
+		connect.NewRequest(&v1.SidFunctionCreateRequest{SidFunctions: []*v1.SidFunction{sf}}))
+	if err != nil {
+		t.Fatalf("SidFunctionCreate: %v", err)
+	}
+	if len(resp.Msg.Errors) != 0 {
+		t.Fatalf("SidFunctionCreate errors: %v", resp.Msg.Errors)
+	}
+}
+
+// TestSidFunctionCircuitLifecycle covers the server-level proxy circuit
+// lifecycle: bind on create, orphan cleanup when a re-create moves or
+// drops the circuit, and unbind (with ad_cache cleanup) on delete.
+func TestSidFunctionCircuitLifecycle(t *testing.T) {
+	s, mapOps := newLiveSidServer(t)
+	const prefix = "fc00:2::10/128"
+
+	t.Run("create binds the circuit", func(t *testing.T) {
+		createSid(t, s, adProxy(prefix, 5, 5))
+		if _, err := mapOps.GetServiceIngress(5, 0); err != nil {
+			t.Fatalf("circuit not bound after create: %v", err)
+		}
+	})
+
+	t.Run("re-create on a new circuit unbinds the old one", func(t *testing.T) {
+		createSid(t, s, adProxy(prefix, 6, 6))
+		if _, err := mapOps.GetServiceIngress(6, 0); err != nil {
+			t.Fatalf("new circuit not bound: %v", err)
+		}
+		if _, err := mapOps.GetServiceIngress(5, 0); err == nil {
+			t.Fatalf("old circuit was orphaned (still bound after the SID moved)")
+		}
+	})
+
+	t.Run("re-create as a non-proxy action unbinds the circuit", func(t *testing.T) {
+		createSid(t, s, &v1.SidFunction{
+			Action:        v1.Srv6LocalAction_SRV6_LOCAL_ACTION_END,
+			TriggerPrefix: prefix,
+		})
+		if _, err := mapOps.GetServiceIngress(6, 0); err == nil {
+			t.Fatalf("circuit survived the SID becoming a non-proxy action")
+		}
+	})
+
+	t.Run("delete unbinds the circuit", func(t *testing.T) {
+		createSid(t, s, adProxy(prefix, 7, 7))
+		resp, err := s.SidFunctionDelete(context.Background(),
+			connect.NewRequest(&v1.SidFunctionDeleteRequest{TriggerPrefixes: []string{prefix}}))
+		if err != nil {
+			t.Fatalf("SidFunctionDelete: %v", err)
+		}
+		if len(resp.Msg.Errors) != 0 {
+			t.Fatalf("delete errors: %v", resp.Msg.Errors)
+		}
+		// The chained ad_cache delete is covered by pkg/bpf's
+		// TestServiceIngressLifecycle; here we assert the server-level
+		// unbind on delete.
+		if _, err := mapOps.GetServiceIngress(7, 0); err == nil {
+			t.Fatalf("circuit survived delete")
+		}
+	})
+}
+
+// TestSidFunctionFlushOwnerScope verifies that an RPC flush does not
+// unbind the return circuit of a proxy SID owned by another writer (a
+// BGP-owned SID), which the previous all-owner collection did — stealing
+// a live SID's circuit and leaking its decapsulated traffic.
+func TestSidFunctionFlushOwnerScope(t *testing.T) {
+	s, mapOps := newLiveSidServer(t)
+
+	// An RPC-owned proxy SID (will be flushed).
+	createSid(t, s, adProxy("fc00:2::20/128", 8, 8))
+
+	// A BGP-owned proxy SID installed directly (survives an RPC flush).
+	bgpEntry := &bpf.SidFunctionEntry{Action: uint8(v1.Srv6LocalAction_SRV6_LOCAL_ACTION_END_AD)}
+	svc := &bpf.SidAuxService{IfaceOut: 9, IfaceIn: 9, InnerType: bpf.SvcInnerIPv4}
+	bgpOwner := bpf.OwnerBGPVPN(65000, "65000:100")
+	if err := mapOps.CreateSidFunction("fc00:2::21/128", bgpEntry, bpf.NewSidAuxService(svc), bgpOwner); err != nil {
+		t.Fatalf("create BGP SID: %v", err)
+	}
+	if _, err := mapOps.CreateServiceIngress(9, 0, &bpf.ServiceIngressEntry{
+		Behavior: bpf.SvcRetAD, InnerTypeMask: bpf.SvcInnerIPv4,
+		Sid: netip.MustParseAddr("fc00:2::21").As16(),
+	}); err != nil {
+		t.Fatalf("bind BGP circuit: %v", err)
+	}
+
+	if _, err := s.SidFunctionFlush(context.Background(),
+		connect.NewRequest(&v1.SidFunctionFlushRequest{})); err != nil {
+		t.Fatalf("SidFunctionFlush: %v", err)
+	}
+
+	if _, err := mapOps.GetServiceIngress(8, 0); err == nil {
+		t.Fatalf("RPC-owned circuit survived the flush")
+	}
+	if _, err := mapOps.GetServiceIngress(9, 0); err != nil {
+		t.Fatalf("BGP-owned circuit was unbound by an RPC flush: %v", err)
+	}
+}

--- a/pkg/server/sid_function_test.go
+++ b/pkg/server/sid_function_test.go
@@ -13,7 +13,7 @@ import (
 // s.mapOps; tests that exercise raw / index / range-check paths can therefore
 // share this minimal server without spinning up real BPF maps.
 func newProtoToEntryServer() *SidFunctionServer {
-	return NewSidFunctionServer(nil, nil, nil)
+	return NewSidFunctionServer(nil, nil, nil, nil)
 }
 
 // pluginAction returns a v1.Srv6LocalAction value inside the endpoint plugin
@@ -629,6 +629,63 @@ func TestProtoToEntry_EndAN(t *testing.T) {
 		})
 		if err == nil || !strings.Contains(err.Error(), "service_name") {
 			t.Fatalf("expected the service_name length error, got %v", err)
+		}
+	})
+}
+
+// TestProtoToEntry_ProxyFieldScope covers validateProxyFieldScope: a
+// behavior-specific field set on the wrong action must be rejected, not
+// silently accepted and dropped (the protoToEntry/entryToProto asymmetry
+// the project forbids).
+func TestProtoToEntry_ProxyFieldScope(t *testing.T) {
+	s := newProtoToEntryServer()
+
+	t.Run("hop_limit_margin on non-AD rejected", func(t *testing.T) {
+		margin := uint32(4)
+		_, _, err := s.protoToEntry(&v1.SidFunction{
+			Action:         v1.Srv6LocalAction_SRV6_LOCAL_ACTION_END_DT4,
+			TriggerPrefix:  "fc00:1::1/128",
+			HopLimitMargin: &margin,
+		})
+		if err == nil || !strings.Contains(err.Error(), "hop_limit_margin applies to END_AD only") {
+			t.Fatalf("expected the hop_limit_margin scope error, got %v", err)
+		}
+	})
+
+	t.Run("service_name on non-AN rejected", func(t *testing.T) {
+		name := "demo"
+		_, _, err := s.protoToEntry(&v1.SidFunction{
+			Action:        v1.Srv6LocalAction_SRV6_LOCAL_ACTION_END,
+			TriggerPrefix: "fc00:1::1/128",
+			ServiceName:   &name,
+		})
+		if err == nil || !strings.Contains(err.Error(), "service_name applies to END_AN only") {
+			t.Fatalf("expected the service_name scope error, got %v", err)
+		}
+	})
+
+	t.Run("inner_type on non-proxy rejected", func(t *testing.T) {
+		_, _, err := s.protoToEntry(&v1.SidFunction{
+			Action:        v1.Srv6LocalAction_SRV6_LOCAL_ACTION_END_DT4,
+			TriggerPrefix: "fc00:1::1/128",
+			InnerType:     v1.Srv6ProxyInnerType_SRV6_PROXY_INNER_TYPE_IPV4,
+		})
+		if err == nil || !strings.Contains(err.Error(), "inner_type applies to the proxy actions") {
+			t.Fatalf("expected the inner_type scope error, got %v", err)
+		}
+	})
+
+	t.Run("inner_type on a proxy action is allowed", func(t *testing.T) {
+		in := uint32(1)
+		_, _, err := s.protoToEntry(&v1.SidFunction{
+			Action:        v1.Srv6LocalAction_SRV6_LOCAL_ACTION_END_AD,
+			TriggerPrefix: "fc00:2::1/128",
+			Oif:           1,
+			IfaceIn:       &in,
+			InnerType:     v1.Srv6ProxyInnerType_SRV6_PROXY_INNER_TYPE_IPV4,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error for a valid END_AD: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## 概要

service programming review の残 should-fix のうち control-plane lifecycle 系を対応します。#112 (dataplane hardening) に続く 2 本目。データプレーン変更なし (server のみ)。

## 修正 (レビュー findings)

- **mutation mutex**: create/delete/flush を直列化。CreateServiceIngress の same-SID re-bind (read-then-write) と capture-then-delete の順序が concurrent unbind と race する TOCTOU を解消 (security I-1)
- **orphan on re-create**: proxy SID を別 iface_in/vlan で再作成、または非 proxy action に変えたとき、旧 return circuit を unbind。従来は旧 binding が恒久 orphan (そのポートが永久 black-hole、pinned map で再起動も生存) でした (principal 1、security 5、quality F2)
- **flush の owner scope**: Delete RPC と同じ owner-scoped delete を per-prefix で回し、実際に flush した SID の circuit だけ unbind。従来の all-owner 収集は、生きている BGP-owned proxy SID の return circuit を奪い (decapsulated plaintext の fail-open leak)、pre-flush listing 失敗時に全 circuit を silent leak していました (security I-2/4、quality F1) — listing 失敗は hard error に
- **silent error の surface**: SidFunctionServer に logger を通し、circuit unbind 失敗や End.AS SID の return-circuit binding 読み取り失敗を warn。従来はエラー握り潰し (quality F3/F4、principal 2)
- **field scope 検証**: behavior 固有 field を別 action に付けた場合を reject (hop_limit_margin を非 AD、service_name を非 AN、inner_type を非 proxy)。従来は accept + silent drop で protoToEntry/entryToProto asymmetry (project invariant 違反、quality F7、principal 3)。buildServiceIngress の `default: // END_AS` を explicit case + erroring default に (quality F6、principal 4)

## テスト

- server-level lifecycle テスト (live BPF map、sudo Unit Test job で実行): orphan-on-re-create cleanup、非 proxy 再作成の unbind、delete unbind、owner-scoped flush protection
- unit テスト: field-scope validation の 4 ケース
- `go test -exec sudo -race ./pkg/server/ ./pkg/bpf/` green、golangci-lint 0 issues

## 残 (別 PR / 要 design 判断)

dataplane correctness 系 (AD 復路の flow-label 再導出 = ECMP、publish protocol の seqlock 化、AS return の length clamp、L3 circuit FIB miss の fail-closed 統一) と、observability (service return per-slot stats)、docs/design/ja/service_programming.md、CLI list 列は次以降。trust boundary の clarifying question 次第で AS length / FIB-miss の severity が決まります。