### PR TITLE
feat(bgp): aggregate a VPN prefix's paths into one ECMP group

### DIFF
--- a/docs/design/ja/ecmp.md
+++ b/docs/design/ja/ecmp.md
@@ -85,6 +85,20 @@ data plane が複数 path を持てても、受信側が path を区別できな
 
 peer 設定の `add_paths_receive` で ADD-PATH の receive を negotiate します。route reflector 配下では必要です。reflector は既定で prefix ごとに best path だけを reflect するので、これを有効にしないと他の PE の path はそもそも届かず、受信側で何をしても復元できません。iBGP full mesh では各 PE が自分の path を直接送るため不要です。送信方向は有効にしません。Vinbero は自分の NLRI について複数 path を広告しないので、使わない capability を negotiate しないためです。
 
+## L3VPN の path 集約
+
+受信した VPN 経路は `{family, prefix}` 単位で 1 つの ECMP group に集約します。RD は key に含めません。同じ prefix を広告する PE はそれぞれ自分の RD を使うので、RD を key に入れると 2 台目の PE の経路が別エントリになり、1 台目を上書きしてしまうためです。
+
+集約前は prefix をそのまま headend map に書き、owner を RD 込みにしていました。このため 2 台目の PE の書き込みは cross-owner チェックに掛かって失敗し、経路は単に捨てられていました。さらに 1 台目が withdraw すると、生き残っている PE の経路は再広告されるまで復活せず、その prefix は blackhole していました。集約と RD 非依存の owner でこの両方が解消します。
+
+path の識別は `{rd, PathSource}` です。RD が PE を、`PathSource` が peer 内の path を区別するので、2 台の PE からの広告も、ADD-PATH で 1 peer から届く複数 path も、別々の path として保持できます。
+
+program する member は SID で dedupe して SID 順に並べ、8 本で打ち切ります。並び順を固定するのは見た目のためではありません。data plane は member 数の剰余で path を選ぶので、Go の map 反復順に依存すると同じ path 集合でも reconcile のたびに flow の分散先が変わってしまいます。同じ SID に解決する path は転送結果が同じなので dedupe します。両方 program すると、その PE の取り分だけが黙って倍になります。
+
+trigger エントリには group_id に加えて先頭 member の segments も入れます。data plane は group を解決できないとき trigger 自身の segments に fallback するので、reconcile の途中や再起動直後の窓で drop でなく単一 path 転送に degrade します。
+
+group id は再起動を跨げません。owner tag は 64 バイトに収まる必要があり、prefix を入れると IPv6 で溢れるため、どの group がどの prefix のものだったかを記録できないからです。そこで起動時に自分が owner の group を sweep して世代ごとの orphan が積み上がるのを防ぎ、他の owner が持つ group と衝突しないよう、残っている id の上から採番を再開します。
+
 ## 制約と今後
 
 - `mup_uplink_v4/v6_map` の値も `headend_entry` ですが、behavior プログラム内で lookup されるため group 解決を通りません。`CreateMupUplinkV4/V6` が書き込み時に `group_id` を 0 に強制します。

--- a/pkg/bgp/apply/applier.go
+++ b/pkg/bgp/apply/applier.go
@@ -32,6 +32,12 @@ type headendOps interface {
 	CreateHeadendV6(triggerPrefix string, entry *bpf.HeadendEntry, owner bpf.OwnerTag) error
 	DeleteHeadendV4(triggerPrefix string, requester bpf.OwnerTag) error
 	DeleteHeadendV6(triggerPrefix string, requester bpf.OwnerTag) error
+	// The rest support the upgrade off the pre-aggregation per-RD owner;
+	// see clearLegacyVPNHeadend.
+	GetHeadendV4Owner(triggerPrefix string) (bpf.OwnerTag, bool, error)
+	GetHeadendV6Owner(triggerPrefix string) (bpf.OwnerTag, bool, error)
+	ForceDeleteHeadendV4(triggerPrefix string) error
+	ForceDeleteHeadendV6(triggerPrefix string) error
 }
 
 // mupOps is the subset of bpf.MapOperations the BGP MUP uplink path needs:
@@ -84,8 +90,7 @@ type Applier struct {
 	// MUP receive state, guarded by mupMu: the GoBGP RouteHandler goroutine
 	// applies routes (applyMUP), and VrfBgpService mutations re-reconcile
 	// installed downlinks when a binding's GTP4 source prefix changes
-	// (ReconcileMUPGTP4SrcForRD), so unlike the single-goroutine VPN state
-	// this is
+	// (ReconcileMUPGTP4SrcForRD), so unlike the single-goroutine VPN state this is
 	// touched from two goroutines. mupT1ST / mupT2ST hold each session's
 	// full route plus the SID currently programmed for it (so an arriving /
 	// withdrawn discovery route can reconcile the install). mupISD / mupDSD
@@ -223,7 +228,7 @@ func (a *Applier) applyVPN(vr *bgp.VPNRoute, src bgp.PathSource, withdraw bool) 
 			// a withdraw arriving before the route is re-advertised is the
 			// only chance to remove it. Delete unconditionally; it is a
 			// no-op when the entry is already absent.
-			if err := a.deleteHeadend(vr.Family, vr.Prefix, bpf.OwnerBGPVPN(a.localASN, "")); err != nil {
+			if err := a.deleteTrigger(vr.Family, vr.Prefix); err != nil {
 				a.logger.Error("withdraw untracked VPN prefix",
 					zap.String("prefix", vr.Prefix), zap.Error(err))
 			}

--- a/pkg/bgp/apply/applier.go
+++ b/pkg/bgp/apply/applier.go
@@ -55,6 +55,7 @@ type dataPlane interface {
 	policyMapOps
 	fdbBdOps
 	mupOps
+	ecmpOps
 }
 
 // Applier applies received BGP routes to the Vinbero data plane.
@@ -69,6 +70,10 @@ type Applier struct {
 	localASN    uint32
 	srPolicy    *srPolicyTable
 	evpn        *evpnTable
+	// vpnGroups aggregates the paths learned for each VPN prefix into one
+	// ECMP group. Touched only from the route-handler goroutine and from
+	// NewApplier's startup reset, which runs before any route arrives.
+	vpnGroups *vpnGroupTable
 	// mupDefaultAllow forces every MUP session route through the historical
 	// default-allow path even when some VRF binding has declared a mup_ipv*
 	// family. It is the escape hatch for the asymmetric-expansion case where
@@ -79,7 +84,8 @@ type Applier struct {
 	// MUP receive state, guarded by mupMu: the GoBGP RouteHandler goroutine
 	// applies routes (applyMUP), and VrfBgpService mutations re-reconcile
 	// installed downlinks when a binding's GTP4 source prefix changes
-	// (ReconcileMUPGTP4SrcForRD), so unlike steeredRoutes this state is
+	// (ReconcileMUPGTP4SrcForRD), so unlike the single-goroutine VPN state
+	// this is
 	// touched from two goroutines. mupT1ST / mupT2ST hold each session's
 	// full route plus the SID currently programmed for it (so an arriving /
 	// withdrawn discovery route can reconcile the install). mupISD / mupDSD
@@ -93,12 +99,6 @@ type Applier struct {
 	mupISD      map[mupISDKey]mupISDEntry
 	mupDSD      map[mupDSDKey]mupDSDEntry
 	mupGateRefs map[string]int
-	// steeredRoutes maps a steered VPN route to the SR Policy key it
-	// references, so a withdraw (which carries no color/next-hop) can unref
-	// the right policy. Touched only from applyVPN, which runs on the single
-	// GoBGP RouteHandler goroutine, so it needs no extra locking; the
-	// srPolicyTable it drives is mutex-guarded for the concurrent CRUD path.
-	steeredRoutes map[bgp.RouteKey]policyKey
 	// evpnMu serializes the EVPN receive state (evpnTable.peers/fdb/mcast)
 	// between the GoBGP RouteHandler goroutine (applyEVPN) and the RPC-driven
 	// ReplayEVPN (VrfBridgeAttach / commitBinding re-pull the loc-rib after
@@ -112,25 +112,28 @@ type Applier struct {
 // vrfBindings supplies the route-target import filter; an empty manager
 // accepts every received route.
 func NewApplier(dp dataPlane, locators *locator.Manager, vrfBindings *vrfbgp.Manager, fibInjector fib.Injector, srcLocator string, localASN uint32, logger *zap.Logger) *Applier {
-	return &Applier{
-		headend:       dp,
-		fdbBd:         dp,
-		mupUplink:     dp,
-		locators:      locators,
-		vrfBindings:   vrfBindings,
-		fib:           fibInjector,
-		srcLocator:    srcLocator,
-		localASN:      localASN,
-		srPolicy:      newSRPolicyTable(dp, logger),
-		evpn:          newEVPNTable(),
-		steeredRoutes: make(map[bgp.RouteKey]policyKey),
-		mupT1ST:       make(map[mupT1STKey]*mupSessionState),
-		mupT2ST:       make(map[mupT2STKey]*mupSessionState),
-		mupISD:        make(map[mupISDKey]mupISDEntry),
-		mupDSD:        make(map[mupDSDKey]mupDSDEntry),
-		mupGateRefs:   make(map[string]int),
-		logger:        logger.Named("bgp.apply"),
+	a := &Applier{
+		headend:     dp,
+		fdbBd:       dp,
+		mupUplink:   dp,
+		locators:    locators,
+		vrfBindings: vrfBindings,
+		fib:         fibInjector,
+		srcLocator:  srcLocator,
+		localASN:    localASN,
+		srPolicy:    newSRPolicyTable(dp, logger),
+		vpnGroups:   newVPNGroupTable(dp, localASN, logger),
+		evpn:        newEVPNTable(),
+		mupT1ST:     make(map[mupT1STKey]*mupSessionState),
+		mupT2ST:     make(map[mupT2STKey]*mupSessionState),
+		mupISD:      make(map[mupISDKey]mupISDEntry),
+		mupDSD:      make(map[mupDSDKey]mupDSDEntry),
+		mupGateRefs: make(map[string]int),
+		logger:      logger.Named("bgp.apply"),
 	}
+	// Runs before the BGP session starts, so it cannot race a route event.
+	a.vpnGroups.reset()
+	return a
 }
 
 // SetMUPDefaultAllow toggles the MUP receive-side default-allow escape hatch.
@@ -162,7 +165,7 @@ func (a *Applier) Apply(ev bgp.RouteEvent) {
 	case ev.SRPolicy != nil:
 		a.srPolicy.apply(*ev.SRPolicy, ev.IsWithdraw)
 	case ev.VPN != nil:
-		a.applyVPN(ev.VPN, ev.IsWithdraw)
+		a.applyVPN(ev.VPN, ev.Source, ev.IsWithdraw)
 	case ev.Unicast != nil:
 		a.applyUnicast(ev.Unicast, ev.IsWithdraw)
 	case ev.EVPN != nil:
@@ -199,21 +202,34 @@ func (a *Applier) ApplyLocalSRPolicyCapped(p bgp.SRPolicy, max uint32) error {
 	return a.srPolicy.applyLocalCapped(p, max)
 }
 
-func (a *Applier) applyVPN(vr *bgp.VPNRoute, withdraw bool) {
-	owner := bpf.OwnerBGPVPN(a.localASN, vr.RD)
-	rk := vr.Key()
+func (a *Applier) applyVPN(vr *bgp.VPNRoute, src bgp.PathSource, withdraw bool) {
+	dk := vpnDestKey{family: vr.Family, prefix: vr.Prefix}
+	pk := vpnPathKey{rd: vr.RD, source: src}
 	if withdraw {
-		// Release any SR Policy reference this route held. The withdraw
-		// event carries no color/next-hop, so the reverse index is the only
-		// way to know which policy to unref.
-		a.steer(rk, nil)
 		// Withdraw bypasses the import-RT filter so a route accepted
-		// earlier is always torn down (deleteHeadend is a no-op when the
-		// entry is already absent).
-		if err := a.deleteHeadend(vr.Family, vr.Prefix, owner); err != nil {
-			a.logger.Error("withdraw VPN route",
-				zap.String("prefix", vr.Prefix), zap.Error(err))
+		// earlier is always torn down, and drops only this path: the prefix
+		// survives on whatever other PEs still advertise it.
+		d, released := a.vpnGroups.remove(dk, pk)
+		if released != nil {
+			// The withdraw carries no color or next hop, so the reference
+			// recorded against the path is the only way to know which
+			// policy to release.
+			a.srPolicy.unref(released.color, released.endpoint)
 		}
+		if d == nil {
+			// Nothing tracked for this prefix, but the data plane may still
+			// hold an entry this process never saw: with pinned maps an
+			// entry installed before a restart outlives the accumulator, and
+			// a withdraw arriving before the route is re-advertised is the
+			// only chance to remove it. Delete unconditionally; it is a
+			// no-op when the entry is already absent.
+			if err := a.deleteHeadend(vr.Family, vr.Prefix, bpf.OwnerBGPVPN(a.localASN, "")); err != nil {
+				a.logger.Error("withdraw untracked VPN prefix",
+					zap.String("prefix", vr.Prefix), zap.Error(err))
+			}
+			return
+		}
+		a.reconcileVPNGroup(dk, d)
 		return
 	}
 	// Import-RT filter: once any VRF binding declares this family, a
@@ -234,17 +250,9 @@ func (a *Applier) applyVPN(vr *bgp.VPNRoute, withdraw bool) {
 			zap.String("prefix", vr.Prefix), zap.String("rd", vr.RD))
 		return
 	}
-	entry, err := a.buildHeadendEntry(vr.SRv6SID)
-	if err != nil {
-		a.logger.Error("build headend entry",
-			zap.String("prefix", vr.Prefix), zap.Error(err))
-		return
-	}
-	// Color-based auto-steering: stamp the SR Policy id for {color, next
-	// hop} so the XDP headend composes this route's service SID onto that
-	// policy's transport. reserveID only resolves the id; the steering
-	// reference is committed (steer) after the headend write succeeds, so
-	// a failed write never pins the id.
+	// Color-based auto-steering is decided per path: the paths aggregated
+	// onto one prefix can carry different colors, so each contributes its
+	// own SR Policy reference rather than the prefix holding a single one.
 	var want *policyKey
 	if vr.Color != 0 {
 		endpoint, perr := netip.ParseAddr(vr.NextHop)
@@ -262,43 +270,35 @@ func (a *Applier) applyVPN(vr *bgp.VPNRoute, withdraw bool) {
 				zap.String("nexthop", vr.NextHop))
 		default:
 			want = &policyKey{color: vr.Color, endpoint: endpoint}
-			entry.PolicyId = a.srPolicy.reserveID(want.color, want.endpoint)
 		}
 	}
-	if err := a.createHeadend(vr.Family, vr.Prefix, entry, owner); err != nil {
-		a.logger.Error("install VPN route",
-			zap.String("prefix", vr.Prefix), zap.Error(err))
+
+	// Take the new reference before releasing the old one so a re-advertise
+	// that keeps the same target never drops the refcount to zero and lets
+	// the policy be garbage-collected between the two calls.
+	// remove is only for the reference the previous advertisement of THIS
+	// path held; upsert below re-adds it, so the destination it returns is
+	// deliberately ignored.
+	_, replaced := a.vpnGroups.remove(dk, pk)
+	if want != nil {
+		a.srPolicy.ref(want.color, want.endpoint)
+	}
+	if replaced != nil {
+		a.srPolicy.unref(replaced.color, replaced.endpoint)
+	}
+	d, ok := a.vpnGroups.upsert(dk, pk, &vpnPath{sid: vr.SRv6SID, steer: want})
+	if !ok {
+		// Refused by a bound. The reference just taken would otherwise pin
+		// a policy no path holds.
+		if want != nil {
+			a.srPolicy.unref(want.color, want.endpoint)
+		}
+		if d != nil {
+			a.reconcileVPNGroup(dk, d)
+		}
 		return
 	}
-	// The entry is installed -- commit the steering reference (or release a
-	// stale one when the route is no longer steered).
-	a.steer(rk, want)
-	a.logger.Info("VPN route installed",
-		zap.String("prefix", vr.Prefix), zap.String("sid", vr.SRv6SID))
-}
-
-// steer reconciles a route's SR Policy reference against its desired target
-// (want == nil means "not steered") and returns the policy_id to stamp (0
-// when unsteered). It diffs against the recorded reference so a re-advertise
-// with an unchanged target neither leaks nor double-counts a reference.
-func (a *Applier) steer(rk bgp.RouteKey, want *policyKey) uint32 {
-	old, had := a.steeredRoutes[rk]
-	switch {
-	case want == nil:
-		if had {
-			a.srPolicy.unref(old.color, old.endpoint)
-			delete(a.steeredRoutes, rk)
-		}
-		return 0
-	case had && old == *want:
-		return a.srPolicy.idOf(want.color, want.endpoint)
-	default:
-		if had {
-			a.srPolicy.unref(old.color, old.endpoint)
-		}
-		a.steeredRoutes[rk] = *want
-		return a.srPolicy.ref(want.color, want.endpoint)
-	}
+	a.reconcileVPNGroup(dk, d)
 }
 
 func (a *Applier) applyUnicast(ur *bgp.UnicastRoute, withdraw bool) {

--- a/pkg/bgp/apply/applier_test.go
+++ b/pkg/bgp/apply/applier_test.go
@@ -33,6 +33,11 @@ type fakeHeadend struct {
 	v6deleted []string
 	createErr error
 
+	ecmpGroups  map[uint32][]bpf.EcmpPath
+	ecmpOwners  map[uint32]bpf.OwnerTag
+	ecmpDeletes []uint32
+	putEcmpErr  error
+
 	fdb           map[fdbKey]*bpf.FdbEntry
 	bdPeers       map[bdPeerKey]*bpf.HeadendEntry
 	bdPeerReverse map[bdPeerKey]bool // writeReverse flag passed per peer
@@ -53,6 +58,8 @@ func newFakeHeadend() *fakeHeadend {
 		bdPeers:       map[bdPeerKey]*bpf.HeadendEntry{},
 		bdPeerReverse: map[bdPeerKey]bool{},
 		esis:          map[[bpf.ESILen]byte]*bpf.EsiEntry{},
+		ecmpGroups:    map[uint32][]bpf.EcmpPath{},
+		ecmpOwners:    map[uint32]bpf.OwnerTag{},
 	}
 }
 
@@ -124,6 +131,44 @@ func (f *fakeHeadend) SetEsiDfPe(esi [bpf.ESILen]byte, dfAddr [bpf.IPv6AddrLen]b
 func (f *fakeHeadend) UpsertSRPolicy(uint32, []netip.Addr) error { return nil }
 func (f *fakeHeadend) DeleteSRPolicy(uint32) error               { return nil }
 func (f *fakeHeadend) HighestSRPolicyIDInUse() (uint32, error)   { return 0, nil }
+
+// ECMP group surface. ecmpGroups records the last member set written per
+// group id so tests can assert on aggregation, and survivingOwners seeds
+// what a restart would find already installed.
+func (f *fakeHeadend) PutEcmpGroup(groupID uint32, paths []bpf.EcmpPath, owner bpf.OwnerTag) error {
+	if f.putEcmpErr != nil {
+		return f.putEcmpErr
+	}
+	if f.ecmpGroups == nil {
+		f.ecmpGroups = map[uint32][]bpf.EcmpPath{}
+	}
+	f.ecmpGroups[groupID] = paths
+	f.ecmpOwners[groupID] = owner
+	return nil
+}
+
+func (f *fakeHeadend) DeleteEcmpGroup(groupID uint32, requester bpf.OwnerTag) error {
+	f.ecmpDeletes = append(f.ecmpDeletes, groupID)
+	delete(f.ecmpGroups, groupID)
+	delete(f.ecmpOwners, groupID)
+	return nil
+}
+
+func (f *fakeHeadend) ListEcmpGroups() (map[uint32]*bpf.EcmpGroupInfo, error) {
+	out := map[uint32]*bpf.EcmpGroupInfo{}
+	for id := range f.ecmpOwners {
+		out[id] = &bpf.EcmpGroupInfo{}
+	}
+	return out, nil
+}
+
+func (f *fakeHeadend) ListEcmpGroupOwners() (map[uint32]bpf.OwnerTag, error) {
+	out := map[uint32]bpf.OwnerTag{}
+	for id, o := range f.ecmpOwners {
+		out[id] = o
+	}
+	return out, nil
+}
 
 // mupUplinkKey records an mup_uplink_v4_map write in fakeHeadend.
 type mupUplinkKey struct {

--- a/pkg/bgp/apply/applier_test.go
+++ b/pkg/bgp/apply/applier_test.go
@@ -181,15 +181,21 @@ func (f *fakeHeadend) PutEcmpGroup(groupID uint32, paths []bpf.EcmpPath, owner b
 }
 
 func (f *fakeHeadend) DeleteEcmpGroup(groupID uint32, requester bpf.OwnerTag) error {
+	if cur, ok := f.ecmpOwners[groupID]; ok && cur != requester {
+		return bpf.ErrEntryOwnerMismatch
+	}
 	f.ecmpDeletes = append(f.ecmpDeletes, groupID)
 	delete(f.ecmpGroups, groupID)
 	delete(f.ecmpOwners, groupID)
 	return nil
 }
 
+// Enumerates the group table, not the owner table: an id is occupied by the
+// group existing, whether or not an owner was recorded for it. Deriving this
+// from ecmpOwners would make the ownerless case untestable.
 func (f *fakeHeadend) ListEcmpGroups() (map[uint32]*bpf.EcmpGroupInfo, error) {
 	out := map[uint32]*bpf.EcmpGroupInfo{}
-	for id := range f.ecmpOwners {
+	for id := range f.ecmpGroups {
 		out[id] = &bpf.EcmpGroupInfo{}
 	}
 	return out, nil

--- a/pkg/bgp/apply/applier_test.go
+++ b/pkg/bgp/apply/applier_test.go
@@ -33,6 +33,13 @@ type fakeHeadend struct {
 	v6deleted []string
 	createErr error
 
+	// v4owners / v6owners model the persisted owner table so the upgrade off
+	// the pre-aggregation per-RD owner can be exercised.
+	v4owners map[string]bpf.OwnerTag
+	v6owners map[string]bpf.OwnerTag
+	v4forced []string
+	v6forced []string
+
 	ecmpGroups  map[uint32][]bpf.EcmpPath
 	ecmpOwners  map[uint32]bpf.OwnerTag
 	ecmpDeletes []uint32
@@ -58,6 +65,8 @@ func newFakeHeadend() *fakeHeadend {
 		bdPeers:       map[bdPeerKey]*bpf.HeadendEntry{},
 		bdPeerReverse: map[bdPeerKey]bool{},
 		esis:          map[[bpf.ESILen]byte]*bpf.EsiEntry{},
+		v4owners:      map[string]bpf.OwnerTag{},
+		v6owners:      map[string]bpf.OwnerTag{},
 		ecmpGroups:    map[uint32][]bpf.EcmpPath{},
 		ecmpOwners:    map[uint32]bpf.OwnerTag{},
 	}
@@ -131,6 +140,30 @@ func (f *fakeHeadend) SetEsiDfPe(esi [bpf.ESILen]byte, dfAddr [bpf.IPv6AddrLen]b
 func (f *fakeHeadend) UpsertSRPolicy(uint32, []netip.Addr) error { return nil }
 func (f *fakeHeadend) DeleteSRPolicy(uint32) error               { return nil }
 func (f *fakeHeadend) HighestSRPolicyIDInUse() (uint32, error)   { return 0, nil }
+
+func (f *fakeHeadend) GetHeadendV4Owner(prefix string) (bpf.OwnerTag, bool, error) {
+	o, ok := f.v4owners[prefix]
+	return o, ok, nil
+}
+
+func (f *fakeHeadend) GetHeadendV6Owner(prefix string) (bpf.OwnerTag, bool, error) {
+	o, ok := f.v6owners[prefix]
+	return o, ok, nil
+}
+
+func (f *fakeHeadend) ForceDeleteHeadendV4(prefix string) error {
+	delete(f.v4owners, prefix)
+	delete(f.v4created, prefix)
+	f.v4forced = append(f.v4forced, prefix)
+	return nil
+}
+
+func (f *fakeHeadend) ForceDeleteHeadendV6(prefix string) error {
+	delete(f.v6owners, prefix)
+	delete(f.v6created, prefix)
+	f.v6forced = append(f.v6forced, prefix)
+	return nil
+}
 
 // ECMP group surface. ecmpGroups records the last member set written per
 // group id so tests can assert on aggregation, and survivingOwners seeds
@@ -210,28 +243,49 @@ func (f *fakeHeadend) DeleteMupUplinkV6(instance uint32, endpoint string, teid u
 	return nil
 }
 
-func (f *fakeHeadend) CreateHeadendV4(p string, e *bpf.HeadendEntry, _ bpf.OwnerTag) error {
+// Create / Delete honour the recorded owner the way bpf.MapOperations does,
+// so tests can exercise the cross-owner paths (the pre-aggregation per-RD
+// owner in particular) rather than assuming every write lands.
+func (f *fakeHeadend) CreateHeadendV4(p string, e *bpf.HeadendEntry, owner bpf.OwnerTag) error {
 	if f.createErr != nil {
 		return f.createErr
+	}
+	if cur, ok := f.v4owners[p]; ok && cur != owner {
+		return bpf.ErrEntryOwnerMismatch
 	}
 	f.v4created[p] = e
+	f.v4owners[p] = owner
 	return nil
 }
 
-func (f *fakeHeadend) CreateHeadendV6(p string, e *bpf.HeadendEntry, _ bpf.OwnerTag) error {
+func (f *fakeHeadend) CreateHeadendV6(p string, e *bpf.HeadendEntry, owner bpf.OwnerTag) error {
 	if f.createErr != nil {
 		return f.createErr
 	}
+	if cur, ok := f.v6owners[p]; ok && cur != owner {
+		return bpf.ErrEntryOwnerMismatch
+	}
 	f.v6created[p] = e
+	f.v6owners[p] = owner
 	return nil
 }
 
-func (f *fakeHeadend) DeleteHeadendV4(p string, _ bpf.OwnerTag) error {
+func (f *fakeHeadend) DeleteHeadendV4(p string, requester bpf.OwnerTag) error {
+	if cur, ok := f.v4owners[p]; ok && cur != requester {
+		return bpf.ErrEntryOwnerMismatch
+	}
+	delete(f.v4owners, p)
+	delete(f.v4created, p)
 	f.v4deleted = append(f.v4deleted, p)
 	return nil
 }
 
-func (f *fakeHeadend) DeleteHeadendV6(p string, _ bpf.OwnerTag) error {
+func (f *fakeHeadend) DeleteHeadendV6(p string, requester bpf.OwnerTag) error {
+	if cur, ok := f.v6owners[p]; ok && cur != requester {
+		return bpf.ErrEntryOwnerMismatch
+	}
+	delete(f.v6owners, p)
+	delete(f.v6created, p)
 	f.v6deleted = append(f.v6deleted, p)
 	return nil
 }

--- a/pkg/bgp/apply/vpngroup.go
+++ b/pkg/bgp/apply/vpngroup.go
@@ -1,0 +1,342 @@
+package apply
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+
+	"go.uber.org/zap"
+
+	"github.com/takehaya/vinbero/pkg/bgp"
+	"github.com/takehaya/vinbero/pkg/bpf"
+)
+
+// Bounds on what one node will track and program. Tracking is deliberately
+// wider than programming: the data plane picks 8 paths, but keeping the
+// runners-up means a withdraw promotes one instead of leaving the prefix a
+// path short until the next advertisement. Both are caps against a peer
+// that floods paths, in the same spirit as maxTrackedESIs.
+const (
+	maxTrackedVPNDests = 4096
+	maxPathsPerDest    = 32
+)
+
+// vpnDestKey is what paths aggregate onto: one ECMP group per {family,
+// prefix}. RD is NOT part of it. Each PE advertising a prefix uses its own
+// RD, so keying by RD is what makes the second PE's path a separate entry
+// that overwrites the first instead of joining it.
+type vpnDestKey struct {
+	family bgp.Family
+	prefix string
+}
+
+// vpnPathKey identifies one contributing path. RD distinguishes the PEs and
+// PathSource distinguishes paths within a peer, so two PEs advertising one
+// prefix, or one peer sending several paths under ADD-PATH, both land on
+// distinct keys.
+type vpnPathKey struct {
+	rd     string
+	source bgp.PathSource
+}
+
+// vpnPath is one path's contribution: the service SID to encapsulate to,
+// and the SR Policy reference it holds (nil when the path is not steered).
+// The reference lives here rather than in a separate reverse index because
+// a withdraw carries no color or next hop, so the only way to release the
+// right policy is to have recorded it against the path that took it.
+type vpnPath struct {
+	sid   string
+	steer *policyKey
+}
+
+type vpnDest struct {
+	groupID uint32
+	paths   map[vpnPathKey]*vpnPath
+	// installed is the member SID list last written, used to skip
+	// reconciles that would rewrite an unchanged group.
+	installed []string // memberFingerprint of the last write
+}
+
+// ecmpOps is the subset of bpf.MapOperations the VPN group path needs.
+type ecmpOps interface {
+	PutEcmpGroup(groupID uint32, paths []bpf.EcmpPath, owner bpf.OwnerTag) error
+	DeleteEcmpGroup(groupID uint32, requester bpf.OwnerTag) error
+	ListEcmpGroups() (map[uint32]*bpf.EcmpGroupInfo, error)
+	ListEcmpGroupOwners() (map[uint32]bpf.OwnerTag, error)
+}
+
+// vpnGroupTable aggregates the paths learned for each VPN prefix into one
+// ECMP group.
+//
+// Before this existed a prefix was written straight to the headend map
+// keyed by prefix under an RD-scoped owner, so a second PE advertising the
+// same prefix did not merely lose the race -- its write failed the
+// cross-owner check and the path was dropped. Worse, once the first PE
+// withdrew, the surviving PE's path was never retried, so the prefix went
+// dark until something re-advertised it.
+//
+// All of it is touched from the single GoBGP RouteHandler goroutine, plus
+// reset() before any route arrives, so it needs no lock of its own; the
+// srPolicyTable it references is separately mutex-guarded for the
+// concurrent RPC path.
+type vpnGroupTable struct {
+	dests  map[vpnDestKey]*vpnDest
+	ecmp   ecmpOps
+	logger *zap.Logger
+
+	localASN uint32
+	nextID   uint32
+	freeIDs  []uint32
+}
+
+func newVPNGroupTable(ecmp ecmpOps, localASN uint32, logger *zap.Logger) *vpnGroupTable {
+	return &vpnGroupTable{
+		dests:    make(map[vpnDestKey]*vpnDest),
+		ecmp:     ecmp,
+		logger:   logger.Named("vpngroup"),
+		localASN: localASN,
+	}
+}
+
+// groupOwner is the owner every group this table writes carries. It is
+// shared by all prefixes on purpose (see OwnerBGPVPNGroup).
+func (t *vpnGroupTable) groupOwner() bpf.OwnerTag {
+	return bpf.OwnerBGPVPNGroup(t.localASN)
+}
+
+// reset clears state left by a previous process and seeds id allocation.
+//
+// ecmp_group_map and its owner table are pinned, so a restart finds the
+// previous run's groups still installed. Their ids cannot be resumed: the
+// owner tag deliberately does not name the prefix (it would overflow the
+// tag buffer), so there is no way to tell which group belonged to which
+// prefix. Delete the ones this node owns instead of leaving a new
+// generation of orphans behind on every restart, and start allocating above
+// whatever ids remain so a group owned by someone else -- an RPC-installed
+// one, say -- is never overwritten.
+//
+// The pinned trigger entries keep forwarding meanwhile: each carries
+// fallback segments, so a group that has just been deleted resolves to
+// single-path forwarding rather than a drop, until BGP re-advertises and
+// the group is rebuilt.
+func (t *vpnGroupTable) reset() {
+	owners, err := t.ecmp.ListEcmpGroupOwners()
+	if err != nil {
+		t.logger.Error("list ecmp group owners; stale groups may be left behind", zap.Error(err))
+		owners = nil
+	}
+	mine := t.groupOwner()
+	for id, owner := range owners {
+		if owner != mine {
+			continue
+		}
+		if err := t.ecmp.DeleteEcmpGroup(id, mine); err != nil {
+			t.logger.Error("sweep stale ecmp group", zap.Uint32("group_id", id), zap.Error(err))
+			continue
+		}
+		t.logger.Info("swept ecmp group left by a previous run", zap.Uint32("group_id", id))
+	}
+
+	groups, err := t.ecmp.ListEcmpGroups()
+	if err != nil {
+		t.logger.Error("list ecmp groups; id allocation may collide with surviving groups", zap.Error(err))
+		return
+	}
+	for id := range groups {
+		if id > t.nextID {
+			t.nextID = id
+		}
+	}
+	if t.nextID > 0 {
+		t.logger.Info("resuming ecmp group id allocation above surviving groups",
+			zap.Uint32("highest_in_use", t.nextID))
+	}
+}
+
+func (t *vpnGroupTable) allocID() (uint32, error) {
+	if n := len(t.freeIDs); n > 0 {
+		id := t.freeIDs[n-1]
+		t.freeIDs = t.freeIDs[:n-1]
+		return id, nil
+	}
+	if t.nextID == ^uint32(0) {
+		return 0, fmt.Errorf("ecmp group id space exhausted")
+	}
+	t.nextID++
+	return t.nextID, nil
+}
+
+// upsert records one path for a prefix and returns the destination to
+// reconcile. ok is false when the path was refused by a bound.
+func (t *vpnGroupTable) upsert(dk vpnDestKey, pk vpnPathKey, p *vpnPath) (*vpnDest, bool) {
+	d, ok := t.dests[dk]
+	if !ok {
+		if len(t.dests) >= maxTrackedVPNDests {
+			t.logger.Warn("VPN destination table full; dropping prefix",
+				zap.String("prefix", dk.prefix), zap.Int("limit", maxTrackedVPNDests))
+			return nil, false
+		}
+		id, err := t.allocID()
+		if err != nil {
+			t.logger.Error("allocate ecmp group id",
+				zap.String("prefix", dk.prefix), zap.Error(err))
+			return nil, false
+		}
+		d = &vpnDest{groupID: id, paths: make(map[vpnPathKey]*vpnPath)}
+		t.dests[dk] = d
+	}
+	if _, exists := d.paths[pk]; !exists && len(d.paths) >= maxPathsPerDest {
+		t.logger.Warn("path table full for prefix; dropping path",
+			zap.String("prefix", dk.prefix), zap.String("source", pk.source.String()),
+			zap.Int("limit", maxPathsPerDest))
+		return nil, false
+	}
+	d.paths[pk] = p
+	return d, true
+}
+
+// remove drops one path. It returns the destination when one still exists,
+// along with the steering reference the removed path held so the caller can
+// release it.
+func (t *vpnGroupTable) remove(dk vpnDestKey, pk vpnPathKey) (*vpnDest, *policyKey) {
+	d, ok := t.dests[dk]
+	if !ok {
+		return nil, nil
+	}
+	old := d.paths[pk]
+	delete(d.paths, pk)
+	var released *policyKey
+	if old != nil {
+		released = old.steer
+	}
+	return d, released
+}
+
+// members picks the paths to program, in a deterministic order.
+//
+// Sorting matters beyond tidiness: the data plane selects by hash modulo
+// the member list, so if the order depended on Go's map iteration the same
+// set of paths would spread flows differently on every reconcile and every
+// restart. Sorting by SID pins it.
+//
+// Two paths that resolve to the same SID are the same forwarding outcome
+// (typically one PE re-advertised under a second RD), so they are deduped:
+// programming both would silently double that PE's share of the traffic.
+func (d *vpnDest) members() []*vpnPath {
+	out := make([]*vpnPath, 0, len(d.paths))
+	for _, p := range d.paths {
+		out = append(out, p)
+	}
+	slices.SortFunc(out, func(a, b *vpnPath) int { return cmp.Compare(a.sid, b.sid) })
+	out = slices.CompactFunc(out, func(a, b *vpnPath) bool { return a.sid == b.sid })
+	if len(out) > bpf.EcmpMaxPaths {
+		out = out[:bpf.EcmpMaxPaths]
+	}
+	return out
+}
+
+// memberFingerprint renders the programmed member set so an unchanged
+// reconcile can be skipped. The steering target is part of it: a path whose
+// color changed keeps its SID but must be rewritten with a new policy id.
+func memberFingerprint(ms []*vpnPath) []string {
+	out := make([]string, len(ms))
+	for i, m := range ms {
+		if m.steer == nil {
+			out[i] = m.sid
+			continue
+		}
+		out[i] = fmt.Sprintf("%s@%d/%s", m.sid, m.steer.color, m.steer.endpoint)
+	}
+	return out
+}
+
+// reconcileVPNGroup writes the destination's current member set to the data
+// plane: the ECMP group holding one headend entry per member, and the
+// trigger entry the dispatcher matches on.
+//
+// The trigger carries the first member's segments as well as the group id.
+// The data plane falls back to a trigger's own segments when a group cannot
+// be resolved, so this turns the two windows where that happens -- a
+// reconcile mid-update, and the gap after a restart sweeps the old groups
+// -- into single-path forwarding instead of a drop.
+func (a *Applier) reconcileVPNGroup(dk vpnDestKey, d *vpnDest) {
+	ms := d.members()
+	if len(ms) == 0 {
+		a.retireVPNGroup(dk, d)
+		return
+	}
+	fingerprint := memberFingerprint(ms)
+	if slices.Equal(fingerprint, d.installed) {
+		return
+	}
+
+	// Resolve each member's steering id before building anything: the id is
+	// stamped into the member's own encap entry, so paths steered onto
+	// different SR Policies stay steered after aggregation.
+	paths := make([]bpf.EcmpPath, 0, len(ms))
+	for _, m := range ms {
+		entry, err := a.buildHeadendEntry(m.sid)
+		if err != nil {
+			a.logger.Error("build ECMP member",
+				zap.String("prefix", dk.prefix), zap.String("sid", m.sid), zap.Error(err))
+			return
+		}
+		if m.steer != nil {
+			entry.PolicyId = a.srPolicy.idOf(m.steer.color, m.steer.endpoint)
+		}
+		// Equal weights: BGP multipath has no notion of relative capacity,
+		// so every path carries the same share until something (a weighted
+		// SR Policy, a prober) says otherwise.
+		paths = append(paths, bpf.EcmpPath{Entry: entry, Weight: 1})
+	}
+	owner := a.vpnGroups.groupOwner()
+	if err := a.vpnGroups.ecmp.PutEcmpGroup(d.groupID, paths, owner); err != nil {
+		a.logger.Error("install ECMP group",
+			zap.String("prefix", dk.prefix), zap.Uint32("group_id", d.groupID), zap.Error(err))
+		return
+	}
+
+	// The trigger mirrors the first member so the fallback forwards the same
+	// way the group's first path would, steering included.
+	trigger, err := a.buildHeadendEntry(ms[0].sid)
+	if err != nil {
+		a.logger.Error("build ECMP trigger",
+			zap.String("prefix", dk.prefix), zap.Error(err))
+		return
+	}
+	if ms[0].steer != nil {
+		trigger.PolicyId = a.srPolicy.idOf(ms[0].steer.color, ms[0].steer.endpoint)
+	}
+	trigger.GroupId = d.groupID
+	if err := a.createHeadend(dk.family, dk.prefix, trigger, bpf.OwnerBGPVPN(a.localASN, "")); err != nil {
+		a.logger.Error("install ECMP trigger",
+			zap.String("prefix", dk.prefix), zap.Error(err))
+		return
+	}
+	d.installed = fingerprint
+	a.logger.Info("VPN prefix programmed",
+		zap.String("prefix", dk.prefix), zap.Int("paths", len(ms)),
+		zap.Uint32("group_id", d.groupID))
+}
+
+// retireVPNGroup tears down a destination whose last path went away and
+// returns its group id for reuse.
+func (a *Applier) retireVPNGroup(dk vpnDestKey, d *vpnDest) {
+	owner := a.vpnGroups.groupOwner()
+	if err := a.deleteHeadend(dk.family, dk.prefix, bpf.OwnerBGPVPN(a.localASN, "")); err != nil {
+		a.logger.Error("withdraw VPN trigger",
+			zap.String("prefix", dk.prefix), zap.Error(err))
+	}
+	// The trigger goes first: while the group still exists a stale trigger
+	// forwards correctly, whereas deleting the group first would leave the
+	// trigger resolving to its fallback segments for no reason.
+	if err := a.vpnGroups.ecmp.DeleteEcmpGroup(d.groupID, owner); err != nil {
+		a.logger.Error("delete ECMP group",
+			zap.String("prefix", dk.prefix), zap.Uint32("group_id", d.groupID), zap.Error(err))
+		return
+	}
+	delete(a.vpnGroups.dests, dk)
+	a.vpnGroups.freeIDs = append(a.vpnGroups.freeIDs, d.groupID)
+	a.logger.Info("VPN prefix withdrawn",
+		zap.String("prefix", dk.prefix), zap.Uint32("group_id", d.groupID))
+}

--- a/pkg/bgp/apply/vpngroup.go
+++ b/pkg/bgp/apply/vpngroup.go
@@ -2,6 +2,7 @@ package apply
 
 import (
 	"cmp"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -223,11 +224,35 @@ func (t *vpnGroupTable) remove(dk vpnDestKey, pk vpnPathKey) (*vpnDest, *policyK
 // (typically one PE re-advertised under a second RD), so they are deduped:
 // programming both would silently double that PE's share of the traffic.
 func (d *vpnDest) members() []*vpnPath {
-	out := make([]*vpnPath, 0, len(d.paths))
-	for _, p := range d.paths {
-		out = append(out, p)
+	type keyed struct {
+		key vpnPathKey
+		p   *vpnPath
 	}
-	slices.SortFunc(out, func(a, b *vpnPath) int { return cmp.Compare(a.sid, b.sid) })
+	all := make([]keyed, 0, len(d.paths))
+	for k, p := range d.paths {
+		all = append(all, keyed{k, p})
+	}
+	// SID orders the members, but SortFunc is not stable and two paths can
+	// share a SID, so the key breaks the tie. Without it the survivor of the
+	// dedupe below would depend on map iteration order -- and since the paths
+	// sharing a SID can carry different colors, the programmed policy id
+	// would flip between reconciles and defeat the unchanged-set skip.
+	slices.SortFunc(all, func(a, b keyed) int {
+		if c := cmp.Compare(a.p.sid, b.p.sid); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.key.rd, b.key.rd); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.key.source.Peer.String(), b.key.source.Peer.String()); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.key.source.PathID, b.key.source.PathID)
+	})
+	out := make([]*vpnPath, 0, len(all))
+	for _, k := range all {
+		out = append(out, k.p)
+	}
 	out = slices.CompactFunc(out, func(a, b *vpnPath) bool { return a.sid == b.sid })
 	if len(out) > bpf.EcmpMaxPaths {
 		out = out[:bpf.EcmpMaxPaths]
@@ -308,7 +333,7 @@ func (a *Applier) reconcileVPNGroup(dk vpnDestKey, d *vpnDest) {
 		trigger.PolicyId = a.srPolicy.idOf(ms[0].steer.color, ms[0].steer.endpoint)
 	}
 	trigger.GroupId = d.groupID
-	if err := a.createHeadend(dk.family, dk.prefix, trigger, bpf.OwnerBGPVPN(a.localASN, "")); err != nil {
+	if err := a.createTrigger(dk.family, dk.prefix, trigger); err != nil {
 		a.logger.Error("install ECMP trigger",
 			zap.String("prefix", dk.prefix), zap.Error(err))
 		return
@@ -323,7 +348,7 @@ func (a *Applier) reconcileVPNGroup(dk vpnDestKey, d *vpnDest) {
 // returns its group id for reuse.
 func (a *Applier) retireVPNGroup(dk vpnDestKey, d *vpnDest) {
 	owner := a.vpnGroups.groupOwner()
-	if err := a.deleteHeadend(dk.family, dk.prefix, bpf.OwnerBGPVPN(a.localASN, "")); err != nil {
+	if err := a.deleteTrigger(dk.family, dk.prefix); err != nil {
 		a.logger.Error("withdraw VPN trigger",
 			zap.String("prefix", dk.prefix), zap.Error(err))
 	}
@@ -339,4 +364,78 @@ func (a *Applier) retireVPNGroup(dk vpnDestKey, d *vpnDest) {
 	a.vpnGroups.freeIDs = append(a.vpnGroups.freeIDs, d.groupID)
 	a.logger.Info("VPN prefix withdrawn",
 		zap.String("prefix", dk.prefix), zap.Uint32("group_id", d.groupID))
+}
+
+// clearLegacyVPNHeadend removes a trigger left by the pre-aggregation
+// writer, which owned each prefix per RD.
+//
+// Those entries survive in the pinned headend maps across an upgrade, and
+// the aggregating writer's owner is RD-independent, so without this every
+// previously installed prefix fails the cross-owner check and never comes
+// back -- and a withdraw arriving for one cannot remove it either.
+//
+// The owner is read first and force-deleted only when it is this node's own
+// legacy shape. An unconditional force would also destroy an entry an
+// operator installed for the same prefix over RPC.
+//
+// Reports whether anything was cleared, so the caller knows a retry is
+// worth attempting.
+func (a *Applier) clearLegacyVPNHeadend(fam bgp.Family, prefix string) bool {
+	var (
+		owner bpf.OwnerTag
+		found bool
+		err   error
+	)
+	switch fam {
+	case bgp.FamilyVPNv4:
+		owner, found, err = a.headend.GetHeadendV4Owner(prefix)
+	case bgp.FamilyVPNv6:
+		owner, found, err = a.headend.GetHeadendV6Owner(prefix)
+	default:
+		return false
+	}
+	if err != nil || !found || !bpf.IsLegacyBGPVPNOwner(a.localASN, owner) {
+		return false
+	}
+	switch fam {
+	case bgp.FamilyVPNv4:
+		err = a.headend.ForceDeleteHeadendV4(prefix)
+	case bgp.FamilyVPNv6:
+		err = a.headend.ForceDeleteHeadendV6(prefix)
+	}
+	if err != nil {
+		a.logger.Error("clear pre-aggregation VPN trigger",
+			zap.String("prefix", prefix), zap.String("owner", string(owner)), zap.Error(err))
+		return false
+	}
+	a.logger.Info("cleared pre-aggregation VPN trigger",
+		zap.String("prefix", prefix), zap.String("owner", string(owner)))
+	return true
+}
+
+// createTrigger writes the trigger entry, migrating off a pre-aggregation
+// owner if one is in the way.
+func (a *Applier) createTrigger(fam bgp.Family, prefix string, entry *bpf.HeadendEntry) error {
+	owner := bpf.OwnerBGPVPN(a.localASN, "")
+	err := a.createHeadend(fam, prefix, entry, owner)
+	if !errors.Is(err, bpf.ErrEntryOwnerMismatch) {
+		return err
+	}
+	if !a.clearLegacyVPNHeadend(fam, prefix) {
+		return err
+	}
+	return a.createHeadend(fam, prefix, entry, owner)
+}
+
+// deleteTrigger removes the trigger entry, including one left by the
+// pre-aggregation writer.
+func (a *Applier) deleteTrigger(fam bgp.Family, prefix string) error {
+	err := a.deleteHeadend(fam, prefix, bpf.OwnerBGPVPN(a.localASN, ""))
+	if !errors.Is(err, bpf.ErrEntryOwnerMismatch) {
+		return err
+	}
+	if a.clearLegacyVPNHeadend(fam, prefix) {
+		return nil
+	}
+	return err
 }

--- a/pkg/bgp/apply/vpngroup_test.go
+++ b/pkg/bgp/apply/vpngroup_test.go
@@ -189,6 +189,26 @@ func TestVPNGroup_ResetSweepsOwnGroupsAndSkipsOthers(t *testing.T) {
 	}
 }
 
+// A group can exist with no owner recorded -- written by a build that
+// predates owner tracking, or one whose owner write was lost. It is not ours
+// to sweep, but its id is still occupied, so allocation must step over it.
+func TestVPNGroup_ResetSkipsUnownedGroupIDs(t *testing.T) {
+	fh := newFakeHeadend()
+	fh.ecmpGroups[7] = nil // present in the group table, absent from the owner table
+
+	a := NewApplier(fh, testLocatorManager(t), vrfbgp.NewManager(), &fakeFib{}, "LOC1", 65000, zap.NewNop())
+
+	// Not ours to sweep: destroying a group we cannot attribute could take
+	// out one another component installed.
+	if _, present := fh.ecmpGroups[7]; !present {
+		t.Error("swept a group with no recorded owner")
+	}
+	a.Apply(vpnEvent("10.0.0.0/24", "65000:1", "fd00:1:1:a::", "fd00::1", false))
+	if got := fh.v4created["10.0.0.0/24"].GroupId; got == 7 {
+		t.Errorf("allocated group id 7, which an unowned group already occupies")
+	}
+}
+
 // A rolling upgrade finds the pinned headend maps holding entries written by
 // the pre-aggregation code, which owned each prefix per RD. The aggregating
 // writer's owner is RD-independent, so without a migration path every one of

--- a/pkg/bgp/apply/vpngroup_test.go
+++ b/pkg/bgp/apply/vpngroup_test.go
@@ -188,3 +188,95 @@ func TestVPNGroup_ResetSweepsOwnGroupsAndSkipsOthers(t *testing.T) {
 		t.Errorf("allocated group id %d, which another owner holds", got)
 	}
 }
+
+// A rolling upgrade finds the pinned headend maps holding entries written by
+// the pre-aggregation code, which owned each prefix per RD. The aggregating
+// writer's owner is RD-independent, so without a migration path every one of
+// those prefixes fails the cross-owner check and never comes back.
+func TestVPNGroup_UpgradesOffTheLegacyPerRDOwner(t *testing.T) {
+	t.Run("re-advertise replaces a legacy entry", func(t *testing.T) {
+		fh := newFakeHeadend()
+		fh.v4owners["10.0.0.0/24"] = bpf.OwnerBGPVPN(65000, "65000:1")
+		fh.v4created["10.0.0.0/24"] = &bpf.HeadendEntry{}
+
+		a := NewApplier(fh, testLocatorManager(t), vrfbgp.NewManager(), &fakeFib{}, "LOC1", 65000, zap.NewNop())
+		a.Apply(vpnEvent("10.0.0.0/24", "65000:1", "fd00:1:1:a::", "fd00::1", false))
+
+		trigger := fh.v4created["10.0.0.0/24"]
+		if trigger == nil || trigger.GroupId == 0 {
+			t.Fatal("legacy entry blocked the aggregating writer")
+		}
+		if len(fh.v4forced) != 1 {
+			t.Errorf("legacy entry was not cleared: forced=%v", fh.v4forced)
+		}
+	})
+
+	t.Run("withdraw removes a legacy entry", func(t *testing.T) {
+		// The prefix was installed before the upgrade and withdrawn before it
+		// was ever re-advertised, so nothing is tracked and the old owner is
+		// the only thing standing between it and a permanent stale entry.
+		fh := newFakeHeadend()
+		fh.v4owners["10.0.0.0/24"] = bpf.OwnerBGPVPN(65000, "65000:1")
+		fh.v4created["10.0.0.0/24"] = &bpf.HeadendEntry{}
+
+		a := NewApplier(fh, testLocatorManager(t), vrfbgp.NewManager(), &fakeFib{}, "LOC1", 65000, zap.NewNop())
+		a.Apply(vpnEvent("10.0.0.0/24", "65000:1", "", "fd00::1", true))
+
+		if _, still := fh.v4created["10.0.0.0/24"]; still {
+			t.Error("legacy entry survived its withdraw")
+		}
+	})
+
+	t.Run("another owner's entry is left alone", func(t *testing.T) {
+		// An operator's RPC-installed entry for the same prefix must not be
+		// destroyed by a BGP route; only this node's own legacy shape is
+		// cleared.
+		fh := newFakeHeadend()
+		fh.v4owners["10.0.0.0/24"] = bpf.OwnerRPC
+		rpcEntry := &bpf.HeadendEntry{}
+		fh.v4created["10.0.0.0/24"] = rpcEntry
+
+		a := NewApplier(fh, testLocatorManager(t), vrfbgp.NewManager(), &fakeFib{}, "LOC1", 65000, zap.NewNop())
+		a.Apply(vpnEvent("10.0.0.0/24", "65000:1", "fd00:1:1:a::", "fd00::1", false))
+
+		if len(fh.v4forced) != 0 {
+			t.Errorf("force-deleted an entry owned by %q", bpf.OwnerRPC)
+		}
+		if fh.v4created["10.0.0.0/24"] != rpcEntry {
+			t.Error("the RPC-owned entry was overwritten")
+		}
+	})
+}
+
+// Two paths can share a SID while carrying different colors. The survivor of
+// the dedupe decides the programmed policy id, so it must not depend on map
+// iteration order or the group would flap between reconciles.
+func TestVPNGroup_DedupeIsDeterministic(t *testing.T) {
+	pick := func() string {
+		fh := newFakeHeadend()
+		a := NewApplier(fh, testLocatorManager(t), vrfbgp.NewManager(), &fakeFib{}, "LOC1", 65000, zap.NewNop())
+		for _, rd := range []string{"65000:3", "65000:1", "65000:2"} {
+			ev := vpnEvent("10.0.0.0/24", rd, "fd00:1:1:a::", "fd00::1", false)
+			a.Apply(ev)
+		}
+		d := a.vpnGroups.dests[vpnDestKey{family: bgp.FamilyVPNv4, prefix: "10.0.0.0/24"}]
+		ms := d.members()
+		if len(ms) != 1 {
+			t.Fatalf("expected the shared SID to dedupe to one member, got %d", len(ms))
+		}
+		// Identify the survivor by the key that still maps to it.
+		for k, p := range d.paths {
+			if p == ms[0] {
+				return k.rd
+			}
+		}
+		t.Fatal("survivor is not one of the tracked paths")
+		return ""
+	}
+	first := pick()
+	for range 20 {
+		if got := pick(); got != first {
+			t.Fatalf("dedupe survivor is not deterministic: %q then %q", first, got)
+		}
+	}
+}

--- a/pkg/bgp/apply/vpngroup_test.go
+++ b/pkg/bgp/apply/vpngroup_test.go
@@ -1,0 +1,190 @@
+package apply
+
+import (
+	"net/netip"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/takehaya/vinbero/pkg/bgp"
+	"github.com/takehaya/vinbero/pkg/bpf"
+	"github.com/takehaya/vinbero/pkg/vrfbgp"
+)
+
+func vpnEvent(prefix, rd, sid, peer string, withdraw bool) bgp.RouteEvent {
+	return bgp.RouteEvent{
+		Family:     bgp.FamilyVPNv4,
+		Source:     bgp.PathSource{Peer: netip.MustParseAddr(peer)},
+		IsWithdraw: withdraw,
+		VPN: &bgp.VPNRoute{
+			Family: bgp.FamilyVPNv4, Prefix: prefix, RD: rd, SRv6SID: sid,
+		},
+	}
+}
+
+func groupSIDs(t *testing.T, fh *fakeHeadend, groupID uint32) []string {
+	t.Helper()
+	paths, ok := fh.ecmpGroups[groupID]
+	if !ok {
+		t.Fatalf("group %d was not installed", groupID)
+	}
+	out := make([]string, len(paths))
+	for i, p := range paths {
+		out[i] = netip.AddrFrom16(p.Entry.DstAddr).String()
+	}
+	return out
+}
+
+// TestVPNGroup_MultiPEAggregation is the defect this table exists to fix.
+// Two PEs advertise one prefix under their own RDs. The old code keyed the
+// headend entry by prefix under an RD-scoped owner, so the second PE's
+// write failed the cross-owner check and its path was dropped entirely.
+func TestVPNGroup_MultiPEAggregation(t *testing.T) {
+	fh := newFakeHeadend()
+	a := NewApplier(fh, testLocatorManager(t), vrfbgp.NewManager(), &fakeFib{}, "LOC1", 65000, zap.NewNop())
+
+	a.Apply(vpnEvent("10.0.0.0/24", "65000:1", "fd00:1:1:a::", "fd00::1", false))
+	a.Apply(vpnEvent("10.0.0.0/24", "65000:2", "fd00:1:1:b::", "fd00::2", false))
+
+	trigger, ok := fh.v4created["10.0.0.0/24"]
+	if !ok {
+		t.Fatal("trigger entry was not installed")
+	}
+	if trigger.GroupId == 0 {
+		t.Fatal("trigger must reference an ECMP group")
+	}
+	sids := groupSIDs(t, fh, trigger.GroupId)
+	if len(sids) != 2 {
+		t.Fatalf("group holds %d paths (%v), want both PEs", len(sids), sids)
+	}
+	// Deterministic order: the data plane selects by hash modulo the member
+	// list, so map iteration order must not leak into path selection.
+	if sids[0] >= sids[1] {
+		t.Errorf("members are not sorted: %v", sids)
+	}
+	// The trigger's own segments are the fallback used when the group cannot
+	// be resolved, so they must name a real path rather than stay empty.
+	if got := netip.AddrFrom16(trigger.DstAddr).String(); got != sids[0] {
+		t.Errorf("trigger fallback = %s, want the first member %s", got, sids[0])
+	}
+}
+
+func TestVPNGroup_WithdrawOnePathKeepsTheRest(t *testing.T) {
+	fh := newFakeHeadend()
+	a := NewApplier(fh, testLocatorManager(t), vrfbgp.NewManager(), &fakeFib{}, "LOC1", 65000, zap.NewNop())
+
+	a.Apply(vpnEvent("10.0.0.0/24", "65000:1", "fd00:1:1:a::", "fd00::1", false))
+	a.Apply(vpnEvent("10.0.0.0/24", "65000:2", "fd00:1:1:b::", "fd00::2", false))
+	a.Apply(vpnEvent("10.0.0.0/24", "65000:1", "fd00:1:1:a::", "fd00::1", true))
+
+	trigger := fh.v4created["10.0.0.0/24"]
+	if trigger == nil {
+		t.Fatal("prefix must survive one PE withdrawing")
+	}
+	if sids := groupSIDs(t, fh, trigger.GroupId); len(sids) != 1 || sids[0] != "fd00:1:1:b::" {
+		t.Fatalf("after withdraw group = %v, want only the surviving PE", sids)
+	}
+	if len(fh.v4deleted) != 0 {
+		t.Errorf("prefix was torn down while a path remained: %v", fh.v4deleted)
+	}
+}
+
+func TestVPNGroup_LastWithdrawTearsDown(t *testing.T) {
+	fh := newFakeHeadend()
+	a := NewApplier(fh, testLocatorManager(t), vrfbgp.NewManager(), &fakeFib{}, "LOC1", 65000, zap.NewNop())
+
+	a.Apply(vpnEvent("10.0.0.0/24", "65000:1", "fd00:1:1:a::", "fd00::1", false))
+	groupID := fh.v4created["10.0.0.0/24"].GroupId
+	a.Apply(vpnEvent("10.0.0.0/24", "65000:1", "fd00:1:1:a::", "fd00::1", true))
+
+	if len(fh.v4deleted) != 1 || fh.v4deleted[0] != "10.0.0.0/24" {
+		t.Errorf("DeleteHeadendV4 = %v, want the prefix torn down", fh.v4deleted)
+	}
+	if _, still := fh.ecmpGroups[groupID]; still {
+		t.Error("group outlived its last path")
+	}
+}
+
+// One PE re-advertising the same prefix under a second RD is the same
+// forwarding outcome; programming it twice would silently double that PE's
+// share of the traffic.
+func TestVPNGroup_DuplicateSIDsAreDeduped(t *testing.T) {
+	fh := newFakeHeadend()
+	a := NewApplier(fh, testLocatorManager(t), vrfbgp.NewManager(), &fakeFib{}, "LOC1", 65000, zap.NewNop())
+
+	a.Apply(vpnEvent("10.0.0.0/24", "65000:1", "fd00:1:1:a::", "fd00::1", false))
+	a.Apply(vpnEvent("10.0.0.0/24", "65000:2", "fd00:1:1:a::", "fd00::1", false))
+
+	trigger := fh.v4created["10.0.0.0/24"]
+	if sids := groupSIDs(t, fh, trigger.GroupId); len(sids) != 1 {
+		t.Fatalf("group holds %v, want one entry for one SID", sids)
+	}
+}
+
+// ADD-PATH: one peer, one RD, several paths. Without PathSource in the key
+// these would overwrite each other and collapse to a single path.
+func TestVPNGroup_AddPathFromOnePeer(t *testing.T) {
+	fh := newFakeHeadend()
+	a := NewApplier(fh, testLocatorManager(t), vrfbgp.NewManager(), &fakeFib{}, "LOC1", 65000, zap.NewNop())
+
+	mk := func(pathID uint32, sid string) bgp.RouteEvent {
+		ev := vpnEvent("10.0.0.0/24", "65000:1", sid, "fd00::1", false)
+		ev.Source.PathID = pathID
+		return ev
+	}
+	a.Apply(mk(1, "fd00:1:1:a::"))
+	a.Apply(mk(2, "fd00:1:1:b::"))
+
+	trigger := fh.v4created["10.0.0.0/24"]
+	if sids := groupSIDs(t, fh, trigger.GroupId); len(sids) != 2 {
+		t.Fatalf("group holds %v, want both ADD-PATH paths", sids)
+	}
+}
+
+func TestVPNGroup_ProgrammedPathsAreCapped(t *testing.T) {
+	fh := newFakeHeadend()
+	a := NewApplier(fh, testLocatorManager(t), vrfbgp.NewManager(), &fakeFib{}, "LOC1", 65000, zap.NewNop())
+
+	for i := range bpf.EcmpMaxPaths + 4 {
+		sid := netip.AddrFrom16([16]byte{0xfd, 0, 0, 1, 0, 1, 0, byte(i + 1)}).String()
+		ev := vpnEvent("10.0.0.0/24", "65000:1", sid, "fd00::1", false)
+		ev.Source.PathID = uint32(i + 1)
+		a.Apply(ev)
+	}
+	trigger := fh.v4created["10.0.0.0/24"]
+	if sids := groupSIDs(t, fh, trigger.GroupId); len(sids) != bpf.EcmpMaxPaths {
+		t.Fatalf("programmed %d paths, want the data plane cap of %d", len(sids), bpf.EcmpMaxPaths)
+	}
+}
+
+// A restart finds the previous run's groups still pinned. Their ids cannot
+// be matched back to prefixes, so they are swept rather than left as a new
+// generation of orphans, and allocation resumes above anything another
+// owner still holds.
+func TestVPNGroup_ResetSweepsOwnGroupsAndSkipsOthers(t *testing.T) {
+	fh := newFakeHeadend()
+	mine := bpf.OwnerBGPVPNGroup(65000)
+	fh.ecmpOwners[1] = mine
+	fh.ecmpOwners[2] = bpf.OwnerRPC
+	fh.ecmpOwners[3] = mine
+	fh.ecmpGroups[1] = nil
+	fh.ecmpGroups[2] = nil
+	fh.ecmpGroups[3] = nil
+
+	a := NewApplier(fh, testLocatorManager(t), vrfbgp.NewManager(), &fakeFib{}, "LOC1", 65000, zap.NewNop())
+
+	if _, still := fh.ecmpOwners[1]; still {
+		t.Error("group 1 was ours and should have been swept")
+	}
+	if _, still := fh.ecmpOwners[3]; still {
+		t.Error("group 3 was ours and should have been swept")
+	}
+	if _, kept := fh.ecmpOwners[2]; !kept {
+		t.Error("group 2 belongs to another owner and must survive")
+	}
+	// Allocation must not hand out 2, which another owner still holds.
+	a.Apply(vpnEvent("10.0.0.0/24", "65000:1", "fd00:1:1:a::", "fd00::1", false))
+	if got := fh.v4created["10.0.0.0/24"].GroupId; got == 2 {
+		t.Errorf("allocated group id %d, which another owner holds", got)
+	}
+}

--- a/pkg/bpf/maps.go
+++ b/pkg/bpf/maps.go
@@ -2094,13 +2094,32 @@ func (m *MapOperations) GetEcmpGroup(groupID uint32) (*EcmpGroupInfo, []*Headend
 	return &info, paths, nil
 }
 
-// ListEcmpGroups returns every installed group info keyed by group id.
+// GetHeadendV4Owner returns the owner recorded for a v4 trigger prefix, or
+// ("", false) when the entry or its owner is absent.
+func (m *MapOperations) GetHeadendV4Owner(triggerPrefix string) (OwnerTag, bool, error) {
+	key, err := buildLpmKeyV4(triggerPrefix)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to build LPM key: %w", err)
+	}
+	return m.headendV4Owners.Lookup(key)
+}
+
+// GetHeadendV6Owner is the v6 counterpart of GetHeadendV4Owner.
+func (m *MapOperations) GetHeadendV6Owner(triggerPrefix string) (OwnerTag, bool, error) {
+	key, err := buildLpmKeyV6(triggerPrefix)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to build LPM key: %w", err)
+	}
+	return m.headendV6Owners.Lookup(key)
+}
+
 // ListEcmpGroupOwners returns the owner tag recorded for every ECMP group.
 //
 // ecmp_group_owner_map is pinned, so this is what a restarted daemon reads
 // to find out which groups survived and who they belong to. A group present
-// in ecmp_group_map with no owner recorded is omitted; the caller should
-// treat its id as taken (see ListEcmpGroups) but must not assume ownership.
+// in ecmp_group_map with no owner recorded is omitted: the caller should
+// still treat its id as taken (ListEcmpGroups reports it) but must not
+// assume it owns it.
 func (m *MapOperations) ListEcmpGroupOwners() (map[uint32]OwnerTag, error) {
 	owners, err := m.ecmpGroupOwners.IterateU32()
 	if err != nil {
@@ -2109,6 +2128,7 @@ func (m *MapOperations) ListEcmpGroupOwners() (map[uint32]OwnerTag, error) {
 	return owners, nil
 }
 
+// ListEcmpGroups returns every installed group info keyed by group id.
 func (m *MapOperations) ListEcmpGroups() (map[uint32]*EcmpGroupInfo, error) {
 	result := make(map[uint32]*EcmpGroupInfo)
 	var key uint32

--- a/pkg/bpf/maps.go
+++ b/pkg/bpf/maps.go
@@ -2095,6 +2095,20 @@ func (m *MapOperations) GetEcmpGroup(groupID uint32) (*EcmpGroupInfo, []*Headend
 }
 
 // ListEcmpGroups returns every installed group info keyed by group id.
+// ListEcmpGroupOwners returns the owner tag recorded for every ECMP group.
+//
+// ecmp_group_owner_map is pinned, so this is what a restarted daemon reads
+// to find out which groups survived and who they belong to. A group present
+// in ecmp_group_map with no owner recorded is omitted; the caller should
+// treat its id as taken (see ListEcmpGroups) but must not assume ownership.
+func (m *MapOperations) ListEcmpGroupOwners() (map[uint32]OwnerTag, error) {
+	owners, err := m.ecmpGroupOwners.IterateU32()
+	if err != nil {
+		return nil, fmt.Errorf("ecmp group owners: %w", err)
+	}
+	return owners, nil
+}
+
 func (m *MapOperations) ListEcmpGroups() (map[uint32]*EcmpGroupInfo, error) {
 	result := make(map[uint32]*EcmpGroupInfo)
 	var key uint32

--- a/pkg/bpf/owner.go
+++ b/pkg/bpf/owner.go
@@ -70,6 +70,23 @@ func OwnerBGPVPNGroup(asn uint32) OwnerTag {
 	return OwnerTag(fmt.Sprintf("bgp:%s:asn=%d:vpngroup", OwnerTagVersion, asn))
 }
 
+// IsLegacyBGPVPNOwner reports whether tag is a pre-aggregation VPN owner
+// belonging to this node: the RD-scoped form OwnerBGPVPN produced when each
+// prefix was written per RD.
+//
+// It exists for the upgrade. Those entries persist in the pinned headend
+// maps, and the aggregating writer uses an RD-independent owner, so every
+// previously installed prefix would fail the cross-owner check and never
+// reinstall. Recognising the old shape lets the writer clear exactly its
+// own leftovers, and nothing else -- an operator's RPC-installed entry for
+// the same prefix must survive.
+func IsLegacyBGPVPNOwner(asn uint32, tag OwnerTag) bool {
+	prefix := fmt.Sprintf("bgp:%s:asn=%d:rd=", OwnerTagVersion, asn)
+	rd, ok := strings.CutPrefix(string(tag), prefix)
+	// An empty RD is the aggregating writer's own owner, not a legacy one.
+	return ok && rd != ""
+}
+
 // OwnerBGPMUP is the entry owner for a downlink H.Encaps headend installed from
 // a BGP MUP T1ST route (SAFI 85). Distinct from OwnerBGPVPN so MUP-owned entries
 // are attributed to MUP and not to an L3VPN route that may share the same RD.

--- a/pkg/bpf/owner.go
+++ b/pkg/bpf/owner.go
@@ -48,6 +48,28 @@ func OwnerBGPVPN(asn uint32, rd string) OwnerTag {
 	return OwnerTag(fmt.Sprintf("bgp:%s:asn=%d:rd=%s", OwnerTagVersion, asn, rd))
 }
 
+// OwnerBGPVPNGroup owns the ECMP groups holding the paths learned for VPN
+// prefixes.
+//
+// It is deliberately scoped by neither RD nor prefix. Not by RD, because a
+// prefix reachable through several PEs arrives under a different RD per PE
+// and an RD-scoped owner would make the second PE's path fail the
+// cross-owner check -- the very defect this aggregation removes (same
+// reasoning as OwnerBGPMUPGate). Not by prefix, because owner tags persist
+// into a 64-byte buffer and "asn + vpngroup + family + an expanded IPv6
+// prefix" runs to ~80 bytes, which would truncate silently and take both
+// the ownership check and any tag-derived bookkeeping down with it.
+//
+// One consequence is that the tag cannot say WHICH prefix a surviving group
+// belonged to. Group ids are therefore not resumed across a restart: the
+// applier sweeps the groups under this owner at startup and rebuilds them
+// as BGP re-advertises. Trigger entries carry fallback segments so a
+// briefly unresolvable group degrades to single-path forwarding rather than
+// dropping.
+func OwnerBGPVPNGroup(asn uint32) OwnerTag {
+	return OwnerTag(fmt.Sprintf("bgp:%s:asn=%d:vpngroup", OwnerTagVersion, asn))
+}
+
 // OwnerBGPMUP is the entry owner for a downlink H.Encaps headend installed from
 // a BGP MUP T1ST route (SAFI 85). Distinct from OwnerBGPVPN so MUP-owned entries
 // are attributed to MUP and not to an L3VPN route that may share the same RD.
@@ -187,6 +209,30 @@ func (o *entryOwnerMap) Delete(key any) error {
 		return err
 	}
 	return nil
+}
+
+// IterateU32 returns every (key, tag) pair in an owner map keyed by
+// uint32. Entries whose tag does not decode are skipped rather than
+// reported: an undecodable tag means the entry predates owner tracking or
+// was written by an incompatible build, and neither is worth failing a
+// startup scan over.
+func (o *entryOwnerMap) IterateU32() (map[uint32]OwnerTag, error) {
+	out := make(map[uint32]OwnerTag)
+	if o == nil {
+		return out, nil
+	}
+	var key uint32
+	var v [auxOwnerTagBytes]byte
+	iter := o.m.Iterate()
+	for iter.Next(&key, &v) {
+		if s, ok := decodeOwnerTag(v[:]); ok {
+			out[key] = OwnerTag(s)
+		}
+	}
+	if err := iter.Err(); err != nil {
+		return nil, fmt.Errorf("iterate owner map: %w", err)
+	}
+	return out, nil
 }
 
 // Lookup returns ("", false, nil) when no owner is recorded (the entry

--- a/pkg/bpf/owner_test.go
+++ b/pkg/bpf/owner_test.go
@@ -69,6 +69,7 @@ func TestOwnerTagWireFitsAuxBuffer(t *testing.T) {
 		OwnerBuiltin,
 		OwnerBGPVPN(4294967295, strings.Repeat("X", 8)),
 		OwnerBGPUnicast(4294967295),
+		OwnerBGPVPNGroup(4294967295),
 	}
 	for _, tag := range cases {
 		if l := len(tag); l > auxOwnerTagBytes-1 {
@@ -97,5 +98,23 @@ func TestCheckEntryOwnerEmptyCallerRejected(t *testing.T) {
 	// sentinel; checkEntryOwner must reject it up front.
 	if _, err := checkEntryOwner(nil, "any-key", ""); err != ErrEmptyOwner {
 		t.Errorf("empty caller: got %v, want ErrEmptyOwner", err)
+	}
+}
+
+// TestOwnerBGPVPNGroup covers the one job this owner has: being shared by
+// every path that contributes to a prefix's group. An RD- or prefix-scoped
+// owner would either reject the second PE's path as a cross-owner write or
+// overflow the 64-byte tag buffer (see TestOwnerTagWireFitsAuxBuffer).
+func TestOwnerBGPVPNGroup(t *testing.T) {
+	const asn = 65000
+	if a, b := OwnerBGPVPNGroup(asn), OwnerBGPVPNGroup(asn); a != b {
+		t.Fatalf("owner is not stable: %q vs %q", a, b)
+	}
+	if OwnerBGPVPNGroup(asn) == OwnerBGPVPNGroup(asn+1) {
+		t.Error("different ASNs must not share an owner")
+	}
+	// Must not collide with the per-RD owner used for the trigger entries.
+	if OwnerBGPVPNGroup(asn) == OwnerBGPVPN(asn, "65000:1") {
+		t.Error("group owner collides with the plain VPN owner")
 	}
 }


### PR DESCRIPTION
ECMP シリーズ (docs/plan/ecmp-support.md) の PR2 後半です。PR #119 で入れた `PathSource` を実際に使い、受信した VPN 経路を prefix 単位で ECMP group に集約します。

## 直る問題

これは multipath 化の話だけではありません。**現状は 2 台目の PE の経路が捨てられています。**

集約前は prefix をそのまま headend map に書き、owner を `OwnerBGPVPN(asn, rd)` としていました。同じ prefix を広告する PE はそれぞれ自分の RD を使うので、2 台目の書き込みは cross-owner チェックに掛かって `ErrEntryOwnerMismatch` で失敗し、経路はログに Error を残して破棄されます。さらに 1 台目が withdraw すると、生き残っている PE の経路は BGP が再送しない限り復活しないので、その prefix は blackhole します。

## 設計

- **集約単位は `{family, prefix}`。** RD は key に含めません。RD を入れると 2 台目の PE が別エントリになり上書きが起きます
- **path の識別は `{rd, PathSource}`。** RD が PE を、`PathSource` が peer 内の path を区別するので、2 台の PE からの広告も ADD-PATH で 1 peer から届く複数 path も別々に保持できます
- **member は SID で dedupe し SID 順に並べて 8 本で cap。** 並び順の固定は見た目のためではありません。data plane は member 数の剰余で選ぶので、map 反復順に依存すると reconcile のたびに flow の分散先が変わります。同じ SID に解決する path を両方 program すると、その PE の取り分が黙って倍になります
- **trigger に先頭 member の segments も入れます。** data plane は group を解決できないとき trigger 自身の segments に fallback するので、reconcile 中や再起動直後の窓が drop でなく単一 path 転送に degrade します
- **steering は path ごと。** member は自分の path の color の policy id を刻み、参照は path レコードが持ちます。prefix 単位の `steeredRoutes` は置き換えて削除しました

## group id と再起動

group id は再起動を跨げません。owner tag は 64 バイトに収める必要があり、prefix を入れると IPv6 で 80 バイトになって無言で切り詰められるため、生き残った group をどの prefix のものか特定できないからです。

そこで起動時に自分が owner の group を sweep し、世代ごとの orphan が積み上がるのを防ぎます。他の owner が持つ group と衝突しないよう、残っている id の上から採番を再開します。sweep 中も pin された trigger は fallback segments で単一 path 転送を続けます。

## 既存テストが捕まえた回帰

`TestApplier_VPNWithdraw` が、追跡していない prefix の withdraw で削除が呼ばれない実装を検出しました。pin 環境では再起動前に入ったエントリを新プロセスは知らないため、withdraw が唯一の削除機会です。無条件削除を復元しています。

## テスト

`TestVPNGroup_*` を新規追加しました。

- 2 PE の集約と member の決定的順序、trigger fallback が実 path を指すこと
- 1 PE の withdraw で残りが生存すること、最後の withdraw で group ごと撤去されること
- 同一 SID の dedupe、ADD-PATH の複数 path 保持、8 本 cap
- 起動時 sweep が自分の group だけを消し、他 owner の id を再利用しないこと

既存の `pkg/bgp/...` 全 green、golangci-lint 0 issues。

## 残り

`docs/plan/ecmp-support.md` の PR3 以降 (kernel FIB multipath、HeadendGroupService、SR Policy weighted、EVPN RT1 aliasing、prober、interop) は後続です。