### PR TITLE
fix(srpolicy): do not reuse policy ids a restart left referenced

### DIFF
--- a/docs/design/ja/persistence.md
+++ b/docs/design/ja/persistence.md
@@ -76,6 +76,14 @@ settings:
 - `sid_endpoint_progs`, `headend_v4_progs`, `headend_v6_progs` (PROG_ARRAY): プログラム FD が毎回異なるので pin しても意味がない
 - `ecmp_live_map`: prober の生死判定は意図的に pin しません。restart 前の古い判定が path を blackhole しないよう、prober が再登録するまでは miss = 全 path live に倒します
 
+### in-memory の採番と pin された参照
+
+pin されるのはマップだけで、control plane 側の採番状態は再起動で消えます。`sr_policy_map` の policy_id は applier が in-memory に採番しますが、その id を参照する `headend_*_map` のエントリは pin で生き残ります。素朴に 0 から採番し直すと、生き残ったエントリが指す id を新しい policy に割り当ててしまい、その prefix が無関係な policy の transport SID list に steer されます。BGP が再広告してエントリを上書きするまで誤転送が続きます。
+
+そこで applier は起動時に `HighestSRPolicyIDInUse` で、pin された状態がまだ参照している最大の policy_id を調べ、その上から採番を再開します。参照元は 2 つあります。`sr_policy_map` の key は install 済み policy を示し、`headend_v4/v6_map` のエントリが持つ policy_id は実際の参照を示します。誤転送を防ぐうえで本質的なのは後者です。policy が withdraw 済みで `sr_policy_map` に entry が無くても、headend 側が id を指したままなら再利用は危険だからです。
+
+生き残った id は使い切りで、対応する policy が再広告されると新しい id を取ります。id は uint32 なので枯渇は実質問題になりません。
+
 ### 破壊的変更時の注意
 
 **schema / capacity を変えたときは pin dir を削除**してください。BPF map の `max_entries` や value サイズは作成後に変更不可なので、cilium/ebpf は pin された既存 map と spec の不一致を見ると load エラーを返します。

