### PR TITLE
feat(evpn): converge on the RT1 mass-withdraw signal

### DIFF
--- a/docs/design/ja/ecmp.md
+++ b/docs/design/ja/ecmp.md
@@ -139,7 +139,17 @@ Single-Active bit は per-ES 経路の ESI Label extended community から読み
 
 transposition の取り出し元も 2 形式で違います。per-EVI は RT2/RT3 と同じく NLRI の MPLS label から取りますが、per-ES はその label を 0 にして、ESI Label extended community の 24-bit label に Argument を載せます (RFC 9252)。per-ES で NLRI label を読むと transposed bits が落ち、まったく別の場所を指す SID を組み立てます。gobgp は両者とも 3 バイトの raw 値として decode するので単位は揃っています。
 
-現時点では decode までで、applier はまだ RT1 を消費しません。aliasing と mass withdraw は data plane 側の変更を伴うため後続にしています。
+### mass withdraw
+
+per-ES A-D の withdraw を受けると、その PE がその segment 上で教えた MAC をまとめて撤去します。PE が per-ES 経路を引くのは segment 全体が自分から失われたという主張なので、MAC ごとの withdraw を待つ必要がありません。segment が数千の MAC を抱えていると、待つ間ずっと black-hole が続きます。この signal が存在する理由がそこにあります。
+
+`{ESI, PE}` から FDB エントリを引く逆引き index を持ちます。single-homed の MAC (ESI が全ゼロ) は index しません。属する segment が無いので、per-ES の withdraw がその MAC についての主張になり得ないためです。per-EVI の withdraw も mass withdraw として扱いません。segment 全体の意味を持つのは per-ES の形だけで、混同すると他の broadcast domain 経由でまだ到達できる MAC を落とします。
+
+再広告に特別な処理は要りません。MAC は通常の RT2 として戻ってきます。
+
+### aliasing (未実装)
+
+per-EVI A-D が運ぶ SID を使った aliasing は、ESI から group_id を引く side table と `l2_headend.c` の参照が要るため後続です。
 
 ## 制約と今後
 

--- a/pkg/bgp/apply/evpn.go
+++ b/pkg/bgp/apply/evpn.go
@@ -67,6 +67,18 @@ type evpnFdbState struct {
 	bdID uint16
 	mac  net.HardwareAddr
 	peer evpnPeerKey
+	// esi and pe record which multi-homed segment and which PE taught us
+	// this MAC, so a mass withdraw can find every MAC one PE contributed to
+	// a segment. esi is all-zero for a single-homed MAC, which is not
+	// indexed: there is no segment to converge off.
+	esi [bpf.ESILen]byte
+	pe  string
+}
+
+// esMemberKey identifies one PE's contribution to one Ethernet Segment.
+type esMemberKey struct {
+	esi [bpf.ESILen]byte
+	pe  string
 }
 
 // evpnMcastKey is the stable identity of an RT3 Inclusive Multicast NLRI
@@ -102,6 +114,12 @@ type evpnTable struct {
 	// Guarded by esMu.
 	esMembers map[[bpf.ESILen]byte]map[string]struct{}
 	esMu      sync.Mutex
+	// macsByES indexes the MACs each PE taught us on each Ethernet Segment.
+	// It exists for mass withdraw (RFC 7432 §8.2): when a PE withdraws its
+	// per-ES Ethernet A-D route it is saying the whole segment is gone, and
+	// waiting for a withdrawal per MAC would keep blackholing traffic for as
+	// long as that takes. Guarded by evpnMu, like fdb itself.
+	macsByES map[esMemberKey]map[evpnFdbKey]struct{}
 }
 
 func newEVPNTable() *evpnTable {
@@ -109,6 +127,7 @@ func newEVPNTable() *evpnTable {
 		peers:     make(map[evpnPeerKey]*evpnPeerState),
 		fdb:       make(map[evpnFdbKey]evpnFdbState),
 		mcast:     make(map[evpnMcastKey]evpnMcastState),
+		macsByES:  make(map[esMemberKey]map[evpnFdbKey]struct{}),
 		esMembers: make(map[[bpf.ESILen]byte]map[string]struct{}),
 	}
 }
@@ -194,11 +213,59 @@ func (a *Applier) applyEVPNLocked(r *bgp.EVPNRoute, withdraw bool) {
 		a.applyEVPNInclusiveMulticast(r, withdraw)
 	case bgp.EVPNRouteTypeEthernetSegment:
 		a.applyEVPNEthernetSegment(r, withdraw)
+	case bgp.EVPNRouteTypeEthernetAD:
+		a.applyEVPNEthernetAD(r, withdraw)
 	default:
-		// RT1 Ethernet A-D now decodes, but nothing consumes it yet: aliasing
-		// and mass withdraw are the data-plane half of that work. RT5 IP
-		// Prefix is not decoded at all. Both are ignored here.
+		// RT5 IP Prefix is not decoded, so it never reaches here.
 	}
