### PR TITLE
feat(evpn): decode RT1 Ethernet A-D routes

### DIFF
--- a/docs/design/ja/ecmp.md
+++ b/docs/design/ja/ecmp.md
@@ -129,6 +129,16 @@ segment を 1 つも指さない list も使えないものとして落としま
 
 program されるのは今のところ先頭の list だけです。data plane 側の weighted 選択は後続の変更です。
 
+## EVPN RT1 の decode
+
+RT1 Ethernet A-D を decode します。従来は decode 自体が無く、applier の default 分岐で捨てられていました。
+
+1 つの NLRI 型が 2 つの異なる主張を運び、Ethernet Tag で区別します。per-ES (tag = MAX-ET) は segment 全体についての主張で、その withdraw が mass withdraw の signal になります。MAC を 1 つずつ withdraw するのを待たずに、障害リンクから収束できます (RFC 7432 8.2)。per-EVI (それ以外の tag) は 1 つの broadcast domain についての主張で、その SRv6 SID が aliasing を可能にします。他の PE からしか学習していない MAC 宛のトラフィックの送り先になるためです。
+
+Single-Active bit は per-ES 経路の ESI Label extended community から読みます。これが立っていると aliasing は禁止です。single-active では DF だけが転送するので、ES を広告している PE 群に分散させると non-DF に届いた分が black-hole します。
+
+現時点では decode までで、applier はまだ RT1 を消費しません。aliasing と mass withdraw は data plane 側の変更を伴うため後続にしています。
+
 ## 制約と今後
 
 - `mup_uplink_v4/v6_map` の値も `headend_entry` ですが、behavior プログラム内で lookup されるため group 解決を通りません。`CreateMupUplinkV4/V6` が書き込み時に `group_id` を 0 に強制します。

--- a/docs/design/ja/ecmp.md
+++ b/docs/design/ja/ecmp.md
@@ -137,6 +137,8 @@ RT1 Ethernet A-D を decode します。従来は decode 自体が無く、appli
 
 Single-Active bit は per-ES 経路の ESI Label extended community から読みます。これが立っていると aliasing は禁止です。single-active では DF だけが転送するので、ES を広告している PE 群に分散させると non-DF に届いた分が black-hole します。
 
+transposition の取り出し元も 2 形式で違います。per-EVI は RT2/RT3 と同じく NLRI の MPLS label から取りますが、per-ES はその label を 0 にして、ESI Label extended community の 24-bit label に Argument を載せます (RFC 9252)。per-ES で NLRI label を読むと transposed bits が落ち、まったく別の場所を指す SID を組み立てます。gobgp は両者とも 3 バイトの raw 値として decode するので単位は揃っています。
+
 現時点では decode までで、applier はまだ RT1 を消費しません。aliasing と mass withdraw は data plane 側の変更を伴うため後続にしています。
 
 ## 制約と今後

--- a/pkg/bgp/apply/evpn.go
+++ b/pkg/bgp/apply/evpn.go
@@ -195,7 +195,9 @@ func (a *Applier) applyEVPNLocked(r *bgp.EVPNRoute, withdraw bool) {
 	case bgp.EVPNRouteTypeEthernetSegment:
 		a.applyEVPNEthernetSegment(r, withdraw)
 	default:
-		// Unsupported route types (RT1 Ethernet A-D, RT5 IP Prefix) are ignored.
+		// RT1 Ethernet A-D now decodes, but nothing consumes it yet: aliasing
+		// and mass withdraw are the data-plane half of that work. RT5 IP
+		// Prefix is not decoded at all. Both are ignored here.
 	}
 }
 