--- a/pkg/bgp/apply/applier_test.go
+++ b/pkg/bgp/apply/applier_test.go
@@ -123,6 +123,7 @@ func (f *fakeHeadend) SetEsiDfPe(esi [bpf.ESILen]byte, dfAddr [bpf.IPv6AddrLen]b
 // interface; the SR Policy table is unit-tested separately (srpolicy_test).
 func (f *fakeHeadend) UpsertSRPolicy(uint32, []netip.Addr) error { return nil }
 func (f *fakeHeadend) DeleteSRPolicy(uint32) error               { return nil }
+func (f *fakeHeadend) HighestSRPolicyIDInUse() (uint32, error)   { return 0, nil }
 
 // mupUplinkKey records an mup_uplink_v4_map write in fakeHeadend.
 type mupUplinkKey struct {

--- a/pkg/bgp/apply/srpolicy.go
+++ b/pkg/bgp/apply/srpolicy.go
@@ -114,11 +114,11 @@ func newSRPolicyTable(mapOps policyMapOps, logger *zap.Logger) *srPolicyTable {
 	//
 	// A failure here is not fatal: with pinning off there is nothing to
 	// collide with, and with pinning on the pre-restart entries keep
-	// forwarding correctly on their own ids. Log and continue from zero
-	// rather than refuse to build the applier.
+	// forwarding correctly on their own ids. Log and continue with an
+	// unseeded allocator rather than refuse to build the applier.
 	highest, err := mapOps.HighestSRPolicyIDInUse()
 	if err != nil {
-		t.logger.Error("read policy ids in use; id allocation starts from zero "+
+		t.logger.Error("read policy ids in use; id allocation restarts from 1 "+
 			"and may collide with entries that survived a restart", zap.Error(err))
 		return t
 	}

--- a/pkg/bgp/apply/srpolicy.go
+++ b/pkg/bgp/apply/srpolicy.go
@@ -44,6 +44,11 @@ func LocalSRPolicy(color uint32, endpoint netip.Addr, segments []netip.Addr, pre
 type policyMapOps interface {
 	UpsertSRPolicy(policyID uint32, transport []netip.Addr) error
 	DeleteSRPolicy(policyID uint32) error
+	// HighestSRPolicyIDInUse reports the largest policy_id the persisted
+	// data plane still refers to, so the allocator can start above it after
+	// a restart instead of reusing an id a surviving headend entry points
+	// at. Returns 0 when the maps are empty or unpinned.
+	HighestSRPolicyIDInUse() (uint32, error)
 }
 
 // policyKey is the SR Policy identity (RFC 9256 §2.1). Color and endpoint
@@ -95,11 +100,34 @@ type srPolicyTable struct {
 }
 
 func newSRPolicyTable(mapOps policyMapOps, logger *zap.Logger) *srPolicyTable {
-	return &srPolicyTable{
+	t := &srPolicyTable{
 		mapOps: mapOps,
 		byKey:  make(map[policyKey]*policyState),
 		logger: logger.Named("srpolicy"),
 	}
+	// Start the id space above anything the pinned data plane still refers
+	// to. Without this a restart hands a fresh policy an id that a surviving
+	// headend entry already points at, and that prefix steers onto the wrong
+	// transport until BGP re-advertises it. Allocation at this point is
+	// purely nextID++ (freeIDs is empty until the first gc), so raising
+	// nextID is enough to keep the two disjoint.
+	//
+	// A failure here is not fatal: with pinning off there is nothing to
+	// collide with, and with pinning on the pre-restart entries keep
+	// forwarding correctly on their own ids. Log and continue from zero
+	// rather than refuse to build the applier.
+	highest, err := mapOps.HighestSRPolicyIDInUse()
+	if err != nil {
+		t.logger.Error("read policy ids in use; id allocation starts from zero "+
+			"and may collide with entries that survived a restart", zap.Error(err))
+		return t
+	}
+	if highest > 0 {
+		t.nextID = highest
+		t.logger.Info("resuming SR Policy id allocation above surviving entries",
+			zap.Uint32("highest_in_use", highest))
+	}
+	return t
 }
 
 // reserveID returns the stable policy_id for {color, endpoint}, allocating

--- a/pkg/bgp/apply/srpolicy_test.go
+++ b/pkg/bgp/apply/srpolicy_test.go
@@ -20,6 +20,10 @@ type fakePolicyMap struct {
 	deletes   []uint32
 	current   map[uint32][]netip.Addr // id -> last transport written (nil = deleted)
 	deleteErr error
+	// highestInUse models what a restart would find still referenced in the
+	// pinned maps; highestErr models that read failing.
+	highestInUse uint32
+	highestErr   error
 }
 
 type upsertCall struct {
@@ -35,6 +39,10 @@ func (f *fakePolicyMap) UpsertSRPolicy(id uint32, transport []netip.Addr) error 
 	f.upserts = append(f.upserts, upsertCall{id, transport})
 	f.current[id] = transport
 	return nil
+}
+
+func (f *fakePolicyMap) HighestSRPolicyIDInUse() (uint32, error) {
+	return f.highestInUse, f.highestErr
 }
 
 func (f *fakePolicyMap) DeleteSRPolicy(id uint32) error {
@@ -367,4 +375,59 @@ func TestSRPolicyTable_LocalCap(t *testing.T) {
 	if err := tbl.applyLocalCapped(mk(9, "2001:db8::9"), 0); err != nil {
 		t.Errorf("max=0 must be unlimited, got %v", err)
 	}
+}
+
+// TestSRPolicyTable_IDsSurviveRestart covers the pinned-map restart hazard.
+// sr_policy_map and the headend maps persist across a vinberod restart, but
+// the id allocator does not: if it restarted from zero it would hand a new
+// policy an id that a surviving headend entry still points at, steering that
+// prefix onto an unrelated transport until BGP re-advertised it.
+func TestSRPolicyTable_IDsSurviveRestart(t *testing.T) {
+	t.Run("allocation starts above surviving ids", func(t *testing.T) {
+		fm := newFakePolicyMap()
+		fm.highestInUse = 7 // a pre-restart entry still references id 7
+		tbl := newSRPolicyTable(fm, zap.NewNop())
+
+		id := tbl.reserveID(10, netip.MustParseAddr("2001:db8::1"))
+		if id <= 7 {
+			t.Fatalf("first id after restart = %d, want > 7 (would collide with a surviving entry)", id)
+		}
+	})
+
+	t.Run("no surviving state starts from one", func(t *testing.T) {
+		tbl, _ := newTestTable()
+		if id := tbl.reserveID(10, netip.MustParseAddr("2001:db8::1")); id != 1 {
+			t.Errorf("first id on a clean start = %d, want 1", id)
+		}
+	})
+
+	t.Run("distinct policies never share an id after restart", func(t *testing.T) {
+		fm := newFakePolicyMap()
+		fm.highestInUse = 3
+		tbl := newSRPolicyTable(fm, zap.NewNop())
+
+		seen := map[uint32]bool{}
+		for i := range 5 {
+			id := tbl.reserveID(uint32(100+i), netip.MustParseAddr("2001:db8::1"))
+			if id <= 3 {
+				t.Fatalf("policy %d got id %d, which a surviving entry may reference", i, id)
+			}
+			if seen[id] {
+				t.Fatalf("id %d handed out twice", id)
+			}
+			seen[id] = true
+		}
+	})
+
+	t.Run("a failed read degrades instead of blocking startup", func(t *testing.T) {
+		fm := newFakePolicyMap()
+		fm.highestErr = errors.New("map iterate failed")
+		tbl := newSRPolicyTable(fm, zap.NewNop())
+		if tbl == nil {
+			t.Fatal("newSRPolicyTable must still build a usable table")
+		}
+		if id := tbl.reserveID(10, netip.MustParseAddr("2001:db8::1")); id == 0 {
+			t.Error("table must still allocate ids after a failed read")
+		}
+	})
 }

--- a/pkg/bpf/maps.go
+++ b/pkg/bpf/maps.go
@@ -1832,33 +1832,44 @@ func (m *MapOperations) DeleteSRPolicy(policyID uint32) error {
 // one that no entry happens to reference yet.
 func (m *MapOperations) HighestSRPolicyIDInUse() (uint32, error) {
 	var highest uint32
+	raise := func(id uint32) {
+		if id > highest {
+			highest = id
+		}
+	}
 
 	var policyID uint32
 	var val BpfSrPolicyValue
 	iter := m.objs.SrPolicyMap.Iterate()
 	for iter.Next(&policyID, &val) {
-		if policyID > highest {
-			highest = policyID
-		}
+		raise(policyID)
 	}
 	if err := iter.Err(); err != nil {
 		return 0, fmt.Errorf("iterate sr_policy_map: %w", err)
 	}
 
-	v4, err := m.ListHeadendV4()
-	if err != nil {
-		return 0, err
+	// Iterate the headend maps directly rather than through ListHeadendV*:
+	// this runs at startup against maps that may be large and pinned, and
+	// only one number is wanted, so materializing every entry into a
+	// string-keyed map would be pure waste.
+	var entry HeadendEntry
+
+	var k4 LpmKeyV4
+	iter = m.objs.HeadendV4Map.Iterate()
+	for iter.Next(&k4, &entry) {
+		raise(entry.PolicyId)
 	}
-	v6, err := m.ListHeadendV6()
-	if err != nil {
-		return 0, err
+	if err := iter.Err(); err != nil {
+		return 0, fmt.Errorf("iterate headend v4 map: %w", err)
 	}
-	for _, entries := range []map[string]*HeadendEntry{v4, v6} {
-		for _, e := range entries {
-			if e.PolicyId > highest {
-				highest = e.PolicyId
-			}
-		}
+
+	var k6 LpmKeyV6
+	iter = m.objs.HeadendV6Map.Iterate()
+	for iter.Next(&k6, &entry) {
+		raise(entry.PolicyId)
+	}
+	if err := iter.Err(); err != nil {
+		return 0, fmt.Errorf("iterate headend v6 map: %w", err)
 	}
 	return highest, nil
 }

--- a/pkg/bpf/maps.go
+++ b/pkg/bpf/maps.go
@@ -1813,6 +1813,56 @@ func (m *MapOperations) DeleteSRPolicy(policyID uint32) error {
 	return nil
 }
 
+// HighestSRPolicyIDInUse returns the largest policy_id the persisted data
+// plane still refers to, or 0 when nothing does.
+//
+// It exists for restart. sr_policy_map and the headend maps are pinned, so
+// after vinberod restarts the old entries keep forwarding while the control
+// plane rebuilds from BGP. The id allocator, however, lives only in memory
+// and would restart from zero and hand a fresh policy an id that a
+// surviving headend entry already points at -- silently steering that
+// prefix onto an unrelated policy's transport until BGP re-advertises it.
+// Seeding the allocator above this value keeps ids disjoint from whatever
+// survived.
+//
+// Both sources matter. The headend maps give the ids that are actually
+// referenced, which is the correctness requirement: reassigning one of them
+// mis-steers live traffic. sr_policy_map adds the ids that hold an
+// installed transport list, so a new policy does not overwrite a surviving
+// one that no entry happens to reference yet.
+func (m *MapOperations) HighestSRPolicyIDInUse() (uint32, error) {
+	var highest uint32
+
+	var policyID uint32
+	var val BpfSrPolicyValue
+	iter := m.objs.SrPolicyMap.Iterate()
+	for iter.Next(&policyID, &val) {
+		if policyID > highest {
+			highest = policyID
+		}
+	}
+	if err := iter.Err(); err != nil {
+		return 0, fmt.Errorf("iterate sr_policy_map: %w", err)
+	}
+
+	v4, err := m.ListHeadendV4()
+	if err != nil {
+		return 0, err
+	}
+	v6, err := m.ListHeadendV6()
+	if err != nil {
+		return 0, err
+	}
+	for _, entries := range []map[string]*HeadendEntry{v4, v6} {
+		for _, e := range entries {
+			if e.PolicyId > highest {
+				highest = e.PolicyId
+			}
+		}
+	}
+	return highest, nil
+}
+
 // GetSRPolicy returns the transport SID list installed for policyID, or
 // nil when no entry exists. Intended for tests and introspection.
 func (m *MapOperations) GetSRPolicy(policyID uint32) ([]net.IP, error) {

--- a/pkg/bpf/xdp_srpolicy_test.go
+++ b/pkg/bpf/xdp_srpolicy_test.go
@@ -145,3 +145,102 @@ func TestUpsertSRPolicyRejectsZeroID(t *testing.T) {
 		t.Fatal("UpsertSRPolicy(0, ...) must be rejected (policy_id 0 = no steering)")
 	}
 }
+
+// TestHighestSRPolicyIDInUse covers the value the id allocator seeds itself
+// from after a restart. Both sources must count: sr_policy_map holds the
+// installed transports, and the headend maps hold the references, which are
+// what make a reassignment mis-steer live traffic.
+func TestHighestSRPolicyIDInUse(t *testing.T) {
+	const hEncaps = uint8(vinberov1.Srv6HeadendBehavior_SRV6_HEADEND_BEHAVIOR_H_ENCAPS)
+	srcAddr, _ := ParseIPv6("fc00::1")
+	serviceSID, _ := ParseIPv6("fd00:5fc::1")
+	entryWith := func(policyID uint32) *HeadendEntry {
+		var segs [MaxSegments][IPv6AddrLen]uint8
+		segs[0] = serviceSID
+		return &HeadendEntry{
+			Mode: hEncaps, NumSegments: 1, PolicyId: policyID,
+			SrcAddr: srcAddr, Segments: segs,
+		}
+	}
+	transport := []netip.Addr{netip.MustParseAddr("fd00:7::1")}
+
+	t.Run("empty maps report zero", func(t *testing.T) {
+		h := newXDPTestHelper(t)
+		got, err := h.mapOps.HighestSRPolicyIDInUse()
+		if err != nil {
+			t.Fatalf("HighestSRPolicyIDInUse: %v", err)
+		}
+		if got != 0 {
+			t.Errorf("got %d, want 0 on a clean data plane", got)
+		}
+	})
+
+	t.Run("installed policies count", func(t *testing.T) {
+		h := newXDPTestHelper(t)
+		for _, id := range []uint32{2, 9, 4} {
+			if err := h.mapOps.UpsertSRPolicy(id, transport); err != nil {
+				t.Fatalf("UpsertSRPolicy(%d): %v", id, err)
+			}
+		}
+		got, err := h.mapOps.HighestSRPolicyIDInUse()
+		if err != nil {
+			t.Fatalf("HighestSRPolicyIDInUse: %v", err)
+		}
+		if got != 9 {
+			t.Errorf("got %d, want 9", got)
+		}
+	})
+
+	t.Run("a reference with no installed policy still counts", func(t *testing.T) {
+		// The dangerous case: the policy was withdrawn before the restart but
+		// a headend entry still points at its id. Reassigning that id would
+		// steer this prefix onto whatever policy takes it next.
+		h := newXDPTestHelper(t)
+		if err := h.mapOps.CreateHeadendV4("192.0.2.0/24", entryWith(21), OwnerRPC); err != nil {
+			t.Fatalf("CreateHeadendV4: %v", err)
+		}
+		got, err := h.mapOps.HighestSRPolicyIDInUse()
+		if err != nil {
+			t.Fatalf("HighestSRPolicyIDInUse: %v", err)
+		}
+		if got != 21 {
+			t.Errorf("got %d, want 21 (an unreferenced-but-installed id is not the only hazard)", got)
+		}
+	})
+
+	t.Run("v6 references count and the maximum wins", func(t *testing.T) {
+		h := newXDPTestHelper(t)
+		if err := h.mapOps.UpsertSRPolicy(3, transport); err != nil {
+			t.Fatalf("UpsertSRPolicy: %v", err)
+		}
+		if err := h.mapOps.CreateHeadendV4("192.0.2.0/24", entryWith(11), OwnerRPC); err != nil {
+			t.Fatalf("CreateHeadendV4: %v", err)
+		}
+		if err := h.mapOps.CreateHeadendV6("2001:db8::/32", entryWith(37), OwnerRPC); err != nil {
+			t.Fatalf("CreateHeadendV6: %v", err)
+		}
+		got, err := h.mapOps.HighestSRPolicyIDInUse()
+		if err != nil {
+			t.Fatalf("HighestSRPolicyIDInUse: %v", err)
+		}
+		if got != 37 {
+			t.Errorf("got %d, want 37", got)
+		}
+	})
+
+	t.Run("unsteered entries do not raise the floor", func(t *testing.T) {
+		// policy_id 0 means "not steered"; it must not be mistaken for a
+		// reference, or every plain VPN route would inflate the id space.
+		h := newXDPTestHelper(t)
+		if err := h.mapOps.CreateHeadendV4("192.0.2.0/24", entryWith(0), OwnerRPC); err != nil {
+			t.Fatalf("CreateHeadendV4: %v", err)
+		}
+		got, err := h.mapOps.HighestSRPolicyIDInUse()
+		if err != nil {
+			t.Fatalf("HighestSRPolicyIDInUse: %v", err)
+		}
+		if got != 0 {
+			t.Errorf("got %d, want 0", got)
+		}
+	})
+}


### PR DESCRIPTION
ECMP シリーズの PR2b (L3VPN 集約) で group ID の採番を設計している最中に、既存の SR Policy に同じ構造の問題があることに気づいたので先に切り出しました。

## 問題

`sr_policy_map` と `headend_v4/v6_map` は pin 対象で、vinberod を再起動してもエントリは生き残って転送を続けます。一方 policy_id の採番は applier の in-memory (`srPolicyTable.nextID`) にしかなく、起動時に pinned map から再構築していません。

そのため `settings.pin_maps.enabled: true` の環境で次が起こります。

1. 再起動前の headend entry が `policy_id = 5` を持ったまま pin で生き残る
2. 新しい applier の `nextID` は 0 から始まるので、最初に到着した別の {color, endpoint} が id 5 を取る
3. その policy が `sr_policy_map[5]` を上書きする
4. まだ再広告されていない prefix のトラフィックが、無関係な policy の transport SID list に steer される

BGP が再広告してエントリを上書きするまで誤転送が続きます。pin の目的は再起動を跨いだ転送継続なので、まさにそれが壊れる形です。

## 修正

起動時に `HighestSRPolicyIDInUse` で、pin された状態がまだ参照している最大の policy_id を調べ、その上から採番を再開します。

参照元は 2 つ見ます。`sr_policy_map` の key は install 済みの policy を示し、`headend_v4/v6_map` の `policy_id` は実際の参照を示します。**correctness 上本質的なのは後者です。** policy が再起動前に withdraw されていれば `sr_policy_map` に entry は残りませんが、headend 側は id を指したままです。その id こそ再利用が危険なので、install 済みだけを見る実装では防げません。

起動直後の採番は `nextID++` のみです (`freeIDs` は最初の gc まで空)。したがって `nextID` を上げるだけで両者の id 空間が交わらなくなります。

読み取りに失敗した場合は log を出して 0 から続行し、起動は止めません。pin off なら衝突相手が存在せず、pin on でも生き残ったエントリは自分の id で正しく転送し続けるためです。

## 影響範囲

`settings.pin_maps.enabled` が true の場合のみ顕在化します (既定は false)。

## テスト

- `TestSRPolicyTable_IDsSurviveRestart` — 生存 id より上から採番すること、clean start では 1 から始まること、再起動後も id が重複しないこと、読み取り失敗時に degrade して起動できること
- `TestHighestSRPolicyIDInUse` (live map) — install 済み policy を数えること、**install されていないが headend から参照されている id も数えること**、v4/v6 の両方を見て最大を返すこと、`policy_id = 0` (未 steer) を参照と誤認しないこと
- 既存の `pkg/bgp/...` 全 green、golangci-lint 0 issues