+}
+
+// applyEVPNEthernetAD handles RT1 Ethernet A-D. Only the per-ES form is acted
+// on today, and only its withdrawal: that is the mass-withdraw signal of RFC
+// 7432 §8.2.
+//
+// A PE withdrawing its per-ES route is saying the whole segment is gone from
+// it. The per-MAC withdrawals follow, but a segment can hold thousands of
+// MACs and every one of them keeps blackholing traffic until its own
+// withdrawal arrives. Acting on the single per-ES route converges the lot at
+// once. Re-advertisement needs no special handling: the MACs come back as
+// ordinary RT2s.
+//
+// The per-EVI form carries the aliasing SID and is not consumed yet; aliasing
+// needs the data-plane group lookup.
+//
+// Caller holds evpnMu.
+func (a *Applier) applyEVPNEthernetAD(r *bgp.EVPNRoute, withdraw bool) {
+	if !withdraw || !r.IsPerES() {
+		return
+	}
+	var zeroESI [bpf.ESILen]byte
+	if r.ESI == zeroESI || r.NextHop == "" {
+		// Without both we cannot say whose contribution to drop, and
+		// guessing would tear down MACs that are still reachable.
+		return
+	}
+	k := esMemberKey{esi: r.ESI, pe: r.NextHop}
+	macs := a.evpn.macsByES[k]
+	if len(macs) == 0 {
+		return
+	}
+	// Snapshot the keys: withdrawEVPNMac mutates the index through
+	// unindexMACByES, and iterating a map while deleting from it would skip
+	// entries.
+	fks := make([]evpnFdbKey, 0, len(macs))
+	for fk := range macs {
+		fks = append(fks, fk)
+	}
+	for _, fk := range fks {
+		st, ok := a.evpn.fdb[fk]
+		if !ok {
+			continue
+		}
+		a.withdrawEVPNMac(fk, st)
+	}
+	a.logger.Info("EVPN mass withdraw", zap.String("pe", r.NextHop),
+		zap.Int("macs", len(fks)))
 }
 
 // ReplayEVPN re-applies the current EVPN loc-rib through the receive path.
@@ -320,7 +387,9 @@ func (a *Applier) applyEVPNMacIP(r *bgp.EVPNRoute, withdraw bool) {
 		}
 		return
 	}
-	a.evpn.fdb[fk] = evpnFdbState{bdID: bdID, mac: mac, peer: pk}
+	st := evpnFdbState{bdID: bdID, mac: mac, peer: pk, esi: r.ESI, pe: r.NextHop}
+	a.evpn.fdb[fk] = st
+	a.indexMACByES(fk, st)
 	a.logger.Info("EVPN MAC installed",
 		zap.String("mac", r.MAC), zap.Uint16("bd_id", bdID), zap.String("sid", r.SRv6SID))
 }
