### PR TITLE
feat(srpolicy): decode every weighted Segment List

### DIFF
--- a/docs/design/ja/ecmp.md
+++ b/docs/design/ja/ecmp.md
@@ -133,5 +133,5 @@ program されるのは今のところ先頭の list だけです。data plane �
 
 - `mup_uplink_v4/v6_map` の値も `headend_entry` ですが、behavior プログラム内で lookup されるため group 解決を通りません。`CreateMupUplinkV4/V6` が書き込み時に `group_id` を 0 に強制します。
 - L2 headend (FDB → bd_peer) の aliasing は EVPN RT1 の対応と同時に入れます。ESI から group_id を引く side table を足し、この group 機構をそのまま使う予定です。
-- SR Policy の weighted segment list は受信側の decode が済んでいます (下記)。data plane 側は `sr_policy_value` に group_id を足し、`tailcall_ctx.flow_hash` で選択する形で拡張します。tailcall_ctx に flow_hash を先に載せてあるのはこのためです。
+- SR Policy の weighted segment list は受信側の decode が済んでいます (上記)。data plane 側は `sr_policy_value` に group_id を足し、`tailcall_ctx.flow_hash` で選択する形で拡張します。tailcall_ctx に flow_hash を先に載せてあるのはこのためです。
 - hash の seed は固定です。path 選択はノード内で per-flow に安定していればよく、固定 seed は BPF_PROG_TEST_RUN のテストを再現可能にします。

--- a/docs/design/ja/ecmp.md
+++ b/docs/design/ja/ecmp.md
@@ -115,9 +115,21 @@ prefix は group 側に記録されていないため、headend map を走査し
 
 liveness は「prober の報告がまだ無い」状態と「実際に全 path が生きている」状態を区別して出します。data plane はどちらも全 path を使うので挙動は同じですが、なぜトラフィックが動いたのかを調べるときに意味が違うためです。
 
+## SR Policy の weighted segment list
+
+candidate path は Segment List を複数持てて、まとめて weighted ECMP の集合になります (RFC 9256 2.2)。受信側はこれを全部 decode し、各 list の weight とともに `CandidatePath.SegmentLists` に載せます。従来は最初の 1 本だけ残して捨てていました。
+
+Weight sub-TLV が無い場合は等分として扱います。RFC 9256 は実装依存としていますが、0 と読むとその list を ECMP 集合から外すことになり、省略の意図と正反対になるためです。
+
+壊れた list は、その list だけを落とします。list が 1 本しか無い前提なら、壊れていたら candidate ごと ineligible にするのが正しい判断でした。より低い preference の代替に steer するより、読めなかった list から組んだ経路に流す方が危険だからです。複数ある場合、他の list は同じ endpoint への独立した記述なので、1 本の破損で全部落とすとまだ使える policy を落とすことになります。全 list が使えない candidate は従来どおり ineligible になります。
+
+segment を 1 つも指さない list も使えないものとして落とします。空のまま有効として扱うと、どこにも encap しない policy を install することになるためです。
+
+program されるのは今のところ先頭の list だけです。data plane 側の weighted 選択は後続の変更です。
+
 ## 制約と今後
 
 - `mup_uplink_v4/v6_map` の値も `headend_entry` ですが、behavior プログラム内で lookup されるため group 解決を通りません。`CreateMupUplinkV4/V6` が書き込み時に `group_id` を 0 に強制します。
 - L2 headend (FDB → bd_peer) の aliasing は EVPN RT1 の対応と同時に入れます。ESI から group_id を引く side table を足し、この group 機構をそのまま使う予定です。
-- SR Policy の weighted segment list (RFC 9256 の複数 Segment List sub-TLV) は `sr_policy_value` に group_id を足し、`tailcall_ctx.flow_hash` で選択する形で拡張できます。tailcall_ctx に flow_hash を先に載せてあるのはこのためです。
+- SR Policy の weighted segment list は受信側の decode が済んでいます (下記)。data plane 側は `sr_policy_value` に group_id を足し、`tailcall_ctx.flow_hash` で選択する形で拡張します。tailcall_ctx に flow_hash を先に載せてあるのはこのためです。
 - hash の seed は固定です。path 選択はノード内で per-flow に安定していればよく、固定 seed は BPF_PROG_TEST_RUN のテストを再現可能にします。

--- a/docs/design/ja/ecmp.md
+++ b/docs/design/ja/ecmp.md
@@ -119,7 +119,9 @@ liveness は「prober の報告がまだ無い」状態と「実際に全 path �
 
 candidate path は Segment List を複数持てて、まとめて weighted ECMP の集合になります (RFC 9256 2.2)。受信側はこれを全部 decode し、各 list の weight とともに `CandidatePath.SegmentLists` に載せます。従来は最初の 1 本だけ残して捨てていました。
 
