### PR TITLE
feat(fib): install multipath kernel routes

### DIFF
--- a/docs/design/ja/ecmp.md
+++ b/docs/design/ja/ecmp.md
@@ -99,6 +99,14 @@ trigger エントリには group_id に加えて先頭 member の segments も�
 
 group id は再起動を跨げません。owner tag は 64 バイトに収まる必要があり、prefix を入れると IPv6 で溢れるため、どの group がどの prefix のものだったかを記録できないからです。そこで起動時に自分が owner の group を sweep して世代ごとの orphan が積み上がるのを防ぎ、他の owner が持つ group と衝突しないよう、残っている id の上から採番を再開します。
 
+## kernel FIB の multipath
+
+BGP で学習した IPv6 unicast 経路は `pkg/fib` から kernel FIB に注入します。`Route` は next hop を複数持てるようになり、2 本以上あるとき netlink の `MultiPath` として渡します。
+
+next hop が 1 本のときは multipath でなく通常の gateway 経路として書きます。kernel は要素 1 つの multipath を通常経路に正規化して返すので、multipath で書くと同じ経路が round trip 後に自分自身と一致しなくなるためです。
+
+weight は 1 始まりの自然な値で扱い、netlink の境界で変換します。wire 上の `rtnh_hops` は weight より 1 小さいので、そのまま渡すと全 next hop の取り分が 1 つずつ増えてしまいます。境界で吸収しているので、上位のコードはこの差を意識しません。weight 0 は 1 と読みます。取り分ゼロの next hop を意図する呼び出し元は無いためです。
+
 ## 制約と今後
 
 - `mup_uplink_v4/v6_map` の値も `headend_entry` ですが、behavior プログラム内で lookup されるため group 解決を通りません。`CreateMupUplinkV4/V6` が書き込み時に `group_id` を 0 に強制します。

--- a/pkg/bgp/apply/applier.go
+++ b/pkg/bgp/apply/applier.go
@@ -328,7 +328,7 @@ func (a *Applier) applyUnicast(ur *bgp.UnicastRoute, withdraw bool) {
 				zap.String("nexthop", ur.NextHop), zap.Error(err))
 			return
 		}