@@ -328,6 +397,46 @@ func (a *Applier) applyEVPNMacIP(r *bgp.EVPNRoute, withdraw bool) {
 // withdrawEVPNMac removes the FDB entry recorded for fk and releases its peer
 // reference, deleting the bd_peer when the last MAC stops referencing it.
 // Caller holds evpnMu.
+// indexMACByES records that one PE taught this MAC on a multi-homed segment,
+// so a per-ES withdraw can find it. A single-homed MAC (all-zero ESI) or one
+// with no identifiable PE is not indexed: neither can be converged off a
+// segment failure.
+func (a *Applier) indexMACByES(fk evpnFdbKey, st evpnFdbState) {
+	var zeroESI [bpf.ESILen]byte
+	if st.esi == zeroESI || st.pe == "" {
+		return
+	}
+	k := esMemberKey{esi: st.esi, pe: st.pe}
+	macs := a.evpn.macsByES[k]
+	if macs == nil {
+		if len(a.evpn.macsByES) >= maxTrackedESIs*maxMembersPerESI {
+			a.logger.Warn("EVPN ES MAC index full; mass withdraw will not cover this segment",
+				zap.String("pe", st.pe))
+			return
+		}
+		macs = make(map[evpnFdbKey]struct{})
+		a.evpn.macsByES[k] = macs
+	}
+	macs[fk] = struct{}{}
+}
+
+// unindexMACByES drops one MAC from the segment index.
+func (a *Applier) unindexMACByES(fk evpnFdbKey, st evpnFdbState) {
+	var zeroESI [bpf.ESILen]byte
+	if st.esi == zeroESI || st.pe == "" {
+		return
+	}
+	k := esMemberKey{esi: st.esi, pe: st.pe}
+	macs := a.evpn.macsByES[k]
+	if macs == nil {
+		return
+	}
+	delete(macs, fk)
+	if len(macs) == 0 {
+		delete(a.evpn.macsByES, k)
+	}
+}
+
 func (a *Applier) withdrawEVPNMac(fk evpnFdbKey, st evpnFdbState) {
 	if err := a.fdbBd.DeleteFdb(st.bdID, st.mac); err != nil {
 		// The FDB entry is still in the map. Keep the reverse index so a
@@ -338,6 +447,7 @@ func (a *Applier) withdrawEVPNMac(fk evpnFdbKey, st evpnFdbState) {
 		return
 	}
 	delete(a.evpn.fdb, fk)
+	a.unindexMACByES(fk, st)
 	if idx, gone := a.evpn.releaseIndex(st.peer); gone {
 		if err := a.fdbBd.DeleteBdPeer(st.bdID, idx); err != nil {
 			// The bd_peer is still in the map but releaseIndex already

--- a/pkg/bgp/apply/evpn_test.go
+++ b/pkg/bgp/apply/evpn_test.go
@@ -641,3 +641,117 @@ func TestApplier_ReplayEVPNConcurrentWithApply(t *testing.T) {
 	}
 	<-done
 }
+
+// rt2FromES is an RT2 learned over a multi-homed Ethernet Segment from a
+// named PE, which is what mass withdraw keys on.
+func rt2FromES(mac, sid, pe string, esi [10]byte) *bgp.EVPNRoute {
+	r := rt2(mac, sid)
+	r.ESI = esi
+	r.NextHop = pe
+	return r
+}
+
+func perESWithdraw(pe string, esi [10]byte) bgp.RouteEvent {
+	return bgp.RouteEvent{
+		Family:     bgp.FamilyEVPN,
+		IsWithdraw: true,
+		EVPN: &bgp.EVPNRoute{
+			Type:        bgp.EVPNRouteTypeEthernetAD,
+			RD:          "65000:100",
+			ESI:         esi,
+			EthernetTag: bgp.EVPNMaxEthernetTag,
+			NextHop:     pe,
+		},
+	}
+}
+
+// A PE withdrawing its per-ES Ethernet A-D route says the whole segment is
+// gone from it (RFC 7432 §8.2). Waiting for a withdrawal per MAC would keep
+// blackholing traffic for as long as that takes, which on a segment holding
+// thousands of MACs is the difference the signal exists to remove.
+func TestApplier_EVPNMassWithdraw(t *testing.T) {
+	esi := [10]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	other := [10]byte{0, 9, 9, 9, 9, 9, 9, 9, 9, 9}
+
+	t.Run("drops every MAC that PE taught on the segment", func(t *testing.T) {
+		a, fh := evpnApplier(t)
+		for _, mac := range []string{"aa:bb:cc:00:00:01", "aa:bb:cc:00:00:02"} {
+			a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN,
+				EVPN: rt2FromES(mac, "fd00:2:2:d2::", "fd00::2", esi)})
+		}
+		if len(fh.fdb) != 2 {
+			t.Fatalf("setup installed %d MACs, want 2", len(fh.fdb))
+		}
+		a.Apply(perESWithdraw("fd00::2", esi))
+		if len(fh.fdb) != 0 {
+			t.Errorf("mass withdraw left %d MACs installed", len(fh.fdb))
+		}
+	})
+
+	t.Run("leaves the other PEs on the segment alone", func(t *testing.T) {
+		// All-active multi-homing means several PEs advertise the same
+		// segment; one going away must not take the survivors' MACs with it.
+		a, fh := evpnApplier(t)
+		a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN,
+			EVPN: rt2FromES("aa:bb:cc:00:00:01", "fd00:2:2:d2::", "fd00::2", esi)})
+		a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN,
+			EVPN: rt2FromES("aa:bb:cc:00:00:02", "fd00:3:3:d2::", "fd00::3", esi)})
+
+		a.Apply(perESWithdraw("fd00::2", esi))
+		if len(fh.fdb) != 1 {
+			t.Fatalf("after withdraw %d MACs remain, want the other PE's one", len(fh.fdb))
+		}
+	})
+
+	t.Run("leaves other segments alone", func(t *testing.T) {
+		a, fh := evpnApplier(t)
+		a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN,
+			EVPN: rt2FromES("aa:bb:cc:00:00:01", "fd00:2:2:d2::", "fd00::2", esi)})
+		a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN,
+			EVPN: rt2FromES("aa:bb:cc:00:00:02", "fd00:2:2:d2::", "fd00::2", other)})
+
+		a.Apply(perESWithdraw("fd00::2", esi))
+		if len(fh.fdb) != 1 {
+			t.Fatalf("after withdraw %d MACs remain, want the other segment's one", len(fh.fdb))
+		}
+	})
+
+	t.Run("single-homed MACs are untouched", func(t *testing.T) {
+		// A MAC with no ESI belongs to no segment, so no per-ES withdrawal
+		// can be a statement about it.
+		a, fh := evpnApplier(t)
+		a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN,
+			EVPN: rt2("aa:bb:cc:00:00:09", "fd00:2:2:d2::")})
+		a.Apply(perESWithdraw("fd00::2", esi))
+		if len(fh.fdb) != 1 {
+			t.Errorf("a single-homed MAC was swept: %d remain", len(fh.fdb))
+		}
+	})
+
+	t.Run("a per-EVI withdraw is not a mass withdraw", func(t *testing.T) {
+		// Only the per-ES form carries the segment-wide meaning; treating a
+		// per-EVI withdrawal the same way would tear down MACs still reachable
+		// through the other broadcast domains.
+		a, fh := evpnApplier(t)
+		a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN,
+			EVPN: rt2FromES("aa:bb:cc:00:00:01", "fd00:2:2:d2::", "fd00::2", esi)})
+		ev := perESWithdraw("fd00::2", esi)
+		ev.EVPN.EthernetTag = 100 // per-EVI
+		a.Apply(ev)
+		if len(fh.fdb) != 1 {
+			t.Errorf("a per-EVI withdraw swept the segment: %d MACs remain", len(fh.fdb))
+		}
+	})
+
+	t.Run("advertising a per-ES route changes nothing", func(t *testing.T) {
+		a, fh := evpnApplier(t)
+		a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN,
+			EVPN: rt2FromES("aa:bb:cc:00:00:01", "fd00:2:2:d2::", "fd00::2", esi)})
+		ev := perESWithdraw("fd00::2", esi)
+		ev.IsWithdraw = false
+		a.Apply(ev)
+		if len(fh.fdb) != 1 {
+			t.Errorf("an advertisement disturbed the FDB: %d MACs remain", len(fh.fdb))
+		}
+	})
+}