-Weight sub-TLV が無い場合は等分として扱います。RFC 9256 は実装依存としていますが、0 と読むとその list を ECMP 集合から外すことになり、省略の意図と正反対になるためです。
+Weight sub-TLV が無い場合は等分として扱います。RFC 9256 が既定値を 1 と定めているためです。
+
+Weight sub-TLV があって値が 0 の場合は、その list を落とします。省略と明示的な 0 は別物で、同一視すると広告側の意図を上書きします。RFC 9256 は weight が 0 の segment list を invalid と規定しており、明示的な 0 は送信側がその list を ECMP 集合から外す意思表示です。既定値として読むと、送信側が無効化した list を復活させることになり、それが先頭なら実際に program される list になってしまいます。
 
 壊れた list は、その list だけを落とします。list が 1 本しか無い前提なら、壊れていたら candidate ごと ineligible にするのが正しい判断でした。より低い preference の代替に steer するより、読めなかった list から組んだ経路に流す方が危険だからです。複数ある場合、他の list は同じ endpoint への独立した記述なので、1 本の破損で全部落とすとまだ使える policy を落とすことになります。全 list が使えない candidate は従来どおり ineligible になります。
 

--- a/pkg/bgp/bgp.go
+++ b/pkg/bgp/bgp.go
@@ -318,9 +318,6 @@ type SRPolicy struct {
 // none is signaled (RFC 9256 §2.7).
 const SRPolicyDefaultPreference = 100
 
-// CandidatePath is one segment-list option for an SRPolicy. The active
-// path is chosen per RFC 9256 §2.9: highest Preference, then highest
-// Origin, then lowest Distinguisher.
 // WeightedSegmentList is one Segment List of a candidate path with the
 // share it takes (RFC 9256 §2.2). A candidate path may carry several, which
 // together form a weighted ECMP set.
@@ -334,7 +331,9 @@ type WeightedSegmentList struct {
 	Weight   uint32
 }
 
-// CandidatePath is one candidate path of an SR Policy (RFC 9256 §2.4).
+// CandidatePath is one segment-list option for an SRPolicy. The active
+// path is chosen per RFC 9256 §2.9: highest Preference, then highest
+// Origin, then lowest Distinguisher.
 type CandidatePath struct {
 	Origin        Origin
 	Distinguisher uint32
@@ -344,9 +343,33 @@ type CandidatePath struct {
 	// view every existing consumer uses.
 	SegmentList []netip.Addr
 	// SegmentLists holds every usable Segment List with its weight, in wire
-	// order. It is what weighted ECMP selects over; SegmentList is its first
-	// element's segments.
+	// order, and is only populated by the BGP decoder. Read it through
+	// Lists() rather than directly: a locally configured path carries just
+	// the single SegmentList, and a consumer reading this field raw would
+	// see such a path as having none.
 	SegmentLists []WeightedSegmentList
+}
+
+// Lists returns the candidate path's Segment Lists as the weighted set to
+// select over, whatever shape the producer filled in.
+//
+// SegmentList and SegmentLists are two views of the same thing, and only the
+// BGP decoder sets both. Locally configured paths and the advertise API set
+// only SegmentList, so a weighted consumer reading SegmentLists directly
+// would treat a perfectly valid single-list path as empty and stop steering
+// it. Going through here means a new producer cannot introduce that bug by
+// omission.
+func (c CandidatePath) Lists() []WeightedSegmentList {
+	if len(c.SegmentLists) > 0 {
+		return c.SegmentLists
+	}
+	if len(c.SegmentList) == 0 {
+		return nil
+	}
+	return []WeightedSegmentList{{
+		Segments: c.SegmentList,
+		Weight:   SRPolicyDefaultWeight,
+	}}
 }
 
 // SRPolicyDefaultWeight is the share a Segment List takes when it carries

--- a/pkg/bgp/bgp.go
+++ b/pkg/bgp/bgp.go
@@ -321,15 +321,36 @@ const SRPolicyDefaultPreference = 100
 // CandidatePath is one segment-list option for an SRPolicy. The active
 // path is chosen per RFC 9256 §2.9: highest Preference, then highest
 // Origin, then lowest Distinguisher.
+// WeightedSegmentList is one Segment List of a candidate path with the
+// share it takes (RFC 9256 §2.2). A candidate path may carry several, which
+// together form a weighted ECMP set.
+//
+// Weight is the value from the Weight sub-TLV, or SRPolicyDefaultWeight
+// when the sub-TLV is absent. RFC 9256 leaves the absent case to the
+// implementation and every deployment treats it as an equal share, so a
+// list without a weight must not be read as taking no traffic.
+type WeightedSegmentList struct {
+	Segments []netip.Addr
+	Weight   uint32
+}
+
 type CandidatePath struct {
 	Origin        Origin
 	Distinguisher uint32
 	Preference    uint32
-	// SegmentList is the SR Policy transport SID list (RFC 9830/9831
-	// Type B SRv6 SIDs). The VPN service SID is composed onto the tail
-	// in the data plane, not stored here.
+	// SegmentList is the transport SID list actually programmed: the first
+	// usable Segment List of this candidate path. Kept as the single-list
+	// view every existing consumer uses.
 	SegmentList []netip.Addr
+	// SegmentLists holds every usable Segment List with its weight, in wire
+	// order. It is what weighted ECMP selects over; SegmentList is its first
+	// element's segments.
+	SegmentLists []WeightedSegmentList
 }
+
+// SRPolicyDefaultWeight is the share a Segment List takes when it carries
+// no Weight sub-TLV.
+const SRPolicyDefaultWeight = 1
 
 // SRPolicyKey identifies a previously-advertised SR Policy for
 // withdrawal: the {Distinguisher, Color, Endpoint} tuple of the NLRI

--- a/pkg/bgp/bgp.go
+++ b/pkg/bgp/bgp.go
@@ -326,14 +326,15 @@ const SRPolicyDefaultPreference = 100
 // together form a weighted ECMP set.
 //
 // Weight is the value from the Weight sub-TLV, or SRPolicyDefaultWeight
-// when the sub-TLV is absent. RFC 9256 leaves the absent case to the
-// implementation and every deployment treats it as an equal share, so a
-// list without a weight must not be read as taking no traffic.
+// when the sub-TLV is absent (RFC 9256: "The default weight is 1"). It is
+// never 0: the RFC declares a segment list whose weight is 0 invalid, so
+// such a list never reaches this type.
 type WeightedSegmentList struct {
 	Segments []netip.Addr
 	Weight   uint32
 }
 
+// CandidatePath is one candidate path of an SR Policy (RFC 9256 §2.4).
 type CandidatePath struct {
 	Origin        Origin
 	Distinguisher uint32
@@ -349,7 +350,7 @@ type CandidatePath struct {
 }
 
 // SRPolicyDefaultWeight is the share a Segment List takes when it carries
-// no Weight sub-TLV.
+// no Weight sub-TLV: RFC 9256 states "The default weight is 1".
 const SRPolicyDefaultWeight = 1
 
 // SRPolicyKey identifies a previously-advertised SR Policy for

--- a/pkg/bgp/bgp_test.go
+++ b/pkg/bgp/bgp_test.go
@@ -150,3 +150,46 @@ func TestPathSource(t *testing.T) {
 		}
 	})
 }