--- a/pkg/bgp/bgp.go
+++ b/pkg/bgp/bgp.go
@@ -454,9 +454,9 @@ type EVPNController interface {
 
 // EVPNRoute is a decoded BGP EVPN NLRI (AFI 25 / SAFI 70). One envelope
 // carries every route type; the fields a type does not use stay zero.
-// The SRv6 service SID (End.DT2U for RT2 and for a per-EVI RT1, End.DT2M
-// for RT3) is decoded from the BGP Prefix-SID attribute's SRv6 L2 Service
-// TLV (RFC 9252 §6); RT4 and a per-ES RT1 carry no SID. The route targets resolve the local bridge domain
+// The SRv6 service SID is decoded from the BGP Prefix-SID attribute's SRv6
+// L2 Service TLV (RFC 9252 §6): End.DT2U for RT2 and a per-EVI RT1, End.DT2M
+// for RT3 and a per-ES RT1. Only RT4 carries no SID. The route targets resolve the local bridge domain
 // through the same import-RT filter the L3VPN path uses.
 type EVPNRoute struct {
 	Type        EVPNRouteType
@@ -466,7 +466,7 @@ type EVPNRoute struct {
 	EthernetTag uint32
 	MAC         string // RT2: "aa:bb:cc:dd:ee:ff"
 	IPAddr      string // RT2: optional host IP (IRB); "" when MAC-only
-	SRv6SID     string // End.DT2U (RT2, per-EVI RT1) / End.DT2M (RT3); "" if none
+	SRv6SID     string // End.DT2U (RT2, per-EVI RT1) / End.DT2M (RT3, per-ES RT1); "" if none
 	NextHop     string
 	ESImportRT  string // RT4: ES-Import route target ("aa:bb:cc:dd:ee:ff"); "" otherwise
 	// SingleActive is the ESI Label extended community's Single-Active bit
@@ -475,7 +475,7 @@ type EVPNRoute struct {
 	// be aliased across PEs. Meaningless on other route types.
 	SingleActive bool
 	// RemoteSrc is the advertising PE's SRv6 encap source (the SID's locator
-	// base) for any route carrying a SID -- RT2, RT3 and a per-EVI RT1 --
+	// base) for any route carrying a SID -- RT2, RT3 and either RT1 form --
 	// used as the RX reverse-map key for split-horizon and remote-MAC
 	// learning, distinct from the local TX encap source. "" if not derivable.
 	RemoteSrc string

--- a/pkg/bgp/bgp.go
+++ b/pkg/bgp/bgp.go
@@ -403,6 +403,7 @@ type SRPolicyController interface {
 type EVPNRouteType uint8
 
 const (
+	EVPNRouteTypeEthernetAD         EVPNRouteType = 1 // RT1: Ethernet A-D -> aliasing / mass withdraw
 	EVPNRouteTypeMACIP              EVPNRouteType = 2 // RT2: MAC/IP -> fdb_map + bd_peer_map
 	EVPNRouteTypeInclusiveMulticast EVPNRouteType = 3 // RT3: Inclusive Multicast -> bd_peer_map (BUM)
 	EVPNRouteTypeEthernetSegment    EVPNRouteType = 4 // RT4: Ethernet Segment -> esi_map (DF election)
@@ -468,11 +469,28 @@ type EVPNRoute struct {
 	SRv6SID     string // End.DT2U (RT2) / End.DT2M (RT3); "" if none
 	NextHop     string
 	ESImportRT  string // RT4: ES-Import route target ("aa:bb:cc:dd:ee:ff"); "" otherwise
+	// SingleActive is the ESI Label extended community's Single-Active bit
+	// (RFC 7432 §7.5), carried on a per-ES RT1. It says the segment is
+	// single-active, so only the DF forwards for it and the segment must NOT
+	// be aliased across PEs. Meaningless on other route types.
+	SingleActive bool
 	// RemoteSrc is the advertising PE's SRv6 encap source (the SID's locator
 	// base) for RT2/RT3, used as the RX reverse-map key for split-horizon and
 	// remote-MAC learning -- distinct from the local TX encap source. "" if not
 	// derivable.
 	RemoteSrc string
+}
+
+// EVPNMaxEthernetTag is the reserved Ethernet Tag (MAX-ET) that marks a
+// per-ES Ethernet A-D route, as opposed to a per-EVI one (RFC 7432 §8.2).
+// The two carry different meaning: per-ES is the segment-wide statement used
+// for mass withdraw, per-EVI is the per-broadcast-domain statement that
+// enables aliasing.
+const EVPNMaxEthernetTag uint32 = 0xFFFFFFFF
+
+// IsPerES reports whether an Ethernet A-D route is the per-ES form.
+func (r EVPNRoute) IsPerES() bool {
+	return r.Type == EVPNRouteTypeEthernetAD && r.EthernetTag == EVPNMaxEthernetTag
 }
 
 // MUPRouteType enumerates the BGP MUP SAFI (85) route types Vinbero consumes

--- a/pkg/bgp/bgp.go
+++ b/pkg/bgp/bgp.go
@@ -454,9 +454,9 @@ type EVPNController interface {
 
 // EVPNRoute is a decoded BGP EVPN NLRI (AFI 25 / SAFI 70). One envelope
 // carries every route type; the fields a type does not use stay zero.
-// The SRv6 service SID (End.DT2U for RT2, End.DT2M for RT3) is decoded
-// from the BGP Prefix-SID attribute's SRv6 L2 Service TLV (RFC 9252 §6);
-// RT4 carries no SID. The route targets resolve the local bridge domain
+// The SRv6 service SID (End.DT2U for RT2 and for a per-EVI RT1, End.DT2M
+// for RT3) is decoded from the BGP Prefix-SID attribute's SRv6 L2 Service
+// TLV (RFC 9252 §6); RT4 and a per-ES RT1 carry no SID. The route targets resolve the local bridge domain
 // through the same import-RT filter the L3VPN path uses.
 type EVPNRoute struct {
 	Type        EVPNRouteType
@@ -466,7 +466,7 @@ type EVPNRoute struct {
 	EthernetTag uint32
 	MAC         string // RT2: "aa:bb:cc:dd:ee:ff"
 	IPAddr      string // RT2: optional host IP (IRB); "" when MAC-only
-	SRv6SID     string // End.DT2U (RT2) / End.DT2M (RT3); "" if none
+	SRv6SID     string // End.DT2U (RT2, per-EVI RT1) / End.DT2M (RT3); "" if none
 	NextHop     string
 	ESImportRT  string // RT4: ES-Import route target ("aa:bb:cc:dd:ee:ff"); "" otherwise
 	// SingleActive is the ESI Label extended community's Single-Active bit
@@ -475,9 +475,9 @@ type EVPNRoute struct {
 	// be aliased across PEs. Meaningless on other route types.
 	SingleActive bool
 	// RemoteSrc is the advertising PE's SRv6 encap source (the SID's locator
-	// base) for RT2/RT3, used as the RX reverse-map key for split-horizon and
-	// remote-MAC learning -- distinct from the local TX encap source. "" if not
-	// derivable.
+	// base) for any route carrying a SID -- RT2, RT3 and a per-EVI RT1 --
+	// used as the RX reverse-map key for split-horizon and remote-MAC
+	// learning, distinct from the local TX encap source. "" if not derivable.
 	RemoteSrc string
 }
 

--- a/pkg/bgp/bgp.go
+++ b/pkg/bgp/bgp.go
@@ -472,7 +472,10 @@ type EVPNRoute struct {
 	// SingleActive is the ESI Label extended community's Single-Active bit
 	// (RFC 7432 §7.5), carried on a per-ES RT1. It says the segment is
 	// single-active, so only the DF forwards for it and the segment must NOT
-	// be aliased across PEs. Meaningless on other route types.
+	// be aliased across PEs. It also reads true when a per-ES route omits
+	// that community altogether: RFC 7432 makes it mandatory there, so an
+	// absent one is a malformed advertisement, and refusing to alias is the
+	// safe reading. Meaningless on other route types.
 	SingleActive bool
 	// RemoteSrc is the advertising PE's SRv6 encap source (the SID's locator
 	// base) for any route carrying a SID -- RT2, RT3 and either RT1 form --

--- a/pkg/bgp/gobgp/decode_evpn.go
+++ b/pkg/bgp/gobgp/decode_evpn.go
@@ -67,7 +67,16 @@ func decodeEVPNEthernetAD(p *apiutil.Path, rt *gobgppkt.EVPNEthernetAutoDiscover
 	// when the ESI filtering approach is used along with the Transposition
 	// Scheme"). Reading the NLRI label for a per-ES route would drop the
 	// transposed bits and compose a SID that points somewhere else.
-	esiLabel, singleActive := decodeESILabel(p.Attrs)
+	esiLabel, singleActive, haveESILabel := decodeESILabel(p.Attrs)
+	if r.IsPerES() && !haveESILabel {
+		// RFC 7432 §8.2.1 makes the ESI Label extended community mandatory on
+		// a per-ES route, so its absence is a malformed advertisement rather
+		// than a statement of all-active. Fail closed: the only decision that
+		// turns on this bit is whether the segment may be aliased, and
+		// aliasing a segment whose redundancy mode we do not actually know
+		// would black-hole traffic landing on a non-DF.
+		singleActive = true
+	}
 	label := rt.Label
 	if r.IsPerES() {
 		label = esiLabel
@@ -79,10 +88,12 @@ func decodeEVPNEthernetAD(p *apiutil.Path, rt *gobgppkt.EVPNEthernetAutoDiscover
 }
 
 // decodeESILabel reads the ESI Label extended community (RFC 7432 §7.5),
-// returning its 24-bit label and the Single-Active bit. An absent community
-// yields (0, false): all-active, which is the mode that permits aliasing,
-// and no transposed bits.
-func decodeESILabel(attrs []gobgppkt.PathAttributeInterface) (uint32, bool) {
+// returning its 24-bit label, the Single-Active bit, and whether the
+// community was there at all. Callers need the third value because absence
+// is not the same as a cleared bit: the community is mandatory on a per-ES
+// route, so a missing one means the advertisement is malformed, not that the
+// segment is all-active.
+func decodeESILabel(attrs []gobgppkt.PathAttributeInterface) (uint32, bool, bool) {
 	for _, a := range attrs {
 		ec, ok := a.(*gobgppkt.PathAttributeExtendedCommunities)
 		if !ok {
@@ -90,11 +101,11 @@ func decodeESILabel(attrs []gobgppkt.PathAttributeInterface) (uint32, bool) {
 		}
 		for _, c := range ec.Value {
 			if esi, ok := c.(*gobgppkt.ESILabelExtended); ok {
-				return esi.Label, esi.IsSingleActive
+				return esi.Label, esi.IsSingleActive, true
 			}
 		}
 	}
-	return 0, false
+	return 0, false, false
 }
 
 // decodeEVPNEthernetSegment decodes an RT4 Ethernet Segment route (RFC 7432

--- a/pkg/bgp/gobgp/decode_evpn.go
+++ b/pkg/bgp/gobgp/decode_evpn.go
@@ -8,9 +8,11 @@ import (
 )
 
 // decodeEVPNRoute builds Vinbero's EVPNRoute view of a received EVPN NLRI
-// (AFI 25 / SAFI 70). RT2 (MAC/IP), RT3 (Inclusive Multicast), and RT4
-// (Ethernet Segment) are decoded; other route types return nil, which the
-// Applier treats as a no-op.
+// (AFI 25 / SAFI 70). RT1 (Ethernet A-D), RT2 (MAC/IP), RT3 (Inclusive
+// Multicast) and RT4 (Ethernet Segment) are decoded; RT5 (IP Prefix) is not,
+// and returns nil, which the Applier treats as a no-op. Decoding a type is
+// not the same as acting on it: RT1 currently reaches the Applier and falls
+// through, since aliasing and mass withdraw are not implemented yet.
 func decodeEVPNRoute(p *apiutil.Path) *bgp.EVPNRoute {
 	nlri, ok := p.Nlri.(*gobgppkt.EVPNNLRI)
 	if !ok {

--- a/pkg/bgp/gobgp/decode_evpn.go
+++ b/pkg/bgp/gobgp/decode_evpn.go
@@ -21,11 +21,64 @@ func decodeEVPNRoute(p *apiutil.Path) *bgp.EVPNRoute {
 		return decodeEVPNMacIP(p, rt)
 	case *gobgppkt.EVPNMulticastEthernetTagRoute:
 		return decodeEVPNMulticast(p, rt)
+	case *gobgppkt.EVPNEthernetAutoDiscoveryRoute:
+		return decodeEVPNEthernetAD(p, rt)
 	case *gobgppkt.EVPNEthernetSegmentRoute:
 		return decodeEVPNEthernetSegment(p, rt)
 	default:
 		return nil
 	}
+}
+
+// decodeEVPNEthernetAD decodes an RT1 Ethernet A-D route (RFC 7432 §7.1).
+//
+// One NLRI type carries two different statements, told apart by the Ethernet
+// Tag. Per-ES (tag = MAX-ET) is about the segment as a whole: it advertises
+// reachability of the ES and its withdrawal is the mass-withdraw signal that
+// lets peers converge off a failed link without waiting for every MAC to be
+// withdrawn one by one (RFC 7432 §8.2). Per-EVI (any other tag) is about one
+// broadcast domain, and its SRv6 SID is what makes aliasing possible: it
+// gives a peer somewhere to send traffic for MACs it has only learned from
+// another PE on the same segment.
+//
+// The Single-Active bit rides on the per-ES route's ESI Label extended
+// community and matters because it forbids aliasing: on a single-active
+// segment only the DF forwards, so spreading traffic across the PEs
+// advertising the ES would black-hole whatever landed on a non-DF.
+func decodeEVPNEthernetAD(p *apiutil.Path, rt *gobgppkt.EVPNEthernetAutoDiscoveryRoute) *bgp.EVPNRoute {
+	r := &bgp.EVPNRoute{
+		Type:        bgp.EVPNRouteTypeEthernetAD,
+		ESI:         esiToArray(rt.ESI),
+		EthernetTag: rt.ETag,
+		RTs:         decodeRouteTargets(p.Attrs),
+		NextHop:     decodeNextHop(p.Attrs),
+	}
+	if rt.RD != nil {
+		r.RD = rt.RD.String()
+	}
+	label := rt.Label
+	r.SRv6SID = decodeSRv6SID(p.Attrs, label)
+	r.RemoteSrc = decodeRemoteSrc(p.Attrs, label, defaultLocatorPrefixLen)
+	r.SingleActive = decodeSingleActive(p.Attrs)
+	return r
+}
+
+// decodeSingleActive reads the Single-Active bit from the ESI Label extended
+// community (RFC 7432 §7.5). Absent community means all-active, which is the
+// mode that permits aliasing.
+func decodeSingleActive(attrs []gobgppkt.PathAttributeInterface) bool {
+	for _, a := range attrs {
+		ec, ok := a.(*gobgppkt.PathAttributeExtendedCommunities)
+		if !ok {
+			continue
+		}
+		for _, c := range ec.Value {
+			if esi, ok := c.(*gobgppkt.ESILabelExtended); ok && esi.IsSingleActive {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // decodeEVPNEthernetSegment decodes an RT4 Ethernet Segment route (RFC 7432

--- a/pkg/bgp/gobgp/decode_evpn.go
+++ b/pkg/bgp/gobgp/decode_evpn.go
@@ -58,29 +58,43 @@ func decodeEVPNEthernetAD(p *apiutil.Path, rt *gobgppkt.EVPNEthernetAutoDiscover
 	if rt.RD != nil {
 		r.RD = rt.RD.String()
 	}
+	// Where the transposed Argument bits live differs between the two forms.
+	// A per-EVI route transposes into the NLRI's MPLS label like RT2/RT3 do,
+	// but a per-ES route sets that label to 0 and carries the bits in the
+	// 24-bit label of the ESI Label extended community instead (RFC 9252:
+	// "The 24-bit ESI Label field of the ESI Label extended community
+	// carries the whole or a portion of the Argument part of the SRv6 SID
+	// when the ESI filtering approach is used along with the Transposition
+	// Scheme"). Reading the NLRI label for a per-ES route would drop the
+	// transposed bits and compose a SID that points somewhere else.
+	esiLabel, singleActive := decodeESILabel(p.Attrs)
 	label := rt.Label
+	if r.IsPerES() {
+		label = esiLabel
+	}
 	r.SRv6SID = decodeSRv6SID(p.Attrs, label)
 	r.RemoteSrc = decodeRemoteSrc(p.Attrs, label, defaultLocatorPrefixLen)
-	r.SingleActive = decodeSingleActive(p.Attrs)
+	r.SingleActive = singleActive
 	return r
 }
 
-// decodeSingleActive reads the Single-Active bit from the ESI Label extended
-// community (RFC 7432 §7.5). Absent community means all-active, which is the
-// mode that permits aliasing.
-func decodeSingleActive(attrs []gobgppkt.PathAttributeInterface) bool {
+// decodeESILabel reads the ESI Label extended community (RFC 7432 §7.5),
+// returning its 24-bit label and the Single-Active bit. An absent community
+// yields (0, false): all-active, which is the mode that permits aliasing,
+// and no transposed bits.
+func decodeESILabel(attrs []gobgppkt.PathAttributeInterface) (uint32, bool) {
 	for _, a := range attrs {
 		ec, ok := a.(*gobgppkt.PathAttributeExtendedCommunities)
 		if !ok {
 			continue
 		}
 		for _, c := range ec.Value {
-			if esi, ok := c.(*gobgppkt.ESILabelExtended); ok && esi.IsSingleActive {
-				return true
+			if esi, ok := c.(*gobgppkt.ESILabelExtended); ok {
+				return esi.Label, esi.IsSingleActive
 			}
 		}
 	}
-	return false
+	return 0, false
 }
 
 // decodeEVPNEthernetSegment decodes an RT4 Ethernet Segment route (RFC 7432

--- a/pkg/bgp/gobgp/decode_evpn_test.go
+++ b/pkg/bgp/gobgp/decode_evpn_test.go
@@ -256,6 +256,76 @@ func rt1Path(t *testing.T, etag uint32, sid string, singleActive bool) *apiutil.
 	return &apiutil.Path{Family: gobgppkt.RF_EVPN, Nlri: nlri, Attrs: attrs}
 }
 
+// rt1TransposedPath builds an RT1 whose SID has its Argument bits transposed
+// out into a label, so the decoded SID depends on which label the decoder
+// reads. nlriLabel goes in the NLRI, esiLabel in the ESI Label extended
+// community.
+func rt1TransposedPath(t *testing.T, etag, nlriLabel, esiLabel uint32) *apiutil.Path {
+	t.Helper()
+	rd := gobgppkt.NewRouteDistinguisherTwoOctetAS(65000, 100)
+	esi := gobgppkt.EthernetSegmentIdentifier{
+		Type:  gobgppkt.ESI_ARBITRARY,
+		Value: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
+	}
+	nlri := &gobgppkt.EVPNNLRI{
+		RouteType: gobgppkt.EVPN_ROUTE_TYPE_ETHERNET_AUTO_DISCOVERY,
+		RouteTypeData: &gobgppkt.EVPNEthernetAutoDiscoveryRoute{
+			RD: rd, ESI: esi, ETag: etag, Label: nlriLabel,
+		},
+	}
+	info := gobgppkt.NewSRv6InformationSubTLV(
+		netip.MustParseAddr("fd00:1:1::"), gobgppkt.END_DT2M)
+	// block 32 / node 16 / function 16, argument transposed out: 16 bits at
+	// offset 64.
+	info.SubSubTLVs = append(info.SubSubTLVs,
+		gobgppkt.NewSRv6SIDStructureSubSubTLV(32, 16, 16, 16, 16, 64))
+	rt, _ := gobgppkt.ParseExtendedCommunity(gobgppkt.EC_SUBTYPE_ROUTE_TARGET, "65000:100")
+	attrs := []gobgppkt.PathAttributeInterface{
+		gobgppkt.NewPathAttributeExtendedCommunities([]gobgppkt.ExtendedCommunityInterface{
+			rt, gobgppkt.NewESILabelExtended(esiLabel, false),
+		}),
+		gobgppkt.NewPathAttributePrefixSID(
+			gobgppkt.NewSRv6ServiceTLV(gobgppkt.TLVTypeSRv6L2Service, info)),
+	}
+	return &apiutil.Path{Family: gobgppkt.RF_EVPN, Nlri: nlri, Attrs: attrs}
+}
+
+// RFC 9252 puts the transposed Argument bits in different places for the two
+// RT1 forms: a per-EVI route uses the NLRI's MPLS label, a per-ES route sets
+// that label to 0 and uses the 24-bit ESI Label extended community instead.
+// Reading the wrong one composes a SID pointing somewhere else entirely, and
+// nothing downstream would notice.
+func TestDecodeEVPN_RT1TranspositionSource(t *testing.T) {
+	t.Run("per-EVI transposes from the NLRI label", func(t *testing.T) {
+		// The ESI Label differs between the two paths; only the NLRI label
+		// may move the SID.
+		a := decodeEVPNRoute(rt1TransposedPath(t, 100, 0x11000, 0))
+		b := decodeEVPNRoute(rt1TransposedPath(t, 100, 0x11000, 0x99000))
+		if a.SRv6SID != b.SRv6SID {
+			t.Errorf("per-EVI SID moved with the ESI Label: %q vs %q", a.SRv6SID, b.SRv6SID)
+		}
+		c := decodeEVPNRoute(rt1TransposedPath(t, 100, 0x22000, 0))
+		if a.SRv6SID == c.SRv6SID {
+			t.Errorf("per-EVI SID did not follow the NLRI label: both %q", a.SRv6SID)
+		}
+	})
+
+	t.Run("per-ES transposes from the ESI Label community", func(t *testing.T) {
+		et := bgp.EVPNMaxEthernetTag
+		// A per-ES route carries NLRI label 0 on the wire; vary it anyway to
+		// prove the decoder is not reading it.
+		a := decodeEVPNRoute(rt1TransposedPath(t, et, 0, 0x11000))
+		b := decodeEVPNRoute(rt1TransposedPath(t, et, 0x77000, 0x11000))
+		if a.SRv6SID != b.SRv6SID {
+			t.Errorf("per-ES SID moved with the NLRI label: %q vs %q", a.SRv6SID, b.SRv6SID)
+		}
+		c := decodeEVPNRoute(rt1TransposedPath(t, et, 0, 0x22000))
+		if a.SRv6SID == c.SRv6SID {
+			t.Errorf("per-ES SID did not follow the ESI Label: both %q", a.SRv6SID)
+		}
+	})
+}
+
 func TestDecodeEVPN_RT1(t *testing.T) {
 	// One NLRI type carries two statements, told apart by the Ethernet Tag.
 	// Confusing them would be serious: treating a per-ES withdraw as per-EVI

--- a/pkg/bgp/gobgp/decode_evpn_test.go
+++ b/pkg/bgp/gobgp/decode_evpn_test.go
@@ -61,8 +61,6 @@ func TestDecodeEVPN_RT2(t *testing.T) {
 	}
 }
 
-// An unsupported EVPN route type (here RT1 Ethernet A-D) decodes to nil; the
-// Applier treats nil as a no-op until that type's phase lands (RT4 in E3).
 // A route type Vinbero does not decode must come back nil so the applier is
 // never handed a half-populated route. RT5 IP Prefix is the remaining one;
 // RT1 used to sit here too and now decodes.

--- a/pkg/bgp/gobgp/decode_evpn_test.go
+++ b/pkg/bgp/gobgp/decode_evpn_test.go
@@ -373,10 +373,26 @@ func TestDecodeEVPN_RT1(t *testing.T) {
 		}
 	})
 
-	t.Run("absent community means all-active", func(t *testing.T) {
+	t.Run("a per-ES route missing the mandatory community refuses aliasing", func(t *testing.T) {
+		// RFC 7432 §8.2.1: "The ESI Label extended community MUST be included
+		// in the route." Absence is a malformed advertisement, not a
+		// statement of all-active, and reading it as all-active would let a
+		// segment whose redundancy mode we do not know be aliased.
 		r := decodeEVPNRoute(rt1Path(t, bgp.EVPNMaxEthernetTag, "", false))
-		if r.SingleActive {
-			t.Error("no ESI Label community must read as all-active")
+		if !r.SingleActive {
+			t.Error("a per-ES route with no ESI Label community must not be treated as aliasable")
+		}
+	})
+
+	t.Run("an all-active per-ES route is aliasable", func(t *testing.T) {
+		// The community present with the bit clear is the real all-active
+		// signal, and must stay distinguishable from the missing-community
+		// case above.
+		p := rt1Path(t, bgp.EVPNMaxEthernetTag, "", false)
+		attrs := p.Attrs[0].(*gobgppkt.PathAttributeExtendedCommunities)
+		attrs.Value = append(attrs.Value, gobgppkt.NewESILabelExtended(0, false))
+		if r := decodeEVPNRoute(p); r.SingleActive {
+			t.Error("an explicit all-active per-ES route must be aliasable")
 		}
 	})
 }

--- a/pkg/bgp/gobgp/decode_evpn_test.go
+++ b/pkg/bgp/gobgp/decode_evpn_test.go
@@ -63,13 +63,16 @@ func TestDecodeEVPN_RT2(t *testing.T) {
 
 // An unsupported EVPN route type (here RT1 Ethernet A-D) decodes to nil; the
 // Applier treats nil as a no-op until that type's phase lands (RT4 in E3).
-func TestDecodeEVPN_NonRT2IsNil(t *testing.T) {
+// A route type Vinbero does not decode must come back nil so the applier is
+// never handed a half-populated route. RT5 IP Prefix is the remaining one;
+// RT1 used to sit here too and now decodes.
+func TestDecodeEVPN_UndecodedTypeIsNil(t *testing.T) {
 	nlri := &gobgppkt.EVPNNLRI{
-		RouteType:     gobgppkt.EVPN_ROUTE_TYPE_ETHERNET_AUTO_DISCOVERY,
-		RouteTypeData: &gobgppkt.EVPNEthernetAutoDiscoveryRoute{},
+		RouteType:     gobgppkt.EVPN_IP_PREFIX,
+		RouteTypeData: &gobgppkt.EVPNIPPrefixRoute{},
 	}
 	if r := decodeEVPNRoute(&apiutil.Path{Family: gobgppkt.RF_EVPN, Nlri: nlri}); r != nil {
-		t.Errorf("unsupported EVPN route decoded to %+v, want nil", r)
+		t.Errorf("undecoded EVPN route decoded to %+v, want nil", r)
 	}
 }
 
@@ -218,4 +221,94 @@ func TestDecodeEVPN_RT2RemoteSrc(t *testing.T) {
 	if r == nil || r.RemoteSrc != "fd00:200::" {
 		t.Errorf("RemoteSrc = %q, want fd00:200:: (/48 fallback)", r.RemoteSrc)
 	}
+}
+
+// rt1Path builds a received EVPN RT1 (Ethernet A-D) path. etag selects the
+// per-ES form (MAX-ET) or a per-EVI one; singleActive attaches the ESI Label
+// extended community with the Single-Active bit set.
+func rt1Path(t *testing.T, etag uint32, sid string, singleActive bool) *apiutil.Path {
+	t.Helper()
+	rd := gobgppkt.NewRouteDistinguisherTwoOctetAS(65000, 100)
+	esi := gobgppkt.EthernetSegmentIdentifier{
+		Type:  gobgppkt.ESI_ARBITRARY,
+		Value: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
+	}
+	nlri := &gobgppkt.EVPNNLRI{
+		RouteType: gobgppkt.EVPN_ROUTE_TYPE_ETHERNET_AUTO_DISCOVERY,
+		RouteTypeData: &gobgppkt.EVPNEthernetAutoDiscoveryRoute{
+			RD: rd, ESI: esi, ETag: etag,
+		},
+	}
+	rt, _ := gobgppkt.ParseExtendedCommunity(gobgppkt.EC_SUBTYPE_ROUTE_TARGET, "65000:100")
+	ecs := []gobgppkt.ExtendedCommunityInterface{rt}
+	if singleActive {
+		ecs = append(ecs, gobgppkt.NewESILabelExtended(0, true))
+	}
+	attrs := []gobgppkt.PathAttributeInterface{
+		gobgppkt.NewPathAttributeExtendedCommunities(ecs),
+	}
+	if sid != "" {
+		attrs = append(attrs, gobgppkt.NewPathAttributePrefixSID(
+			gobgppkt.NewSRv6ServiceTLV(
+				gobgppkt.TLVTypeSRv6L2Service,
+				gobgppkt.NewSRv6InformationSubTLV(netip.MustParseAddr(sid), gobgppkt.END_DT2U),
+			),
+		))
+	}
+	return &apiutil.Path{Family: gobgppkt.RF_EVPN, Nlri: nlri, Attrs: attrs}
+}
+
+func TestDecodeEVPN_RT1(t *testing.T) {
+	// One NLRI type carries two statements, told apart by the Ethernet Tag.
+	// Confusing them would be serious: treating a per-ES withdraw as per-EVI
+	// loses the mass-withdraw signal, and treating per-EVI as per-ES would
+	// apply one broadcast domain's SID to the whole segment.
+	t.Run("per-EVI carries the aliasing SID", func(t *testing.T) {
+		r := decodeEVPNRoute(rt1Path(t, 100, "fd00:1:1:2::", false))
+		if r == nil {
+			t.Fatal("RT1 did not decode")
+		}
+		if r.Type != bgp.EVPNRouteTypeEthernetAD {
+			t.Errorf("type = %d, want RT1", r.Type)
+		}
+		if r.IsPerES() {
+			t.Error("a per-EVI route must not report IsPerES")
+		}
+		if r.EthernetTag != 100 {
+			t.Errorf("ethernet tag = %d, want 100", r.EthernetTag)
+		}
+		if r.SRv6SID != "fd00:1:1:2::" {
+			t.Errorf("SID = %q, want the aliasing SID", r.SRv6SID)
+		}
+		if r.ESI != [10]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9} {
+			t.Errorf("ESI = %v", r.ESI)
+		}
+	})
+
+	t.Run("per-ES is identified by MAX-ET", func(t *testing.T) {
+		r := decodeEVPNRoute(rt1Path(t, bgp.EVPNMaxEthernetTag, "", false))
+		if r == nil {
+			t.Fatal("RT1 did not decode")
+		}
+		if !r.IsPerES() {
+			t.Errorf("ethernet tag %#x should mark a per-ES route", r.EthernetTag)
+		}
+	})
+
+	t.Run("single-active is read from the ESI Label community", func(t *testing.T) {
+		// Single-active forbids aliasing: only the DF forwards, so spreading
+		// traffic over the PEs advertising the ES would black-hole whatever
+		// reached a non-DF.
+		r := decodeEVPNRoute(rt1Path(t, bgp.EVPNMaxEthernetTag, "", true))
+		if !r.SingleActive {
+			t.Error("Single-Active bit was not decoded")
+		}
+	})
+
+	t.Run("absent community means all-active", func(t *testing.T) {
+		r := decodeEVPNRoute(rt1Path(t, bgp.EVPNMaxEthernetTag, "", false))
+		if r.SingleActive {
+			t.Error("no ESI Label community must read as all-active")
+		}
+	})
 }


### PR DESCRIPTION
ECMP シリーズ (docs/plan/ecmp-support.md) の PR6 の前半です。plan では 1 本にまとまっていますが、data plane 変更 (`esi_ecmp_map` + `l2_headend.c`) を含むと大きすぎるので、decode 層を先に切り出しました。

## 背景

RT1 Ethernet A-D は **decode 自体が存在せず**、applier の default 分岐で捨てられていました。aliasing も mass withdraw も、この経路にしか載っていない情報から始まるので、受信時点で捨てている限り何も作れません。

## 1 つの NLRI 型が運ぶ 2 つの主張

RT1 は Ethernet Tag で意味が変わり、取り違えると深刻です。

- **per-ES (tag = MAX-ET)** — segment 全体についての主張。その withdraw が mass withdraw の signal で、MAC を 1 つずつ withdraw するのを待たずに障害リンクから収束できます (RFC 7432 8.2)
- **per-EVI (それ以外)** — 1 つの broadcast domain についての主張。SRv6 SID が aliasing を可能にし、他の PE からしか学習していない MAC 宛トラフィックの送り先になります

per-ES の withdraw を per-EVI として扱うと mass withdraw の signal を失い、逆なら 1 つの broadcast domain の SID を segment 全体に適用してしまいます。`IsPerES()` を用意して、呼び出し側が MAX-ET 比較を各所に書かないようにしました。

## Single-Active

per-ES 経路の ESI Label extended community から読みます。これが立つと **aliasing は禁止**です。single-active では DF だけが転送するので、ES を広告している PE 群に分散させると non-DF に届いた分が black-hole します。community が無ければ all-active で、aliasing が許される側です。

## スコープ

RT1 を消費する側はまだありません。`applyEVPN` に届いて従来どおり default 分岐に落ちます。`evpnMu` を取るだけで副作用が無いことは確認済みです。aliasing と mass withdraw は data plane 変更を伴うため後続にします。

## 既存テストの更新

`TestDecodeEVPN_NonRT2IsNil` は RT1 を「未対応型」の例として nil を期待していました。前提が変わったので、まだ decode しない RT5 IP Prefix を使う形に変え、`TestDecodeEVPN_UndecodedTypeIsNil` に改名しています。

## テスト

- per-EVI が aliasing SID と ESI を運ぶこと、per-ES が MAX-ET で識別されること
- Single-Active bit が読めること、community 不在が all-active になること
- 未 decode 型 (RT5) が nil のままであること

`pkg/bgp/...` 全 green、golangci-lint 0 issues。