### PR TITLE
feat(bgp): carry per-path identity on received routes

### DIFF
--- a/cmd/vinberod/main.go
+++ b/cmd/vinberod/main.go
@@ -430,6 +430,7 @@ func startBGPSession(ctx context.Context, session bgp.Session, cfg config.BGPCon
 			Families:        families,
 			Passive:         p.Passive,
 			ConnectRetrySec: p.ConnectRetrySec,
+			AddPathsReceive: p.AddPathsReceive,
 		}); err != nil {
 			return err
 		}

--- a/docs/design/ja/ecmp.md
+++ b/docs/design/ja/ecmp.md
@@ -75,6 +75,16 @@ plugin の shared map partition では `ecmp_group_map`、`ecmp_path_map`、`ecm
 
 `headend_entry` と `tailcall_ctx` のサイズが変わるため、この変更は plugin ABI break です。plugin SDK は v4 に bump し、旧 SDK でコンパイル済みの plugin ELF は `PluginRegister` の MapReplacements 互換チェックで弾かれるので、v4 ヘッダで再コンパイルしてください。
 
+## BGP path identity
+
+data plane が複数 path を持てても、受信側が path を区別できなければ group を組めません。gobgp は同一 NLRI に対する複数 PE の path をそれぞれ配送していますが、Vinbero の変換は送信元を捨てていたため、2 本目の PE の広告が 1 本目の更新と区別できませんでした。
+
+そこで `RouteEvent` に `PathSource{Peer, PathID}` を載せます。`Peer` は学習元の neighbor で、自ノード発の path では zero 値になります。`PathID` は RFC 7911 の ADD-PATH 識別子で、ADD-PATH を negotiate していなければ 0 です。peer 内でのみ一意なので、path の識別は必ず 2 つ組で行い `PathID` 単体では行いません。
+
+変換は `pathToRouteEvent` の 1 箇所に集約されていて、live の subscription と loc-rib snapshot の両方がここを通ります。したがって path identity は watch と `ListRoutes` と replay のすべてに同時に反映されます。
+
+peer 設定の `add_paths_receive` で ADD-PATH の receive を negotiate します。route reflector 配下では必要です。reflector は既定で prefix ごとに best path だけを reflect するので、これを有効にしないと他の PE の path はそもそも届かず、受信側で何をしても復元できません。iBGP full mesh では各 PE が自分の path を直接送るため不要です。送信方向は有効にしません。Vinbero は自分の NLRI について複数 path を広告しないので、使わない capability を negotiate しないためです。
+
 ## 制約と今後
 
 - `mup_uplink_v4/v6_map` の値も `headend_entry` ですが、behavior プログラム内で lookup されるため group 解決を通りません。`CreateMupUplinkV4/V6` が書き込み時に `group_id` を 0 に強制します。

--- a/pkg/bgp/bgp.go
+++ b/pkg/bgp/bgp.go
@@ -223,7 +223,8 @@ type PathSource struct {
 // learned from a neighbor.
 func (s PathSource) IsLocal() bool { return !s.Peer.IsValid() }
 
-// String renders the source as "peer[#pathid]" for logs and map keys.
+// String renders the source for logs: "local" for a locally originated
+// path, "peer" when no ADD-PATH id applies, and "peer#pathid" otherwise.
 func (s PathSource) String() string {
 	if s.IsLocal() {
 		return "local"

--- a/pkg/bgp/bgp.go
+++ b/pkg/bgp/bgp.go
@@ -126,6 +126,19 @@ type PeerConfig struct {
 	// default is 120s; a smaller value reconnects faster after a startup or
 	// transient failure. Governs the pre-establishment dial only.
 	ConnectRetrySec uint32
+	// AddPathsReceive negotiates ADD-PATH receive (RFC 7911) for every
+	// family of this neighbor, so the peer may send several paths for one
+	// NLRI and each arrives with its own PathID.
+	//
+	// It matters behind a route reflector, which by default reflects only
+	// its best path per NLRI: without ADD-PATH the client simply never sees
+	// the other PEs' paths and no amount of receiver-side work recovers
+	// them. In an iBGP full mesh every PE already sends its own path
+	// directly, so this is not needed there.
+	//
+	// This is receive-only. Vinbero does not advertise multiple paths for
+	// its own NLRIs, so the send direction stays off.
+	AddPathsReceive bool
 }
 
 // PeerState is a read-only snapshot of a neighbor's session.
@@ -187,11 +200,49 @@ type RouteAdvertiser interface {
 	Withdraw(ctx context.Context, key RouteKey) error
 }
 
+// PathSource identifies which BGP path an update came from, so a consumer
+// can hold several paths for one NLRI instead of collapsing them.
+//
+// Without it a receiver can only key on the NLRI, and a second PE
+// advertising the same prefix is indistinguishable from an update to the
+// first PE's route. That is what blocks ECMP: the paths are all present on
+// the wire and gobgp delivers each one, but the receiver has nowhere to put
+// the second.
+//
+// Peer is the neighbor the path was learned from, and is the zero Addr for
+// a locally originated path (which is how ListRoutes tells the two apart).
+// PathID is the ADD-PATH identifier (RFC 7911) as sent by that peer; it is
+// 0 unless ADD-PATH receive is negotiated, and is only unique within a
+// peer, so a path is identified by the pair and never by PathID alone.
+type PathSource struct {
+	Peer   netip.Addr
+	PathID uint32
+}
+
+// IsLocal reports whether the path was originated by this node rather than
+// learned from a neighbor.
+func (s PathSource) IsLocal() bool { return !s.Peer.IsValid() }
+
+// String renders the source as "peer[#pathid]" for logs and map keys.
+func (s PathSource) String() string {
+	if s.IsLocal() {
+		return "local"
+	}
+	if s.PathID == 0 {
+		return s.Peer.String()
+	}
+	return fmt.Sprintf("%s#%d", s.Peer, s.PathID)
+}
+
 // RouteEvent is a single received BGP route update delivered to a
 // RouteHandler. IsWithdraw distinguishes a withdrawal from an
 // advertisement.
 type RouteEvent struct {
-	Family     Family
+	Family Family
+	// Source identifies the path this update belongs to. Consumers that
+	// keep per-path state must include it in their key; consumers that
+	// only track the NLRI can ignore it.
+	Source     PathSource
 	VPN        *VPNRoute
 	Unicast    *UnicastRoute
 	SRPolicy   *SRPolicy

--- a/pkg/bgp/bgp.go
+++ b/pkg/bgp/bgp.go
@@ -224,7 +224,8 @@ type PathSource struct {
 func (s PathSource) IsLocal() bool { return !s.Peer.IsValid() }
 
 // String renders the source for logs: "local" for a locally originated
-// path, "peer" when no ADD-PATH id applies, and "peer#pathid" otherwise.
+// path, the bare peer address when no ADD-PATH id applies, and
+// "<peer address>#<path id>" otherwise.
 func (s PathSource) String() string {
 	if s.IsLocal() {
 		return "local"

--- a/pkg/bgp/bgp_test.go
+++ b/pkg/bgp/bgp_test.go
@@ -1,6 +1,9 @@
 package bgp
 
-import "testing"
+import (
+	"net/netip"
+	"testing"
+)
 
 // N3 regression: MUPRoute.Family classifies an IPv4-mapped IPv6 endpoint
 // (::ffff:a.b.c.d) as FamilyMUPIPv4. Without Addr.Unmap, netip.Addr.Is4
@@ -95,4 +98,55 @@ func TestValidateIPv6NextHop(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestPathSource covers the identity ECMP aggregation keys on. The zero
+// value must read as "locally originated", because that is what gobgp
+// hands back for this node's own advertisements and ListRoutes uses it to
+// skip them.
+func TestPathSource(t *testing.T) {
+	peer := netip.MustParseAddr("fd00::1")
+
+	t.Run("zero value is local", func(t *testing.T) {
+		var s PathSource
+		if !s.IsLocal() {
+			t.Error("zero PathSource must report IsLocal")
+		}
+		if got := s.String(); got != "local" {
+			t.Errorf("String() = %q, want %q", got, "local")
+		}
+	})
+
+	t.Run("peer without add-path", func(t *testing.T) {
+		s := PathSource{Peer: peer}
+		if s.IsLocal() {
+			t.Error("a path from a peer must not report IsLocal")
+		}
+		if got, want := s.String(), "fd00::1"; got != want {
+			t.Errorf("String() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("peer with add-path id", func(t *testing.T) {
+		s := PathSource{Peer: peer, PathID: 3}
+		if got, want := s.String(), "fd00::1#3"; got != want {
+			t.Errorf("String() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("comparable and usable as a map key", func(t *testing.T) {
+		// The accumulator keys per-path state on this struct, so it must be
+		// comparable and must not collide across peers or path ids.
+		seen := map[PathSource]int{}
+		seen[PathSource{Peer: peer, PathID: 1}]++
+		seen[PathSource{Peer: peer, PathID: 2}]++
+		seen[PathSource{Peer: netip.MustParseAddr("fd00::2"), PathID: 1}]++
+		seen[PathSource{Peer: peer, PathID: 1}]++
+		if len(seen) != 3 {
+			t.Fatalf("distinct sources collapsed: got %d keys, want 3", len(seen))
+		}
+		if n := seen[PathSource{Peer: peer, PathID: 1}]; n != 2 {
+			t.Errorf("repeat of one source counted %d times, want 2", n)
+		}
+	})
 }

--- a/pkg/bgp/gobgp/session.go
+++ b/pkg/bgp/gobgp/session.go
@@ -170,7 +170,7 @@ func (s *Session) AddPeer(ctx context.Context, p bgp.PeerConfig) error {
 	if srv == nil {
 		return bgp.ErrSessionNotStarted
 	}
-	afiSafis, err := familiesToAfiSafis(p.Families)
+	afiSafis, err := familiesToAfiSafis(p.Families, p.AddPathsReceive)
 	if err != nil {
 		return fmt.Errorf("add peer %s: %w", p.Neighbor, err)
 	}
@@ -271,16 +271,31 @@ func familyToAPI(f bgp.Family) (*gobgpapi.Family, error) {
 	}
 }
 
-func familiesToAfiSafis(fs []bgp.Family) ([]*gobgpapi.AfiSafi, error) {
+// familiesToAfiSafis builds the per-family capability set for a neighbor.
+// addPathsReceive applies to every family: ADD-PATH is negotiated per
+// AFI/SAFI, and a peer that reflects multiple paths for one family
+// generally does so for all of them, so Vinbero does not expose a
+// per-family knob for it.
+//
+// Only the receive direction is enabled. SendMax is left 0 (send
+// disabled): Vinbero originates one path per NLRI, so advertising ADD-PATH
+// send would negotiate a capability it never exercises.
+func familiesToAfiSafis(fs []bgp.Family, addPathsReceive bool) ([]*gobgpapi.AfiSafi, error) {
 	out := make([]*gobgpapi.AfiSafi, 0, len(fs))
 	for _, f := range fs {
 		fam, err := familyToAPI(f)
 		if err != nil {
 			return nil, err
 		}
-		out = append(out, &gobgpapi.AfiSafi{
+		as := &gobgpapi.AfiSafi{
 			Config: &gobgpapi.AfiSafiConfig{Family: fam, Enabled: true},
-		})
+		}
+		if addPathsReceive {
+			as.AddPaths = &gobgpapi.AddPaths{
+				Config: &gobgpapi.AddPathsConfig{Receive: true},
+			}
+		}
+		out = append(out, as)
 	}
 	return out, nil
 }

--- a/pkg/bgp/gobgp/subscriber.go
+++ b/pkg/bgp/gobgp/subscriber.go
@@ -67,12 +67,20 @@ func (s *Session) Subscribe(filter bgp.Family, handler bgp.RouteHandler) (func()
 // pathToRouteEvent converts a gobgp received Path into a Vinbero
 // RouteEvent. VPN families are fully decoded (RD / prefix / SRv6 SID /
 // route targets / next hop); IPv6 unicast carries prefix and next hop.
+//
+// This is the single conversion point for both the live subscription and
+// the loc-rib snapshot, so the path identity it attaches below reaches
+// every consumer of either.
 func pathToRouteEvent(p *apiutil.Path) (bgp.RouteEvent, bool) {
 	fam, ok := apiFamilyToVinbero(p.Family)
 	if !ok {
 		return bgp.RouteEvent{}, false
 	}
-	ev := bgp.RouteEvent{Family: fam, IsWithdraw: p.Withdrawal}
+	ev := bgp.RouteEvent{
+		Family:     fam,
+		Source:     pathSource(p),
+		IsWithdraw: p.Withdrawal,
+	}
 	switch fam {
 	case bgp.FamilyVPNv4, bgp.FamilyVPNv6:
 		ev.VPN = decodeVPNRoute(p, fam)
@@ -89,6 +97,18 @@ func pathToRouteEvent(p *apiutil.Path) (bgp.RouteEvent, bool) {
 		ev.MUP = decodeMUPRoute(p)
 	}
 	return ev, true
+}
+
+// pathSource extracts the path's identity: which neighbor sent it and,
+// when ADD-PATH receive is negotiated, which of that neighbor's paths it
+// is. gobgp names the received ADD-PATH identifier RemoteID (LocalID is
+// the id gobgp would use when re-advertising, which is not this path's
+// identity on the wire we learned it from).
+//
+// A locally originated path has no source address, which leaves Peer as
+// the zero Addr and makes PathSource.IsLocal report true.
+func pathSource(p *apiutil.Path) bgp.PathSource {
+	return bgp.PathSource{Peer: p.PeerAddress, PathID: p.RemoteID}
 }
 
 // apiFamilyToVinbero maps a gobgp route family to a Vinbero Family.

--- a/pkg/bgp/gobgp/subscriber_test.go
+++ b/pkg/bgp/gobgp/subscriber_test.go
@@ -2,6 +2,7 @@ package gobgp
 
 import (
 	"errors"
+	"net/netip"
 	"testing"
 
 	"github.com/osrg/gobgp/v4/pkg/apiutil"
@@ -70,6 +71,100 @@ func TestPathToRouteEvent(t *testing.T) {
 	t.Run("unconsumed-family-skipped", func(t *testing.T) {
 		if _, ok := pathToRouteEvent(&apiutil.Path{Family: gobgppkt.RF_IPv4_UC}); ok {
 			t.Error("pathToRouteEvent should skip families Vinbero does not consume")
+		}
+	})
+}
+
+// TestPathToRouteEventSource covers the path identity the ECMP aggregation
+// depends on. Two PEs advertising one prefix reach the receiver as two
+// events that differ only in Source, so dropping it (as the conversion did
+// before) makes them indistinguishable and collapses them to one path.
+func TestPathToRouteEventSource(t *testing.T) {
+	peerA := netip.MustParseAddr("fd00::a")
+	peerB := netip.MustParseAddr("fd00::b")
+
+	t.Run("peer address and path id are carried", func(t *testing.T) {
+		ev, ok := pathToRouteEvent(&apiutil.Path{
+			Family: gobgppkt.RF_IPv6_VPN, PeerAddress: peerA, RemoteID: 7,
+		})
+		if !ok {
+			t.Fatal("pathToRouteEvent returned ok=false")
+		}
+		if ev.Source.Peer != peerA {
+			t.Errorf("Source.Peer = %v, want %v", ev.Source.Peer, peerA)
+		}
+		if ev.Source.PathID != 7 {
+			t.Errorf("Source.PathID = %d, want 7", ev.Source.PathID)
+		}
+		if ev.Source.IsLocal() {
+			t.Error("a path learned from a peer must not report IsLocal")
+		}
+	})
+
+	t.Run("distinct peers yield distinct sources", func(t *testing.T) {
+		a, _ := pathToRouteEvent(&apiutil.Path{Family: gobgppkt.RF_IPv6_VPN, PeerAddress: peerA})
+		b, _ := pathToRouteEvent(&apiutil.Path{Family: gobgppkt.RF_IPv6_VPN, PeerAddress: peerB})
+		if a.Source == b.Source {
+			t.Fatal("two PEs must not share a PathSource; ECMP cannot separate them")
+		}
+	})
+
+	t.Run("add-path ids separate paths from one peer", func(t *testing.T) {
+		a, _ := pathToRouteEvent(&apiutil.Path{Family: gobgppkt.RF_IPv6_VPN, PeerAddress: peerA, RemoteID: 1})
+		b, _ := pathToRouteEvent(&apiutil.Path{Family: gobgppkt.RF_IPv6_VPN, PeerAddress: peerA, RemoteID: 2})
+		if a.Source == b.Source {
+			t.Fatal("ADD-PATH ids from one peer must produce distinct sources")
+		}
+	})
+
+	t.Run("locally originated path has no peer", func(t *testing.T) {
+		// gobgp leaves PeerAddress invalid for a path this node originated.
+		// ListRoutes relies on exactly this to skip its own advertisements.
+		ev, ok := pathToRouteEvent(&apiutil.Path{Family: gobgppkt.RF_IPv6_VPN})
+		if !ok {
+			t.Fatal("pathToRouteEvent returned ok=false")
+		}
+		if !ev.Source.IsLocal() {
+			t.Errorf("Source %v should report IsLocal", ev.Source)
+		}
+		if got := ev.Source.String(); got != "local" {
+			t.Errorf("String() = %q, want %q", got, "local")
+		}
+	})
+}
+
+func TestFamiliesToAfiSafisAddPaths(t *testing.T) {
+	fams := []bgp.Family{bgp.FamilyVPNv4, bgp.FamilyVPNv6}
+
+	t.Run("off by default", func(t *testing.T) {
+		out, err := familiesToAfiSafis(fams, false)
+		if err != nil {
+			t.Fatalf("familiesToAfiSafis: %v", err)
+		}
+		for i, as := range out {
+			if as.AddPaths != nil {
+				t.Errorf("family %d: AddPaths set while disabled", i)
+			}
+		}
+	})
+
+	t.Run("receive enabled for every family, send left off", func(t *testing.T) {
+		out, err := familiesToAfiSafis(fams, true)
+		if err != nil {
+			t.Fatalf("familiesToAfiSafis: %v", err)
+		}
+		if len(out) != len(fams) {
+			t.Fatalf("got %d afi-safis, want %d", len(out), len(fams))
+		}
+		for i, as := range out {
+			if as.AddPaths == nil || !as.AddPaths.Config.GetReceive() {
+				t.Errorf("family %d: ADD-PATH receive not enabled", i)
+			}
+			// Vinbero originates one path per NLRI; negotiating send would
+			// advertise a capability it never uses.
+			if as.AddPaths != nil && as.AddPaths.Config.GetSendMax() != 0 {
+				t.Errorf("family %d: SendMax = %d, want 0", i, as.AddPaths.Config.GetSendMax())
+			}
 		}
 	})
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -282,6 +282,12 @@ type BGPPeerConfig struct {
 	// 5 (gobgp's own default is 120) so a peer unreachable at startup
 	// reconnects within seconds.
 	ConnectRetrySec uint32 `yaml:"connect_retry_sec,omitempty" default:"5"`
+	// AddPathsReceive negotiates ADD-PATH receive (RFC 7911) with this
+	// neighbor, so it may send several paths for one prefix. Set it on a
+	// route reflector session: a reflector sends only its best path per
+	// prefix by default, which hides the other PEs' paths from ECMP. An
+	// iBGP full mesh does not need it, since every PE sends its own path.
+	AddPathsReceive bool `yaml:"add_paths_receive,omitempty"`
 }
 
 // BpfConstants returns the set of read-only constants rewritten into every
@@ -339,7 +345,7 @@ type EntriesConfig struct {
 	// EcmpGroup sizes the ECMP group tables: ecmp_group_map / owner / live
 	// get this capacity directly, ecmp_path_map gets capacity x 8 (one slot
 	// per possible path).
-	EcmpGroup   EntryCapacityConfig `yaml:"ecmp_group,omitempty"`
+	EcmpGroup EntryCapacityConfig `yaml:"ecmp_group,omitempty"`
 	// ServiceIngress sizes the service-programming proxy tables: both the
 	// IFACE-IN return map (service_ingress_map) and the End.AD dynamic
 	// cache (ad_cache_map) are keyed by the proxy attachment circuit.

--- a/vinbero.yml
+++ b/vinbero.yml
@@ -54,3 +54,8 @@ settings:
 #         - vpnv6
 #         - ipv6_unicast
 #         - sr_policy_ipv6
+#       # Negotiate ADD-PATH receive (RFC 7911) so this neighbor may send
+#       # several paths for one prefix. Set it on a route reflector session:
+#       # a reflector sends only its best path per prefix by default, which
+#       # hides the other PEs' paths. An iBGP full mesh does not need it.
+#       add_paths_receive: false


### PR DESCRIPTION
ECMP シリーズ (docs/plan/ecmp-support.md) の PR2 前半にあたる配管です。PR1 (#101) で入ったデータプレーンの path group を、BGP から実際に駆動できるようにする土台を作ります。

## 背景

データプレーン側は複数 path を保持できるようになりましたが、受信側が path を区別できません。gobgp は同一 NLRI に対する複数 PE の path をそれぞれ配送しているのに、Vinbero の変換が送信元を捨てていたため、2 本目の PE の広告が 1 本目の更新と区別できませんでした。

なお現状の挙動は plan に書いた last-write-wins より悪いことが分かりました。`OwnerBGPVPN(asn, rd)` が RD を含むため、異なる RD の 2 PE が同一 prefix を広告すると 2 本目は `ErrEntryOwnerMismatch` で破棄されます。この点は集約を入れる後続 PR で owner tag を RD 非依存にして解消します。

## 変更内容

`PathSource{Peer, PathID}` を追加し `RouteEvent` に載せます。

- `Peer` は学習元の neighbor で、自ノード発の path では zero 値になります
- `PathID` は RFC 7911 の ADD-PATH 識別子です。gobgp の `RemoteID` が受信した識別子で、`LocalID` は再広告時に使う id なので前者を使います。peer 内でのみ一意なため、path の識別は 2 つ組で行い `PathID` 単体では行いません
- 変換は `pathToRouteEvent` の 1 箇所に集約されているので、live subscription と loc-rib snapshot の両方に同時に効きます

peer 設定に `add_paths_receive` を追加します。route reflector は既定で prefix ごとに best path しか reflect しないため、これを有効にしないと他の PE の path はそもそも届きません。full mesh では不要です。送信方向は negotiate しません。Vinbero は自分の NLRI について複数 path を広告しないためです。

## スコープ

新フィールドを key に使う consumer はまだいません。L3VPN の集約は後続 PR に分けています。今回の session で大きな変更ほどレビューで実問題が出たため、機械的な配管と設計判断を含む集約を分離しました。

## テスト

- `TestPathSource` — zero 値が local と読めること、map key として peer と path id で衝突しないこと
- `TestPathToRouteEventSource` — peer と path id が伝わること、異なる peer / 異なる ADD-PATH id が別の source になること、自ノード発が local になること
- `TestFamiliesToAfiSafisAddPaths` — 既定で off、有効時は全 family で receive のみ有効で SendMax が 0 のまま
- 既存の `pkg/bgp/...` `pkg/config/...` 全 green、golangci-lint 0 issues

`pkg/config/config.go` に main から存在した gofmt 崩れがあったので併せて直しています。