+
+// SegmentList and SegmentLists are two views of one thing, and only the BGP
+// decoder fills both. Lists() is what keeps a locally configured path -- which
+// carries just SegmentList -- from looking empty to a weighted consumer.
+func TestCandidatePathLists(t *testing.T) {
+	a := netip.MustParseAddr("fd00:1::1")
+	b := netip.MustParseAddr("fd00:2::1")
+
+	t.Run("decoder-populated set is returned as is", func(t *testing.T) {
+		cp := CandidatePath{
+			SegmentList: []netip.Addr{a},
+			SegmentLists: []WeightedSegmentList{
+				{Segments: []netip.Addr{a}, Weight: 1},
+				{Segments: []netip.Addr{b}, Weight: 4},
+			},
+		}
+		got := cp.Lists()
+		if len(got) != 2 || got[1].Weight != 4 {
+			t.Fatalf("Lists() = %v, want both weighted lists", got)
+		}
+	})
+
+	t.Run("single-list producer is normalized to one equal share", func(t *testing.T) {
+		// This is the shape LocalSRPolicy and the advertise API produce.
+		cp := CandidatePath{SegmentList: []netip.Addr{a, b}}
+		got := cp.Lists()
+		if len(got) != 1 {
+			t.Fatalf("Lists() = %v, want one synthesized list", got)
+		}
+		if got[0].Weight != SRPolicyDefaultWeight {
+			t.Errorf("weight = %d, want the default %d", got[0].Weight, SRPolicyDefaultWeight)
+		}
+		if len(got[0].Segments) != 2 {
+			t.Errorf("segments = %v, want both carried through", got[0].Segments)
+		}
+	})
+
+	t.Run("an ineligible candidate has no lists", func(t *testing.T) {
+		if got := (CandidatePath{}).Lists(); got != nil {
+			t.Errorf("Lists() = %v, want nil for a candidate with no segments", got)
+		}
+	})
+}

--- a/pkg/bgp/gobgp/decode_srpolicy.go
+++ b/pkg/bgp/gobgp/decode_srpolicy.go
@@ -83,13 +83,17 @@ func decodeSRPolicyTunnel(attrs []gobgppkt.PathAttributeInterface) (uint32, []bg
 		case *gobgppkt.TunnelEncapSubTLVSRPreference:
 			preference = v.Preference
 		case *gobgppkt.TunnelEncapSubTLVSRSegmentList:
+			weight, ok := segmentListWeight(v)
+			if !ok {
+				continue
+			}
 			segments, ok := decodeSegmentList(v)
 			if !ok {
 				continue
 			}
 			lists = append(lists, bgp.WeightedSegmentList{
 				Segments: segments,
-				Weight:   segmentListWeight(v),
+				Weight:   weight,
 			})
 		}
 	}