-		r.NextHop = nh
+		r.NextHops = []fib.NextHop{{Gw: nh}}
 	}
 	if err := a.fib.Add(r); err != nil {
 		a.logger.Error("install unicast route",

--- a/pkg/fib/route.go
+++ b/pkg/fib/route.go
@@ -24,7 +24,10 @@ import (
 // routeProtocol marks every FIB entry Vinbero installs as BGP-originated.
 const routeProtocol = netlink.RouteProtocol(unix.RTPROT_BGP)
 
-// NextHop is one way out for a prefix.
+// NextHop is one way out for a prefix. At least one of Gw and Ifindex must
+// be set: with neither there is nothing for the kernel to resolve the hop
+// against. (A route with no next hop at all is a different thing and is
+// expressed by leaving Route.NextHops empty.)
 //
 // Weight is the natural 1-based share the kernel documents, NOT the
 // rtnh_hops value carried on the wire, which is one less. The conversion
@@ -32,9 +35,19 @@ const routeProtocol = netlink.RouteProtocol(unix.RTPROT_BGP)
 // a weight of 1 is encoded as 0. Weight 0 is read as 1: a zero-weight
 // next hop would take no traffic, which no caller means by "unset".
 type NextHop struct {
-	Gw      netip.Addr // zero value => directly connected
-	Ifindex int        // 0 = let the kernel resolve it from Gw
+	Gw      netip.Addr // zero value => on-link via Ifindex, which is then required
+	Ifindex int        // 0 = let the kernel resolve it from Gw, which is then required
 	Weight  int        // 0 or 1 = an equal share
+}
+
+// validate rejects a next hop the kernel could not resolve. Catching it here
+// turns a caller's mistake into an error naming the hop, rather than an
+// opaque netlink failure or, worse, a route that installs and blackholes.
+func (nh NextHop) validate(i int) error {
+	if !nh.Gw.IsValid() && nh.Ifindex == 0 {
+		return fmt.Errorf("fib: next hop %d has neither a gateway nor an interface", i)
+	}
+	return nil
 }
 
 // Route is a kernel FIB entry Vinbero manages for a BGP-learned prefix.
@@ -143,13 +156,19 @@ func toNetlinkRoute(r Route) (*netlink.Route, error) {
 	case 0:
 	case 1:
 		nh := r.NextHops[0]
+		if err := nh.validate(0); err != nil {
+			return nil, err
+		}
 		if nh.Gw.IsValid() {
 			nl.Gw = net.IP(nh.Gw.AsSlice())
 		}
 		nl.LinkIndex = nh.Ifindex
 	default:
 		nl.MultiPath = make([]*netlink.NexthopInfo, 0, len(r.NextHops))
-		for _, nh := range r.NextHops {
+		for i, nh := range r.NextHops {
+			if err := nh.validate(i); err != nil {
+				return nil, err
+			}
 			info := &netlink.NexthopInfo{
 				LinkIndex: nh.Ifindex,
 				Hops:      weightToHops(nh.Weight),

--- a/pkg/fib/route.go
+++ b/pkg/fib/route.go
@@ -32,12 +32,14 @@ const routeProtocol = netlink.RouteProtocol(unix.RTPROT_BGP)
 // Weight is the natural 1-based share the kernel documents, NOT the
 // rtnh_hops value carried on the wire, which is one less. The conversion
 // happens at the netlink boundary so nothing above it has to remember that
-// a weight of 1 is encoded as 0. Weight 0 is read as 1: a zero-weight
-// next hop would take no traffic, which no caller means by "unset".
+// a weight of 1 is encoded as 0. Any weight at or below 1 is read as an
+// equal share: a zero weight would mean a next hop that takes no traffic,
+// which no caller means by leaving the field unset, and clamping a negative
+// one is safer than letting it underflow into an enormous share.
 type NextHop struct {
 	Gw      netip.Addr // zero value => on-link via Ifindex, which is then required
 	Ifindex int        // 0 = let the kernel resolve it from Gw, which is then required
-	Weight  int        // 0 or 1 = an equal share
+	Weight  int        // <= 1 = an equal share
 }
 
 // validate rejects a next hop the kernel could not resolve. Catching it here

--- a/pkg/fib/route.go
+++ b/pkg/fib/route.go
@@ -24,12 +24,40 @@ import (
 // routeProtocol marks every FIB entry Vinbero installs as BGP-originated.
 const routeProtocol = netlink.RouteProtocol(unix.RTPROT_BGP)
 
+// NextHop is one way out for a prefix.
+//
+// Weight is the natural 1-based share the kernel documents, NOT the
+// rtnh_hops value carried on the wire, which is one less. The conversion
+// happens at the netlink boundary so nothing above it has to remember that
+// a weight of 1 is encoded as 0. Weight 0 is read as 1: a zero-weight
+// next hop would take no traffic, which no caller means by "unset".
+type NextHop struct {
+	Gw      netip.Addr // zero value => directly connected
+	Ifindex int        // 0 = let the kernel resolve it from Gw
+	Weight  int        // 0 or 1 = an equal share
+}
+
 // Route is a kernel FIB entry Vinbero manages for a BGP-learned prefix.
 type Route struct {
-	Prefix  netip.Prefix
-	NextHop netip.Addr // zero value => no gateway (directly connected)
-	Table   int        // 0 = main table
-	Metric  int        // route priority; 0 = kernel default
+	Prefix netip.Prefix
+	// NextHops is empty for a directly connected route, one element for an
+	// ordinary route, and several for a multipath one. A single next hop is
+	// deliberately encoded as a plain gateway rather than a one-element
+	// multipath: that is the form the kernel hands back, so encoding it any
+	// other way would make a route stop comparing equal to itself after a
+	// round trip.
+	NextHops []NextHop
+	Table    int // 0 = main table
+	Metric   int // route priority; 0 = kernel default
+}
+
+// weightToHops converts a natural 1-based weight to the rtnh_hops value the
+// kernel expects.
+func weightToHops(weight int) int {
+	if weight <= 1 {
+		return 0
+	}
+	return weight - 1
 }
 
 // Injector installs and removes routes in the kernel FIB. Implementations
@@ -111,8 +139,26 @@ func toNetlinkRoute(r Route) (*netlink.Route, error) {
 		Table:    r.Table,
 		Priority: r.Metric,
 	}
-	if r.NextHop.IsValid() {
-		nl.Gw = net.IP(r.NextHop.AsSlice())
+	switch len(r.NextHops) {
+	case 0:
+	case 1:
+		nh := r.NextHops[0]
+		if nh.Gw.IsValid() {
+			nl.Gw = net.IP(nh.Gw.AsSlice())
+		}
+		nl.LinkIndex = nh.Ifindex
+	default:
+		nl.MultiPath = make([]*netlink.NexthopInfo, 0, len(r.NextHops))
+		for _, nh := range r.NextHops {
+			info := &netlink.NexthopInfo{
+				LinkIndex: nh.Ifindex,
+				Hops:      weightToHops(nh.Weight),
+			}
+			if nh.Gw.IsValid() {
+				info.Gw = net.IP(nh.Gw.AsSlice())
+			}
+			nl.MultiPath = append(nl.MultiPath, info)
+		}
 	}
 	return nl, nil
 }
@@ -128,10 +174,22 @@ func fromNetlinkRoute(nl *netlink.Route) (Route, bool) {
 		return Route{}, false
 	}
 	r := Route{Prefix: prefix, Table: nl.Table, Metric: nl.Priority}
-	if len(nl.Gw) > 0 {
-		if nh, ok := netip.AddrFromSlice(nl.Gw); ok {
-			r.NextHop = nh.Unmap()
+	if len(nl.MultiPath) > 0 {
+		for _, info := range nl.MultiPath {
+			nh := NextHop{Ifindex: info.LinkIndex, Weight: info.Hops + 1}
+			if gw, ok := netip.AddrFromSlice(info.Gw); ok && len(info.Gw) > 0 {
+				nh.Gw = gw.Unmap()
+			}
+			r.NextHops = append(r.NextHops, nh)
 		}
+		return r, true
+	}
+	if len(nl.Gw) > 0 || nl.LinkIndex > 0 {
+		nh := NextHop{Ifindex: nl.LinkIndex, Weight: 1}
+		if gw, ok := netip.AddrFromSlice(nl.Gw); ok && len(nl.Gw) > 0 {
+			nh.Gw = gw.Unmap()
+		}
+		r.NextHops = []NextHop{nh}
 	}
 	return r, true
 }

--- a/pkg/fib/route_test.go
+++ b/pkg/fib/route_test.go
@@ -70,8 +70,8 @@ func TestKernelInjector_AddListDelete(t *testing.T) {
 	withTestNetns(t)
 	inj := NewKernelInjector()
 	r := Route{
-		Prefix:  netip.MustParsePrefix("fd00:dead::/64"),
-		NextHop: netip.MustParseAddr("fd00:f1b::2"),
+		Prefix:   netip.MustParsePrefix("fd00:dead::/64"),
+		NextHops: []NextHop{{Gw: netip.MustParseAddr("fd00:f1b::2")}},
 	}
 	if err := inj.Add(r); err != nil {
 		t.Fatalf("Add: %v", err)
@@ -86,8 +86,8 @@ func TestKernelInjector_AddListDelete(t *testing.T) {
 	if routes[0].Prefix != r.Prefix {
 		t.Errorf("listed prefix = %s, want %s", routes[0].Prefix, r.Prefix)
 	}
-	if routes[0].NextHop != r.NextHop {
-		t.Errorf("listed nexthop = %s, want %s", routes[0].NextHop, r.NextHop)
+	if len(routes[0].NextHops) != 1 || routes[0].NextHops[0].Gw != r.NextHops[0].Gw {
+		t.Errorf("listed nexthops = %v, want %v", routes[0].NextHops, r.NextHops)
 	}
 
 	if err := inj.Delete(r.Prefix); err != nil {
@@ -106,8 +106,8 @@ func TestKernelInjector_AddIsIdempotent(t *testing.T) {
 	withTestNetns(t)
 	inj := NewKernelInjector()
 	r := Route{
-		Prefix:  netip.MustParsePrefix("fd00:beef::/64"),
-		NextHop: netip.MustParseAddr("fd00:f1b::2"),
+		Prefix:   netip.MustParsePrefix("fd00:beef::/64"),
+		NextHops: []NextHop{{Gw: netip.MustParseAddr("fd00:f1b::2")}},
 	}
 	if err := inj.Add(r); err != nil {
 		t.Fatalf("first Add: %v", err)
@@ -145,7 +145,7 @@ func TestKernelInjector_ListFiltersByProtocol(t *testing.T) {
 
 	inj := NewKernelInjector()
 	bgpPrefix := netip.MustParsePrefix("fd00:dead::/64")
-	if err := inj.Add(Route{Prefix: bgpPrefix, NextHop: netip.MustParseAddr("fd00:f1b::2")}); err != nil {
+	if err := inj.Add(Route{Prefix: bgpPrefix, NextHops: []NextHop{{Gw: netip.MustParseAddr("fd00:f1b::2")}}}); err != nil {
 		t.Fatalf("Add BGP route: %v", err)
 	}
 
@@ -158,5 +158,97 @@ func TestKernelInjector_ListFiltersByProtocol(t *testing.T) {
 	}
 	if routes[0].Prefix != bgpPrefix {
 		t.Errorf("listed prefix = %s, want %s", routes[0].Prefix, bgpPrefix)
+	}
+}
+
+// TestWeightToHops pins the conversion at the netlink boundary. The kernel
+// carries rtnh_hops, which is one less than the weight it documents, so
+// passing a weight straight through would silently give every next hop one
+// extra share.
+func TestWeightToHops(t *testing.T) {
+	cases := []struct{ weight, hops int }{
+		{0, 0}, // unset reads as an equal share
+		{1, 0},
+		{2, 1},
+		{16, 15},
+		{-3, 0}, // nonsense weight must not underflow into a huge share
+	}
+	for _, c := range cases {
+		if got := weightToHops(c.weight); got != c.hops {
+			t.Errorf("weightToHops(%d) = %d, want %d", c.weight, got, c.hops)
+		}
+	}
+}
+
+// A prefix reachable through several PEs must reach the kernel as a real
+// multipath route and come back describing the same next hops, weights
+// included. The weight is where this is easy to get wrong: it round trips
+// through rtnh_hops, which is one less.
+func TestKernelInjector_MultipathRoundTrip(t *testing.T) {
+	withTestNetns(t)
+	inj := NewKernelInjector()
+
+	prefix := netip.MustParsePrefix("2001:db8:abcd::/64")
+	want := Route{
+		Prefix: prefix,
+		NextHops: []NextHop{
+			{Gw: netip.MustParseAddr("fd00:f1b::2"), Weight: 1},
+			{Gw: netip.MustParseAddr("fd00:f1b::3"), Weight: 3},
+		},
+	}
+	if err := inj.Add(want); err != nil {
+		t.Fatalf("Add multipath: %v", err)
+	}
+
+	routes, err := inj.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var got *Route
+	for i := range routes {
+		if routes[i].Prefix == prefix {
+			got = &routes[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("multipath route not listed; got %v", routes)
+	}
+	if len(got.NextHops) != 2 {
+		t.Fatalf("read back %d next hops, want 2: %+v", len(got.NextHops), got.NextHops)
+	}
+	byGw := map[string]int{}
+	for _, nh := range got.NextHops {
+		byGw[nh.Gw.String()] = nh.Weight
+	}
+	for _, w := range want.NextHops {
+		if got := byGw[w.Gw.String()]; got != w.Weight {
+			t.Errorf("next hop %s weight = %d, want %d (rtnh_hops conversion)",
+				w.Gw, got, w.Weight)
+		}
+	}
+
+	if err := inj.Delete(prefix); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+// One next hop must stay a plain gateway route. The kernel normalizes a
+// one-element multipath to that form anyway, so encoding it as multipath
+// would make the route stop comparing equal to itself after a round trip.
+func TestKernelInjector_SingleNextHopIsNotMultipath(t *testing.T) {
+	r := Route{
+		Prefix:   netip.MustParsePrefix("2001:db8:1::/64"),
+		NextHops: []NextHop{{Gw: netip.MustParseAddr("fd00:f1b::2")}},
+	}
+	nl, err := toNetlinkRoute(r)
+	if err != nil {
+		t.Fatalf("toNetlinkRoute: %v", err)
+	}
+	if len(nl.MultiPath) != 0 {
+		t.Errorf("single next hop encoded as multipath: %v", nl.MultiPath)
+	}
+	if nl.Gw == nil {
+		t.Error("single next hop must set Gw")
 	}
 }

--- a/pkg/fib/route_test.go
+++ b/pkg/fib/route_test.go
@@ -252,3 +252,37 @@ func TestKernelInjector_SingleNextHopIsNotMultipath(t *testing.T) {
 		t.Error("single next hop must set Gw")
 	}
 }
+
+// A next hop with neither a gateway nor an interface has nothing for the
+// kernel to resolve against. The old single-address field could not express
+// it; the list can, so it has to be rejected rather than turned into an
+// opaque netlink failure or a route that installs and blackholes.
+func TestToNetlinkRouteRejectsUnresolvableNextHop(t *testing.T) {
+	prefix := netip.MustParsePrefix("2001:db8:1::/64")
+	gw := netip.MustParseAddr("fd00:f1b::2")
+
+	cases := []struct {
+		name    string
+		hops    []NextHop
+		wantErr bool
+	}{
+		{"empty single", []NextHop{{}}, true},
+		{"empty among several", []NextHop{{Gw: gw}, {}}, true},
+		{"gateway only", []NextHop{{Gw: gw}}, false},
+		{"interface only", []NextHop{{Ifindex: 1}}, false},
+		// No next hop at all is a directly connected route, which is a
+		// different thing and stays legal.
+		{"none", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := toNetlinkRoute(Route{Prefix: prefix, NextHops: c.hops})
+			if c.wantErr && err == nil {
+				t.Error("unresolvable next hop was accepted")
+			}
+			if !c.wantErr && err != nil {
+				t.Errorf("valid next hop rejected: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
ECMP シリーズ (docs/plan/ecmp-support.md) の PR3 です。

## 背景

`pkg/fib` の `Route` は next hop を 1 本しか持てず、複数 PE から学習した prefix もそのうち 1 本でしか program できませんでした。`Route.NextHops []NextHop` に変え、2 本以上あるとき netlink の `MultiPath` として渡します。

## 設計で判断したこと

**next hop 1 本は multipath にしません。** kernel は要素 1 つの multipath を通常の gateway 経路に正規化して返すので、multipath で書くと同じ経路が `List` 経由の round trip 後に自分自身と一致しなくなります。

**weight は境界で変換します。** wire 上の `rtnh_hops` は weight より 1 小さい値です (netlink 自身の `String()` も `Hops+1` を weight として出力します)。そのまま渡すと全 next hop の取り分が 1 つずつ増えるので、netlink の境界で吸収し、上位のコードはこの差を意識しません。weight 0 は 1 と読みます。取り分ゼロの next hop を意図する呼び出し元は無いためです。

## スコープ

受信側は今のところ prefix あたり 1 本の next hop を入れたままです。unicast 経路を VPN 経路と同じように集約するのは別の変更にします。今回は data plane 側の表現力を先に用意する形です。

## テスト

- `TestWeightToHops` — 変換表。負値が巨大な取り分に化けないことも含みます
- `TestKernelInjector_MultipathRoundTrip` — 実 netns で multipath を書き、weight 込みで読み戻せること
- `TestKernelInjector_SingleNextHopIsNotMultipath` — 1 本が gateway 経路として encode されること
- 既存の `pkg/fib` / `pkg/bgp/...` 全 green、golangci-lint 0 issues