### PR DESCRIPTION
ECMP シリーズ (docs/plan/ecmp-support.md) の PR6 後半のうち、data plane を伴わずに単独で意味のある mass withdraw を先に実装します。

## 背景

PR #125 で RT1 が decode できるようになりましたが、まだ誰も消費していませんでした。RT1 の役割は 2 つあり、そのうち **mass withdraw は control plane だけで完結します**。

PE が per-ES Ethernet A-D 経路を引くのは、その Ethernet Segment が自分から丸ごと失われたという主張です (RFC 7432 8.2)。MAC ごとの withdraw も後から来ますが、segment が数千の MAC を抱えていると、1 つずつ届くまでその MAC 宛のトラフィックは black-hole し続けます。この signal はまさにそれを避けるために存在します。

## 実装

`{ESI, PE}` から FDB エントリを引く逆引き index を追加し、per-ES A-D の withdraw でその PE がその segment 上で教えた MAC をまとめて撤去します。撤去自体は既存の `withdrawEVPNMac` を通すので、bd_peer の refcount 解放もそのまま効きます。

## 判断したこと

- **single-homed の MAC は index しません。** ESI が全ゼロなら属する segment が無く、per-ES の withdraw がその MAC についての主張になり得ません
- **per-EVI の withdraw は mass withdraw として扱いません。** segment 全体の意味を持つのは per-ES の形だけで、混同すると他の broadcast domain 経由でまだ到達できる MAC を落とします
- **ESI と NextHop の両方が無ければ何もしません。** どちらが欠けても「誰の寄与を落とすか」を特定できず、推測すると到達可能な MAC を壊します
- **撤去前に key を snapshot します。** `withdrawEVPNMac` が index を書き換えるので、走査しながら削除するとエントリを取りこぼします
- 再広告に特別な処理は不要です。MAC は通常の RT2 として戻ります

## スコープ

RT1 のもう一方の役割である aliasing は、ESI から group_id を引く side table と `l2_headend.c` の参照が要るため後続にします。

## テスト

- その PE がその segment 上で教えた MAC が全部落ちること
- **同じ segment の他の PE の MAC は残ること** (all-active multi-homing では複数 PE が同じ segment を広告します)
- 他の segment の MAC は残ること
- single-homed の MAC は触られないこと
- per-EVI の withdraw が segment を掃かないこと
- per-ES の **広告**では何も起きないこと

per-ES の判定を外す mutation で「per-EVI が segment を掃く」形になり、テストが検知することを確認済みです。`pkg/bgp/...` 全 green、golangci-lint 0 issues。