@@ -123,14 +127,24 @@ func decodeSegmentList(v *gobgppkt.TunnelEncapSubTLVSRSegmentList) ([]netip.Addr
 	return segments, true
 }
 
-// segmentListWeight reads a list's share. RFC 9256 leaves an absent Weight
-// sub-TLV to the implementation; an equal share is what deployments assume,
-// and reading absence as zero would silently retire the list.
-func segmentListWeight(v *gobgppkt.TunnelEncapSubTLVSRSegmentList) uint32 {
-	if v.Weight == nil || v.Weight.Weight == 0 {
-		return bgp.SRPolicyDefaultWeight
+// segmentListWeight reads a list's share. ok is false when the list must not
+// be used.
+//
+// An absent Weight sub-TLV and an explicit weight of 0 are NOT the same
+// thing, and conflating them overrides what the advertiser asked for. RFC
+// 9256 sets the default weight to 1 when none is given, but declares a
+// segment list invalid when "its weight is 0" -- an explicit 0 withdraws
+// that list from the ECMP set. Reading it as 1 would put a list the sender
+// disabled back into service, and if it were the first list it would become
+// the one actually programmed.
+func segmentListWeight(v *gobgppkt.TunnelEncapSubTLVSRSegmentList) (uint32, bool) {
+	if v.Weight == nil {
+		return bgp.SRPolicyDefaultWeight, true
 	}
-	return v.Weight.Weight
+	if v.Weight.Weight == 0 {
+		return 0, false
+	}
+	return v.Weight.Weight, true
 }
 
 // srPolicyTunnelSubTLVs returns the sub-TLVs of the SR Policy tunnel

--- a/pkg/bgp/gobgp/decode_srpolicy.go
+++ b/pkg/bgp/gobgp/decode_srpolicy.go
@@ -36,68 +36,101 @@ func decodeSRPolicy(p *apiutil.Path) *bgp.SRPolicy {
 	if !ok || !endpoint.Is6() {
 		return nil
 	}
-	preference, segments := decodeSRPolicyTunnel(p.Attrs)
+	preference, lists := decodeSRPolicyTunnel(p.Attrs)
+	cand := bgp.CandidatePath{
+		Origin:        bgp.OriginBGP,
+		Distinguisher: nlri.Distinguisher,
+		Preference:    preference,
+		SegmentLists:  lists,
+	}
+	// SegmentList is the single-list view every current consumer reads: the
+	// first usable list, which is also what gets programmed until weighted
+	// selection lands in the data plane.
+	if len(lists) > 0 {
+		cand.SegmentList = lists[0].Segments
+	}
 	return &bgp.SRPolicy{
-		Color:    nlri.Color,
-		Endpoint: endpoint,
-		Candidates: []bgp.CandidatePath{{
-			Origin:        bgp.OriginBGP,
-			Distinguisher: nlri.Distinguisher,
-			Preference:    preference,
-			SegmentList:   segments,
-		}},
+		Color:      nlri.Color,
+		Endpoint:   endpoint,
+		Candidates: []bgp.CandidatePath{cand},
 	}
 }
 
 // decodeSRPolicyTunnel walks the SR Policy tunnel sub-TLVs once and returns
-// the candidate path's preference and transport SID list:
+// the candidate path's preference and its Segment Lists:
 //   - Preference sub-TLV (RFC 9830 type 12); RFC 9256 default when absent.
-//   - the FIRST Segment List sub-TLV (type 128); additional ones (weighted
-//     ECMP) are ignored in Phase 1e-c. Only Type B (SRv6 SID) segments are
-//     understood -- Type I/J/K (RFC 9831) carry node/adjacency descriptors
-//     needing a SID/topology DB Vinbero lacks, so they are skipped.
+//   - every Segment List sub-TLV (type 128), each with the share from its
+//     nested Weight sub-TLV, or SRPolicyDefaultWeight when it carries none.
+//     Only Type B (SRv6 SID) segments are understood -- Type I/J/K
+//     (RFC 9831) carry node/adjacency descriptors needing a SID/topology DB
+//     Vinbero lacks, so they are skipped.
 //
-// Without ECMP there is exactly one usable list, so we deliberately take the
-// first one and do not fall through to later lists when it is malformed: an
-// invalid first list yields empty segments and an ineligible candidate,
-// rather than silently steering onto a lower-preference alternate. Picking
-// the first *valid* list is a weighted-ECMP concern deferred with it.
-func decodeSRPolicyTunnel(attrs []gobgppkt.PathAttributeInterface) (uint32, []netip.Addr) {
+// A malformed list is dropped on its own rather than taking the candidate
+// with it. That is the opposite of what a single-list decoder should do: with
+// one list, discarding it and leaving the candidate ineligible is right,
+// because steering onto a lower-preference alternate is safer than steering
+// along a path built from a list we could not read. With several, the other
+// lists are independent statements about how to reach the same endpoint, and
+// dropping them all because one was bad would take down a policy that is
+// still perfectly usable. A candidate whose lists are ALL unusable still ends
+// up ineligible, which preserves the original behaviour for the single-list
+// case.
+func decodeSRPolicyTunnel(attrs []gobgppkt.PathAttributeInterface) (uint32, []bgp.WeightedSegmentList) {
 	preference := uint32(bgp.SRPolicyDefaultPreference)
-	var segments []netip.Addr
-	haveSegments := false
+	var lists []bgp.WeightedSegmentList
 	for _, tlv := range srPolicyTunnelSubTLVs(attrs) {
 		switch v := tlv.(type) {
 		case *gobgppkt.TunnelEncapSubTLVSRPreference:
 			preference = v.Preference
 		case *gobgppkt.TunnelEncapSubTLVSRSegmentList:
-			if haveSegments {
-				continue // first Segment List sub-TLV wins
+			segments, ok := decodeSegmentList(v)
+			if !ok {
+				continue
 			}
-			haveSegments = true
-			valid := true
-			for _, seg := range v.Segments {
-				b, ok := seg.(*gobgppkt.SegmentTypeB)
-				if !ok {
-					continue // Type I/J/K etc.: unsupported, skip
-				}
-				addr, ok := netip.AddrFromSlice(b.SID)
-				// A transport SID must be an SRv6 (IPv6) SID. A malformed or
-				// IPv4 SID makes the whole list unusable -- dropping just this
-				// SID would steer along a wrong path, so discard the list and
-				// let the candidate fall out as ineligible (empty segments).
-				if !ok || !addr.Is6() {
-					valid = false
-					break
-				}
-				segments = append(segments, addr)
-			}
-			if !valid {
-				segments = nil
-			}
+			lists = append(lists, bgp.WeightedSegmentList{
+				Segments: segments,
+				Weight:   segmentListWeight(v),
+			})
 		}
 	}
-	return preference, segments
+	return preference, lists
+}
+
+// decodeSegmentList extracts one Segment List's transport SIDs. ok is false
+// when the list cannot be used as written.
+func decodeSegmentList(v *gobgppkt.TunnelEncapSubTLVSRSegmentList) ([]netip.Addr, bool) {
+	var segments []netip.Addr
+	for _, seg := range v.Segments {
+		b, ok := seg.(*gobgppkt.SegmentTypeB)
+		if !ok {
+			continue // Type I/J/K etc.: unsupported, skip
+		}
+		addr, ok := netip.AddrFromSlice(b.SID)
+		// A transport SID must be an SRv6 (IPv6) SID. A malformed or IPv4
+		// SID makes this whole list unusable -- dropping just that SID
+		// would steer along a path the advertiser never described.
+		if !ok || !addr.Is6() {
+			return nil, false
+		}
+		segments = append(segments, addr)
+	}
+	// A list that named no usable segment carries no path; treating it as
+	// an empty-but-valid list would install a policy that encapsulates to
+	// nothing.
+	if len(segments) == 0 {
+		return nil, false
+	}
+	return segments, true
+}
+
+// segmentListWeight reads a list's share. RFC 9256 leaves an absent Weight
+// sub-TLV to the implementation; an equal share is what deployments assume,
+// and reading absence as zero would silently retire the list.
+func segmentListWeight(v *gobgppkt.TunnelEncapSubTLVSRSegmentList) uint32 {
+	if v.Weight == nil || v.Weight.Weight == 0 {
+		return bgp.SRPolicyDefaultWeight
+	}
+	return v.Weight.Weight
 }
 
 // srPolicyTunnelSubTLVs returns the sub-TLVs of the SR Policy tunnel

--- a/pkg/bgp/gobgp/decode_srpolicy.go
+++ b/pkg/bgp/gobgp/decode_srpolicy.go
@@ -134,7 +134,10 @@ func decodeSegmentList(v *gobgppkt.TunnelEncapSubTLVSRSegmentList) ([]netip.Addr
 // thing, and conflating them overrides what the advertiser asked for. RFC
 // 9256 sets the default weight to 1 when none is given, but declares a
 // segment list invalid when "its weight is 0" -- an explicit 0 withdraws
-// that list from the ECMP set. Reading it as 1 would put a list the sender
+// that list from the ECMP set. The distinction is safe to rely on: gobgp
+// only allocates Weight when a Weight sub-TLV is actually present on the
+// wire, and Vinbero's own advertise path leaves it unset, so a peer that
+// omits the weight is never mistaken for one that disabled the list. Reading it as 1 would put a list the sender
 // disabled back into service, and if it were the first list it would become
 // the one actually programmed.
 func segmentListWeight(v *gobgppkt.TunnelEncapSubTLVSRSegmentList) (uint32, bool) {

--- a/pkg/bgp/gobgp/decode_srpolicy_test.go
+++ b/pkg/bgp/gobgp/decode_srpolicy_test.go
@@ -130,7 +130,6 @@ func TestDecodeSRPolicy_RejectsNonIPv6SID(t *testing.T) {
 	}
 }
 
-// Multiple Segment List sub-TLVs (weighted ECMP): only the first wins.
 // The single-list view is the FIRST list, not an arbitrary one: it is what
 // gets programmed today, so which list it names is observable. The other
 // lists are no longer discarded (see the weighted tests below) -- this pins

--- a/pkg/bgp/gobgp/decode_srpolicy_test.go
+++ b/pkg/bgp/gobgp/decode_srpolicy_test.go
@@ -131,7 +131,11 @@ func TestDecodeSRPolicy_RejectsNonIPv6SID(t *testing.T) {
 }
 
 // Multiple Segment List sub-TLVs (weighted ECMP): only the first wins.
-func TestDecodeSRPolicy_FirstSegmentListWins(t *testing.T) {
+// The single-list view is the FIRST list, not an arbitrary one: it is what
+// gets programmed today, so which list it names is observable. The other
+// lists are no longer discarded (see the weighted tests below) -- this pins
+// only which one leads.
+func TestDecodeSRPolicy_FirstSegmentListLeads(t *testing.T) {
 	p := srPolicyPath(t, 1, 100, "2001:db8::2",
 		&gobgppkt.TunnelEncapSubTLVSRSegmentList{
 			Segments: []gobgppkt.TunnelEncapSubTLVInterface{typeB(t, "fd00:200:0:1::")},
@@ -146,7 +150,10 @@ func TestDecodeSRPolicy_FirstSegmentListWins(t *testing.T) {
 	}
 	segs := got.Candidates[0].SegmentList
 	if len(segs) != 1 || segs[0] != netip.MustParseAddr("fd00:200:0:1::") {
-		t.Errorf("segments = %v, want first list only [fd00:200:0:1::]", segs)
+		t.Errorf("segments = %v, want the first list [fd00:200:0:1::]", segs)
+	}
+	if n := len(got.Candidates[0].SegmentLists); n != 2 {
+		t.Errorf("decoded %d lists, want both retained", n)
 	}
 }
 
@@ -186,5 +193,114 @@ func TestDecodeSRPolicy_Withdraw(t *testing.T) {
 	}
 	if got.Candidates[0].Distinguisher != 3 || len(got.Candidates[0].SegmentList) != 0 {
 		t.Errorf("withdraw candidate = %+v, want dist 3 and no segments", got.Candidates[0])
+	}
+}
+
+func segList(t *testing.T, weight uint32, sids ...string) *gobgppkt.TunnelEncapSubTLVSRSegmentList {
+	t.Helper()
+	sl := &gobgppkt.TunnelEncapSubTLVSRSegmentList{}
+	for _, sid := range sids {
+		sl.Segments = append(sl.Segments, typeB(t, sid))
+	}
+	if weight != 0 {
+		sl.Weight = &gobgppkt.SegmentListWeight{Weight: weight}
+	}
+	return sl
+}
+
+// A candidate path may carry several Segment Lists, which together form a
+// weighted ECMP set (RFC 9256 2.2). The decoder used to keep only the first
+// and discard the rest.
+func TestDecodeSRPolicy_MultipleWeightedSegmentLists(t *testing.T) {
+	p := srPolicyPath(t, 1, 100, "2001:db8::2",
+		segList(t, 1, "fd00:1::1"),
+		segList(t, 3, "fd00:2::1", "fd00:2::2"),
+	)
+	got := decodeSRPolicy(p)
+	if got == nil {
+		t.Fatal("decodeSRPolicy returned nil")
+	}
+	cp := got.Candidates[0]
+	if len(cp.SegmentLists) != 2 {
+		t.Fatalf("decoded %d lists, want 2", len(cp.SegmentLists))
+	}
+	if cp.SegmentLists[0].Weight != 1 || cp.SegmentLists[1].Weight != 3 {
+		t.Errorf("weights = %d,%d want 1,3",
+			cp.SegmentLists[0].Weight, cp.SegmentLists[1].Weight)
+	}
+	if len(cp.SegmentLists[1].Segments) != 2 {
+		t.Errorf("second list segments = %v", cp.SegmentLists[1].Segments)
+	}
+	// The single-list view stays the first list, which is what is programmed
+	// until the data plane selects over the set.
+	if len(cp.SegmentList) != 1 || cp.SegmentList[0].String() != "fd00:1::1" {
+		t.Errorf("SegmentList = %v, want the first list", cp.SegmentList)
+	}
+}
+
+// RFC 9256 leaves an absent Weight sub-TLV to the implementation. Reading it
+// as zero would retire the list from the ECMP set, which is the opposite of
+// what every deployment means by omitting it.
+func TestDecodeSRPolicy_AbsentWeightIsAnEqualShare(t *testing.T) {
+	p := srPolicyPath(t, 1, 100, "2001:db8::2",
+		segList(t, 0, "fd00:1::1"),
+		segList(t, 0, "fd00:2::1"),
+	)
+	cp := decodeSRPolicy(p).Candidates[0]
+	if len(cp.SegmentLists) != 2 {
+		t.Fatalf("decoded %d lists, want 2", len(cp.SegmentLists))
+	}
+	for i, l := range cp.SegmentLists {
+		if l.Weight != bgp.SRPolicyDefaultWeight {
+			t.Errorf("list %d weight = %d, want the default %d",
+				i, l.Weight, bgp.SRPolicyDefaultWeight)
+		}
+	}
+}
+
+// One bad list must not take the usable ones with it: they are independent
+// statements about how to reach the same endpoint.
+func TestDecodeSRPolicy_MalformedListDropsOnlyItself(t *testing.T) {
+	bad := &gobgppkt.TunnelEncapSubTLVSRSegmentList{
+		Segments: []gobgppkt.TunnelEncapSubTLVInterface{
+			// An IPv4 SID cannot be an SRv6 transport SID.
+			&gobgppkt.SegmentTypeB{SID: netip.MustParseAddr("10.0.0.1").AsSlice()},
+		},
+	}
+	p := srPolicyPath(t, 1, 100, "2001:db8::2", bad, segList(t, 2, "fd00:2::1"))
+	cp := decodeSRPolicy(p).Candidates[0]
+	if len(cp.SegmentLists) != 1 {
+		t.Fatalf("decoded %d lists, want only the usable one", len(cp.SegmentLists))
+	}
+	if cp.SegmentLists[0].Weight != 2 {
+		t.Errorf("surviving list weight = %d, want 2", cp.SegmentLists[0].Weight)
+	}
+	if len(cp.SegmentList) != 1 {
+		t.Errorf("SegmentList = %v, want the surviving list", cp.SegmentList)
+	}
+}
+
+// With every list unusable the candidate must still come out ineligible,
+// which is the behaviour the single-list decoder had.
+func TestDecodeSRPolicy_AllListsUnusableLeavesNoSegments(t *testing.T) {
+	bad := &gobgppkt.TunnelEncapSubTLVSRSegmentList{
+		Segments: []gobgppkt.TunnelEncapSubTLVInterface{
+			&gobgppkt.SegmentTypeB{SID: netip.MustParseAddr("10.0.0.1").AsSlice()},
+		},
+	}
+	cp := decodeSRPolicy(srPolicyPath(t, 1, 100, "2001:db8::2", bad)).Candidates[0]
+	if len(cp.SegmentLists) != 0 || len(cp.SegmentList) != 0 {
+		t.Errorf("expected no usable segments, got lists=%v single=%v",
+			cp.SegmentLists, cp.SegmentList)
+	}
+}
+
+// A list naming no usable segment carries no path. Treating it as an
+// empty-but-valid list would install a policy that encapsulates to nothing.
+func TestDecodeSRPolicy_EmptyListIsNotUsable(t *testing.T) {
+	empty := &gobgppkt.TunnelEncapSubTLVSRSegmentList{}
+	cp := decodeSRPolicy(srPolicyPath(t, 1, 100, "2001:db8::2", empty, segList(t, 1, "fd00:2::1"))).Candidates[0]
+	if len(cp.SegmentLists) != 1 {
+		t.Fatalf("decoded %d lists, want only the non-empty one", len(cp.SegmentLists))
 	}
 }

--- a/pkg/bgp/gobgp/decode_srpolicy_test.go
+++ b/pkg/bgp/gobgp/decode_srpolicy_test.go
@@ -196,6 +196,9 @@ func TestDecodeSRPolicy_Withdraw(t *testing.T) {
 	}
 }
 
+// segList builds a Segment List sub-TLV. weight 0 means "no Weight sub-TLV
+// at all"; use segListExplicitWeight to emit one carrying a given value,
+// including 0, which is a different thing on the wire.
 func segList(t *testing.T, weight uint32, sids ...string) *gobgppkt.TunnelEncapSubTLVSRSegmentList {
 	t.Helper()
 	sl := &gobgppkt.TunnelEncapSubTLVSRSegmentList{}
@@ -205,6 +208,13 @@ func segList(t *testing.T, weight uint32, sids ...string) *gobgppkt.TunnelEncapS
 	if weight != 0 {
 		sl.Weight = &gobgppkt.SegmentListWeight{Weight: weight}
 	}
+	return sl
+}
+
+func segListExplicitWeight(t *testing.T, weight uint32, sids ...string) *gobgppkt.TunnelEncapSubTLVSRSegmentList {
+	t.Helper()
+	sl := segList(t, 0, sids...)
+	sl.Weight = &gobgppkt.SegmentListWeight{Weight: weight}
 	return sl
 }
 
@@ -303,4 +313,51 @@ func TestDecodeSRPolicy_EmptyListIsNotUsable(t *testing.T) {
 	if len(cp.SegmentLists) != 1 {
 		t.Fatalf("decoded %d lists, want only the non-empty one", len(cp.SegmentLists))
 	}
+}
+
+// RFC 9256 declares a segment list invalid when "its weight is 0", which is
+// the advertiser withdrawing that list from the ECMP set. It is NOT the same
+// as omitting the Weight sub-TLV, where the default of 1 applies. Reading an
+// explicit 0 as the default would put a list the sender disabled back into
+// service -- and if it came first, that is the list actually programmed.
+func TestDecodeSRPolicy_ExplicitZeroWeightInvalidatesTheList(t *testing.T) {
+	t.Run("zero-weight list is dropped", func(t *testing.T) {
+		p := srPolicyPath(t, 1, 100, "2001:db8::2",
+			segListExplicitWeight(t, 0, "fd00:1::1"),
+			segList(t, 2, "fd00:2::1"),
+		)
+		cp := decodeSRPolicy(p).Candidates[0]
+		if len(cp.SegmentLists) != 1 {
+			t.Fatalf("decoded %d lists, want only the non-zero-weight one", len(cp.SegmentLists))
+		}
+		if cp.SegmentLists[0].Weight != 2 {
+			t.Errorf("surviving weight = %d, want 2", cp.SegmentLists[0].Weight)
+		}
+		// The disabled list came first, so this is what would have been
+		// programmed had the zero been read as a default.
+		if len(cp.SegmentList) != 1 || cp.SegmentList[0].String() != "fd00:2::1" {
+			t.Errorf("SegmentList = %v, want the enabled list", cp.SegmentList)
+		}
+	})
+
+	t.Run("an absent sub-TLV still means an equal share", func(t *testing.T) {
+		cp := decodeSRPolicy(srPolicyPath(t, 1, 100, "2001:db8::2",
+			segList(t, 0, "fd00:1::1"))).Candidates[0]
+		if len(cp.SegmentLists) != 1 {
+			t.Fatalf("decoded %d lists, want the list kept", len(cp.SegmentLists))
+		}
+		if cp.SegmentLists[0].Weight != bgp.SRPolicyDefaultWeight {
+			t.Errorf("weight = %d, want the default %d",
+				cp.SegmentLists[0].Weight, bgp.SRPolicyDefaultWeight)
+		}
+	})
+
+	t.Run("every list disabled leaves the candidate ineligible", func(t *testing.T) {
+		cp := decodeSRPolicy(srPolicyPath(t, 1, 100, "2001:db8::2",
+			segListExplicitWeight(t, 0, "fd00:1::1"))).Candidates[0]
+		if len(cp.SegmentLists) != 0 || len(cp.SegmentList) != 0 {
+			t.Errorf("expected no usable segments, got lists=%v single=%v",
+				cp.SegmentLists, cp.SegmentList)
+		}
+	})
 }


### PR DESCRIPTION
ECMP シリーズ (docs/plan/ecmp-support.md) の PR5 の受信側です。

## 背景

candidate path は Segment List を複数持てて、まとめて weighted ECMP の集合になります (RFC 9256 2.2)。従来の decoder は最初の 1 本だけ残して残りを捨てていたため、weight の情報がそもそも Vinbero に届いていませんでした。全部 decode し、各 list の weight とともに `CandidatePath.SegmentLists` に載せます。

## 判断したこと

**Weight sub-TLV が無い場合は等分**。RFC 9256 は実装依存としていますが、0 と読むとその list を ECMP 集合から外すことになり、省略の意図と正反対になります。

**壊れた list はその list だけ落とします**。list が 1 本しか無い前提なら、壊れていたら candidate ごと ineligible にするのが正しい判断でした。より低い preference の代替に steer するより、読めなかった list から組んだ経路に流す方が危険だからです。複数ある場合は事情が逆で、他の list は同じ endpoint への独立した記述なので、1 本の破損で全部落とすとまだ使える policy を落とすことになります。全 list が使えない candidate は従来どおり ineligible になるので、単一 list のときの挙動は変わりません。

**segment を 1 つも指さない list も落とします**。空のまま有効として扱うと、どこにも encap しない policy を install することになります。

## スコープ

program されるのは今のところ先頭の list だけで、`SegmentList` フィールドがその単一 list ビューとして残ります。data plane 側の weighted 選択 (`sr_policy_value` への group_id 追加と `tailcall_ctx.flow_hash` による選択) は後続の変更にしました。BPF の変更を含むため分けています。

## テスト

- 複数 list と weight を保持すること、先頭が単一 list ビューになること
- Weight 省略が等分になること
- 壊れた list が自分だけ落ちて他が残ること、全滅なら ineligible になること
- segment を持たない list が落ちること
- 既存の `FirstSegmentListWins` は挙動が変わったので `FirstSegmentListLeads` に改名し、他の list が保持されることも検証するよう強化

`pkg/bgp/...` 全 green、golangci-lint 0 issues。