### PR TITLE
feat(interop): ecmp-2site シナリオで path group と prober を E2E 検証する

### DIFF
--- a/.github/workflows/interop-clab.yaml
+++ b/.github/workflows/interop-clab.yaml
@@ -42,6 +42,7 @@ jobs:
         scenario:
           - l3vpn-2site          # SRv6 L3VPN (transposition)
           - l3vpn-2site-auto     # SRv6 L3VPN via VRF-export auto-advertise (no vbctl)
+          - ecmp-2site           # two FRR PEs, one prefix: ECMP spread + prober fast reroute
           - sr-policy-2site      # color-based SR Policy steering (local + multi-hop chain)
           - sr-policy-bgp-2site  # SR Policy learned over BGP (SAFI 73)
           - evpn-2site           # EVPN RT2 (MAC/IP) L2VPN over BGP (SAFI 70)

--- a/.github/workflows/interop-clab.yaml
+++ b/.github/workflows/interop-clab.yaml
@@ -13,6 +13,7 @@ on:
     paths:
       - 'examples/interop-clab/**'
       - 'pkg/bgp/**'
+      - 'pkg/prober/**'
       - 'pkg/config/config.go'
       - 'cmd/vinberod/**'
       - 'cmd/vinbero/**'
@@ -22,6 +23,7 @@ on:
     paths:
       - 'examples/interop-clab/**'
       - 'pkg/bgp/**'
+      - 'pkg/prober/**'
       - 'pkg/config/config.go'
       - 'cmd/vinberod/**'
       - 'cmd/vinbero/**'

--- a/examples/interop-clab/README.md
+++ b/examples/interop-clab/README.md
@@ -30,6 +30,7 @@ Each row links to the scenario's own README.
 |----------|------|----------------|
 | [`l3vpn-2site`](scenarios/l3vpn-2site/README.md) | FRR 10.2.1 | 2-site SRv6 L3VPN — VPNv4/VPNv6 Service TLV encode+decode (RFC 9252 §4 transposition) and a bidirectional SRv6 data-plane ping. |
 | [`l3vpn-2site-auto`](scenarios/l3vpn-2site-auto/README.md) | FRR 10.2.1 | The same L3VPN, but Vinbero originates its VRF route automatically from config (`auto_advertise` + `vrf_bindings`) via the `pkg/bgp/export` exporter — no `vbctl` advertise call. |
+| [`ecmp-2site`](scenarios/ecmp-2site/README.md) | FRR 10.2.1 ×2 | A dual-homed far site: two FRR PEs advertise one prefix, Vinbero aggregates them into an ECMP group, spreads flows over both, and the SRv6 prober masks a cut path in hundreds of milliseconds. |
 | [`sr-policy-2site`](scenarios/sr-policy-2site/README.md) | FRR 10.2.1 | Color-based SR Policy steering (RFC 9256 / RFC 9252 §8): FRR tags a route with a Color Extended Community and Vinbero steers it onto an operator-defined SR Policy carrying a two-segment service chain. |
 | [`sr-policy-bgp-2site`](scenarios/sr-policy-bgp-2site/README.md) | Vinbero | Edge-to-edge SR Policy exchange over BGP (SAFI 73): both PEs advertise and receive SR Policies and steer their L3VPN traffic through a shared TE waypoint — exercises the SR Policy receive/decode path. |
 | [`evpn-2site`](scenarios/evpn-2site/README.md) | Vinbero | SRv6 EVPN L2VPN (ELAN): RT2 (MAC/IP) unicast + RT3 (Inclusive Multicast) BUM flood, a stretched broadcast domain signalled entirely by BGP EVPN. |

--- a/examples/interop-clab/scenarios/ecmp-2site/README.ja.md
+++ b/examples/interop-clab/scenarios/ecmp-2site/README.ja.md
@@ -32,8 +32,8 @@ graph LR
 1. 受信側の ECMP 集約を確認します。RD も SID も異なる同一 prefix の 2 広告が、last-write-wins ではなく member 2 本の 1 group に載ります
 2. per-flow の分散を確認します。inner source が異なる 12 本の ping flow が両 member に hash され、両 FRR PE が実際に encap 済みトラフィックを受け取ることを assert します
 3. prober の生存監視を確認します。`vbctl prober status` に path ごとの probe (宛先は各 FRR PE の loopback) が up で並びます
-4. fast reroute を確認します。`core` が pe-osaka-b への link を落とすと、prober が path をマスクし (100ms probe を 3 回喪失)、BGP がまだ両 path を信じている間に全 flow が pe-osaka-a 経由で流れ続けます
-5. 復旧を確認します。link を戻すと path が復帰し (3 回連続応答)、分散が再開します
+4. fast reroute を確認します。`core` が pe-osaka-b 向けの経路を削除すると (admin link down は veth 両端の IPv6 address を flush してラボを path 障害以上に壊すため使いません)、prober が path をマスクし (100ms probe を 3 回喪失)、BGP がまだ両 path を信じている間に全 flow が pe-osaka-a 経由で流れ続けます
+5. 復旧を確認します。経路を戻すと path が復帰し (3 回連続応答)、分散が再開します
 
 ## 実行方法
 

--- a/examples/interop-clab/scenarios/ecmp-2site/README.ja.md
+++ b/examples/interop-clab/scenarios/ecmp-2site/README.ja.md
@@ -1,0 +1,45 @@
+# ecmp-2site — ECMP path group と prober fast reroute (Vinbero <-> FRR ×2)
+
+*(English: [README.md](./README.md))*
+
+遠端のカスタマーサイトが独立した 2 台の FRR PE に dual-home され、両方が同じ prefix を広告する [containerlab](https://containerlab.dev/) シナリオです。Vinbero PE は 2 本の VPNv4 path を 1 つの ECMP path group に集約し、inner 5-tuple hash で両 PE に flow を分散し、各 path に SRv6 liveness prober を走らせます。片方の FRR PE の underlay を経路途中で切断すると、prober が数百ミリ秒でその path をマスクします。iBGP の hold time はここでは 30 秒で、トラフィックを救うには意図的に遅すぎる設定です。
+
+## トポロジ
+
+```mermaid
+graph LR
+    CET["ce-tokyo<br/>10.1.0.10-21"]
+    PET["pe-tokyo<br/>Vinbero PE<br/>fd00:100::/48"]
+    CORE["core<br/>IPv6 backbone"]
+    PEA["pe-osaka-a<br/>FRR PE<br/>fd00:200::/48"]
+    PEB["pe-osaka-b<br/>FRR PE<br/>fd00:300::/48"]
+    LAN["lan-osaka<br/>L2 bridge"]
+    CEO["ce-osaka<br/>10.2.0.10"]
+
+    CET --- PET
+    PET --- CORE
+    CORE --- PEA
+    CORE --- PEB
+    PEA --- LAN
+    PEB --- LAN
+    LAN --- CEO
+```
+
+3 台の PE はすべてプロバイダ AS 65100 に属します。Vinbero は両 FRR PE と loopback 間で iBGP を張り、各 FRR PE は共有サイト LAN の connected な `10.2.0.0/24` を、それぞれ固有の RD (`65200:200` / `65300:200`) と locator (`fd00:200::/48` / `fd00:300::/48`)、共通の route target `65000:200` で export します。
+
+## 検証内容
+
+1. 受信側の ECMP 集約を確認します。RD も SID も異なる同一 prefix の 2 広告が、last-write-wins ではなく member 2 本の 1 group に載ります
+2. per-flow の分散を確認します。inner source が異なる 12 本の ping flow が両 member に hash され、両 FRR PE が実際に encap 済みトラフィックを受け取ることを assert します
+3. prober の生存監視を確認します。`vbctl prober status` に path ごとの probe (宛先は各 FRR PE の loopback) が up で並びます
+4. fast reroute を確認します。`core` が pe-osaka-b への link を落とすと、prober が path をマスクし (100ms probe を 3 回喪失)、BGP がまだ両 path を信じている間に全 flow が pe-osaka-a 経由で流れ続けます
+5. 復旧を確認します。link を戻すと path が復帰し (3 回連続応答)、分散が再開します
+
+## 実行方法
+
+```bash
+cd examples/interop-clab
+make all SCENARIO=ecmp-2site
+```
+
+Docker、containerlab、sudo が必要です。ホスト kernel に `vrf` モジュールが要ります (`modprobe vrf`)。デプロイ済みのラボに対しては `make test SCENARIO=ecmp-2site` で assert だけ再実行できます。

--- a/examples/interop-clab/scenarios/ecmp-2site/README.md
+++ b/examples/interop-clab/scenarios/ecmp-2site/README.md
@@ -1,0 +1,65 @@
+# ecmp-2site — ECMP path groups + prober fast reroute (Vinbero <-> FRR ×2)
+
+*(日本語: [README.ja.md](./README.ja.md))*
+
+A [containerlab](https://containerlab.dev/) scenario where the far customer
+site is dual-homed to **two independent FRR PEs** that both advertise the same
+prefix. The Vinbero PE aggregates the two VPNv4 paths into one ECMP path
+group, spreads flows across both PEs by inner 5-tuple hash, and runs the SRv6
+liveness prober against each path. Cutting one FRR PE's underlay mid-path is
+masked by the prober in hundreds of milliseconds — the iBGP hold time is 30
+seconds here, deliberately too slow to be the thing that saves the traffic.
+
+## Topology
+
+```mermaid
+graph LR
+    CET["ce-tokyo<br/>10.1.0.10-21"]
+    PET["pe-tokyo<br/>Vinbero PE<br/>fd00:100::/48"]
+    CORE["core<br/>IPv6 backbone"]
+    PEA["pe-osaka-a<br/>FRR PE<br/>fd00:200::/48"]
+    PEB["pe-osaka-b<br/>FRR PE<br/>fd00:300::/48"]
+    LAN["lan-osaka<br/>L2 bridge"]
+    CEO["ce-osaka<br/>10.2.0.10"]
+
+    CET --- PET
+    PET --- CORE
+    CORE --- PEA
+    CORE --- PEB
+    PEA --- LAN
+    PEB --- LAN
+    LAN --- CEO
+```
+
+All three PEs are in provider AS 65100. Vinbero peers iBGP over loopbacks
+with both FRR PEs; each FRR PE exports the connected `10.2.0.0/24` of the
+shared site LAN under its own RD (`65200:200` / `65300:200`) and locator
+(`fd00:200::/48` / `fd00:300::/48`), with the shared route target
+`65000:200`.
+
+## What it proves
+
+1. **Receive-side ECMP aggregation.** The two advertisements of one prefix —
+   different RDs, different SIDs — land in a single ECMP path group with two
+   members instead of last-write-wins.
+2. **Per-flow spread.** Twelve ping flows (distinct inner sources) are hashed
+   across both members; the test asserts both FRR PEs actually receive
+   encapsulated traffic.
+3. **Prober liveness.** `vbctl prober status` shows one probe per path,
+   terminating at each FRR PE's loopback, both up.
+4. **Fast reroute.** `core` drops the pe-osaka-b link. The prober masks the
+   path (three lost 100ms probes) and every flow keeps flowing through
+   pe-osaka-a while BGP still believes both paths exist.
+5. **Recovery.** Restoring the link brings the path back (three answered
+   probes) and traffic spreads again.
+
+## Running
+
+```bash
+cd examples/interop-clab
+make all SCENARIO=ecmp-2site
+```
+
+Needs Docker, containerlab and sudo; the host kernel must have the `vrf`
+module (`modprobe vrf`). `make test SCENARIO=ecmp-2site` re-runs the
+assertions against a deployed lab.

--- a/examples/interop-clab/scenarios/ecmp-2site/README.md
+++ b/examples/interop-clab/scenarios/ecmp-2site/README.md
@@ -47,11 +47,13 @@ shared site LAN under its own RD (`65200:200` / `65300:200`) and locator
    encapsulated traffic.
 3. **Prober liveness.** `vbctl prober status` shows one probe per path,
    terminating at each FRR PE's loopback, both up.
-4. **Fast reroute.** `core` drops the pe-osaka-b link. The prober masks the
-   path (three lost 100ms probes) and every flow keeps flowing through
+4. **Fast reroute.** `core` removes its routes towards pe-osaka-b (an
+   admin link-down would flush the veth pair's IPv6 addresses and break
+   the lab beyond what a path failure means). The prober masks the path
+   (three lost 100ms probes) and every flow keeps flowing through
    pe-osaka-a while BGP still believes both paths exist.
-5. **Recovery.** Restoring the link brings the path back (three answered
-   probes) and traffic spreads again.
+5. **Recovery.** Restoring the routes brings the path back (three
+   answered probes) and traffic spreads again.
 
 ## Running
 

--- a/examples/interop-clab/scenarios/ecmp-2site/clab.yml
+++ b/examples/interop-clab/scenarios/ecmp-2site/clab.yml
@@ -1,0 +1,115 @@
+# containerlab topology for the ecmp-2site interop scenario.
+#
+# The l3vpn-2site design with the far site dual-homed: TWO independent
+# FRR PEs advertise the same customer prefix, so the Vinbero headend
+# aggregates their paths into one ECMP group and spreads flows across
+# both -- and, with the prober enabled, masks a dead path within a few
+# hundred milliseconds, long before BGP notices.
+#
+#                             ┌── pe-osaka-a (FRR) ──┐
+#   ce-tokyo --- pe-tokyo --- core                  lan-osaka --- ce-osaka
+#  10.1.0.0/24  (Vinbero PE)  └── pe-osaka-b (FRR) ──┘          10.2.0.0/24
+#
+# All three PEs are in provider AS 65100 and peer iBGP over loopbacks
+# (Vinbero to each FRR PE; the FRR PEs do not need to peer with each
+# other for this test). `core` is a plain IPv6 router with static
+# underlay routes; `lan-osaka` is a plain L2 bridge for the dual-homed
+# customer site.
+name: ecmp-2site
+
+topology:
+  nodes:
+    # --- ce-tokyo: customer host behind the Vinbero PE ----------------------
+    # Extra addresses 10.1.0.11-21 give the spread test twelve distinct
+    # inner sources: the headend hashes ICMP on {src, dst, proto}, so
+    # varying the source is what exercises both ECMP paths (and keeps
+    # the odds of every flow hashing onto one path negligible).
+    ce-tokyo:
+      kind: linux
+      image: alpine:3.20
+      exec:
+        - ip addr add 10.1.0.10/24 dev eth1
+        - ip addr add 10.1.0.11/24 dev eth1
+        - ip addr add 10.1.0.12/24 dev eth1
+        - ip addr add 10.1.0.13/24 dev eth1
+        - ip addr add 10.1.0.14/24 dev eth1
+        - ip addr add 10.1.0.15/24 dev eth1
+        - ip addr add 10.1.0.16/24 dev eth1
+        - ip addr add 10.1.0.17/24 dev eth1
+        - ip addr add 10.1.0.18/24 dev eth1
+        - ip addr add 10.1.0.19/24 dev eth1
+        - ip addr add 10.1.0.20/24 dev eth1
+        - ip addr add 10.1.0.21/24 dev eth1
+        - ip link set eth1 up
+        - ip route replace 10.2.0.0/24 via 10.1.0.1
+
+    # --- pe-tokyo: the Vinbero PE under test --------------------------------
+    pe-tokyo:
+      kind: linux
+      image: vinbero-interop:latest
+      binds:
+        - vinbero/vinbero.yml:/vinbero.yml
+        - vinbero/start.sh:/start.sh
+      exec:
+        - bash /start.sh
+
+    # --- core: provider backbone, plain IPv6 router -------------------------
+    core:
+      kind: linux
+      image: alpine:3.20
+      binds:
+        - core/start.sh:/start.sh
+      exec:
+        - sh /start.sh
+
+    # --- pe-osaka-a / pe-osaka-b: the two FRR PEs ---------------------------
+    # Each owns its own loopback, SRv6 locator and RD, and advertises the
+    # same vrf-cust prefix under the shared import/export RT -- the
+    # textbook all-active dual-homing the ECMP aggregation exists for.
+    pe-osaka-a:
+      kind: linux
+      image: frr-interop:10.2.1
+      binds:
+        - frr/frr-a.conf:/etc/frr/frr.conf
+        - frr/start.sh:/start.sh
+      exec:
+        - sh /start.sh 2001:db8:ff::2 2001:db8:2::1 10.2.0.1
+
+    pe-osaka-b:
+      kind: linux
+      image: frr-interop:10.2.1
+      binds:
+        - frr/frr-b.conf:/etc/frr/frr.conf
+        - frr/start.sh:/start.sh
+      exec:
+        - sh /start.sh 2001:db8:ff::3 2001:db8:3::1 10.2.0.2
+
+    # --- lan-osaka: the dual-homed customer site's L2 segment ---------------
+    lan-osaka:
+      kind: linux
+      image: alpine:3.20
+      binds:
+        - lan/start.sh:/start.sh
+      exec:
+        - sh /start.sh
+
+    # --- ce-osaka: customer host, default gateway via pe-osaka-a ------------
+    ce-osaka:
+      kind: linux
+      image: alpine:3.20
+      exec:
+        - ip addr add 10.2.0.10/24 dev eth1
+        - ip link set eth1 up
+        - ip route replace 10.1.0.0/24 via 10.2.0.1
+
+  links:
+    # CE <-> PE customer-facing ports.
+    - endpoints: [ce-tokyo:eth1, pe-tokyo:eth2]
+    # Provider underlay: pe-tokyo <-> core <-> {pe-osaka-a, pe-osaka-b}.
+    - endpoints: [pe-tokyo:eth1, core:eth1]
+    - endpoints: [core:eth2, pe-osaka-a:eth2]
+    - endpoints: [core:eth3, pe-osaka-b:eth2]
+    # Dual-homed site LAN: both FRR PEs and the CE on one L2 segment.
+    - endpoints: [pe-osaka-a:eth1, lan-osaka:eth1]
+    - endpoints: [pe-osaka-b:eth1, lan-osaka:eth2]
+    - endpoints: [ce-osaka:eth1, lan-osaka:eth3]

--- a/examples/interop-clab/scenarios/ecmp-2site/core/start.sh
+++ b/examples/interop-clab/scenarios/ecmp-2site/core/start.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Provider backbone router for the ecmp-2site interop scenario: a plain
+# IPv6 router with static routes towards the three PEs (no IGP, no
+# convergence race). This is also where the failover test cuts one FRR
+# PE off (eth3 down), so the loss is a mid-path underlay failure -- the
+# kind BGP takes its hold time to notice and the prober catches in
+# hundreds of milliseconds.
+#
+# Underlay links:
+#   eth1  pe-tokyo   <-> core  2001:db8:1::/64  (core = ::2, pe = ::1)
+#   eth2  pe-osaka-a <-> core  2001:db8:2::/64  (core = ::2, pe = ::1)
+#   eth3  pe-osaka-b <-> core  2001:db8:3::/64  (core = ::2, pe = ::1)
+set -u
+
+ip link set eth1 up
+ip -6 addr add 2001:db8:1::2/64 dev eth1 2>/dev/null || true
+ip link set eth2 up
+ip -6 addr add 2001:db8:2::2/64 dev eth2 2>/dev/null || true
+ip link set eth3 up
+ip -6 addr add 2001:db8:3::2/64 dev eth3 2>/dev/null || true
+
+sysctl -w net.ipv6.conf.all.forwarding=1 >/dev/null 2>&1 || true
+
+# Towards pe-tokyo: its loopback + Vinbero's locator block.
+ip -6 route replace 2001:db8:ff::1/128 via 2001:db8:1::1 dev eth1
+ip -6 route replace fd00:100::/48      via 2001:db8:1::1 dev eth1
+# Towards pe-osaka-a: its loopback + locator block.
+ip -6 route replace 2001:db8:ff::2/128 via 2001:db8:2::1 dev eth2
+ip -6 route replace fd00:200::/48      via 2001:db8:2::1 dev eth2
+# Towards pe-osaka-b: its loopback + locator block.
+ip -6 route replace 2001:db8:ff::3/128 via 2001:db8:3::1 dev eth3
+ip -6 route replace fd00:300::/48      via 2001:db8:3::1 dev eth3
+
+# Pre-resolve the underlay NDP neighbours so the first transit packet
+# is forwarded immediately rather than queued behind NDP resolution.
+ping6 -c 1 -W 2 2001:db8:1::1 >/dev/null 2>&1 || true
+ping6 -c 1 -W 2 2001:db8:2::1 >/dev/null 2>&1 || true
+ping6 -c 1 -W 2 2001:db8:3::1 >/dev/null 2>&1 || true
+
+echo "[start.sh] core IPv6 router ready"

--- a/examples/interop-clab/scenarios/ecmp-2site/core/start.sh
+++ b/examples/interop-clab/scenarios/ecmp-2site/core/start.sh
@@ -2,9 +2,10 @@
 # Provider backbone router for the ecmp-2site interop scenario: a plain
 # IPv6 router with static routes towards the three PEs (no IGP, no
 # convergence race). This is also where the failover test cuts one FRR
-# PE off (eth3 down), so the loss is a mid-path underlay failure -- the
-# kind BGP takes its hold time to notice and the prober catches in
-# hundreds of milliseconds.
+# PE off, by removing the routes towards it (not by downing the link,
+# which would flush the IPv6 addresses on both veth ends): a mid-path
+# underlay failure, the kind BGP takes its hold time to notice and the
+# prober catches in hundreds of milliseconds.
 #
 # Underlay links:
 #   eth1  pe-tokyo   <-> core  2001:db8:1::/64  (core = ::2, pe = ::1)

--- a/examples/interop-clab/scenarios/ecmp-2site/frr/frr-a.conf
+++ b/examples/interop-clab/scenarios/ecmp-2site/frr/frr-a.conf
@@ -50,7 +50,11 @@ router bgp 65100
  !
  neighbor 2001:db8:ff::1 remote-as 65100
  neighbor 2001:db8:ff::1 update-source lo
- neighbor 2001:db8:ff::1 timers 3 10
+! keepalive 10 / hold 30: the negotiated hold time is the MINIMUM of the
+! two sides, and the scenario's premise is that BGP (30s hold) is too
+! slow to be what saves the traffic -- a 10s hold here would let a
+! withdraw race the prober assertion.
+ neighbor 2001:db8:ff::1 timers 10 30
  neighbor 2001:db8:ff::1 timers connect 1
  neighbor 2001:db8:ff::1 capability extended-nexthop
  !

--- a/examples/interop-clab/scenarios/ecmp-2site/frr/frr-a.conf
+++ b/examples/interop-clab/scenarios/ecmp-2site/frr/frr-a.conf
@@ -1,0 +1,93 @@
+frr version 10.2.1
+frr defaults traditional
+hostname pe-osaka-a
+log file /var/log/frr/frr.log
+log stdout
+service integrated-vtysh-config
+!
+! ---------------------------------------------------------------------------
+! pe-osaka-a -- one of the two FRR PEs of the ecmp-2site interop scenario.
+!
+! Both FRR PEs advertise the SAME customer prefix (the dual-homed
+! 10.2.0.0/24 site) under their own RD and locator, sharing the import/
+! export RT. Vinbero on pe-tokyo aggregates the two paths into one ECMP
+! group; this node is one member of it. The config structure follows the
+! l3vpn-2site scenario (FRR topotest bgp_srv6l3vpn_over_ipv6).
+! ---------------------------------------------------------------------------
+!
+interface lo
+ ipv6 address 2001:db8:ff::2/128
+exit
+!
+! eth1 faces the dual-homed site LAN: the customer-facing port, in vrf-cust.
+interface eth1 vrf vrf-cust
+ ip address 10.2.0.1/24
+exit
+!
+! eth2 faces the core: the IPv6 underlay link.
+interface eth2
+ ipv6 address 2001:db8:2::1/64
+exit
+!
+! Static underlay routes: pe-tokyo's loopback and Vinbero's locator block.
+ipv6 route 2001:db8:ff::1/128 2001:db8:2::2
+ipv6 route fd00:100::/48 2001:db8:2::2
+!
+segment-routing
+ srv6
+  locators
+   locator LOC1
+    prefix fd00:200::/48
+   exit
+  exit
+ exit
+exit
+!
+router bgp 65100
+ bgp router-id 10.255.0.2
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ !
+ neighbor 2001:db8:ff::1 remote-as 65100
+ neighbor 2001:db8:ff::1 update-source lo
+ neighbor 2001:db8:ff::1 timers 3 10
+ neighbor 2001:db8:ff::1 timers connect 1
+ neighbor 2001:db8:ff::1 capability extended-nexthop
+ !
+ segment-routing srv6
+  locator LOC1
+ exit
+ !
+ address-family ipv4 vpn
+  neighbor 2001:db8:ff::1 activate
+ exit-address-family
+ !
+ address-family ipv6 vpn
+  neighbor 2001:db8:ff::1 activate
+ exit-address-family
+exit
+!
+router bgp 65100 vrf vrf-cust
+ bgp router-id 10.255.0.2
+ !
+ address-family ipv4 unicast
+  redistribute connected
+  sid vpn export 1
+  rd vpn export 65200:200
+  rt vpn both 65000:200
+  import vpn
+  export vpn
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  redistribute connected
+  sid vpn export 2
+  rd vpn export 65200:206
+  rt vpn both 65000:206
+  import vpn
+  export vpn
+ exit-address-family
+exit
+!
+line vty
+!

--- a/examples/interop-clab/scenarios/ecmp-2site/frr/frr-b.conf
+++ b/examples/interop-clab/scenarios/ecmp-2site/frr/frr-b.conf
@@ -50,7 +50,11 @@ router bgp 65100
  !
  neighbor 2001:db8:ff::1 remote-as 65100
  neighbor 2001:db8:ff::1 update-source lo
- neighbor 2001:db8:ff::1 timers 3 10
+! keepalive 10 / hold 30: the negotiated hold time is the MINIMUM of the
+! two sides, and the scenario's premise is that BGP (30s hold) is too
+! slow to be what saves the traffic -- a 10s hold here would let a
+! withdraw race the prober assertion.
+ neighbor 2001:db8:ff::1 timers 10 30
  neighbor 2001:db8:ff::1 timers connect 1
  neighbor 2001:db8:ff::1 capability extended-nexthop
  !

--- a/examples/interop-clab/scenarios/ecmp-2site/frr/frr-b.conf
+++ b/examples/interop-clab/scenarios/ecmp-2site/frr/frr-b.conf
@@ -1,0 +1,93 @@
+frr version 10.2.1
+frr defaults traditional
+hostname pe-osaka-b
+log file /var/log/frr/frr.log
+log stdout
+service integrated-vtysh-config
+!
+! ---------------------------------------------------------------------------
+! pe-osaka-b -- one of the two FRR PEs of the ecmp-2site interop scenario.
+!
+! Both FRR PEs advertise the SAME customer prefix (the dual-homed
+! 10.2.0.0/24 site) under their own RD and locator, sharing the import/
+! export RT. Vinbero on pe-tokyo aggregates the two paths into one ECMP
+! group; this node is one member of it. The config structure follows the
+! l3vpn-2site scenario (FRR topotest bgp_srv6l3vpn_over_ipv6).
+! ---------------------------------------------------------------------------
+!
+interface lo
+ ipv6 address 2001:db8:ff::3/128
+exit
+!
+! eth1 faces the dual-homed site LAN: the customer-facing port, in vrf-cust.
+interface eth1 vrf vrf-cust
+ ip address 10.2.0.2/24
+exit
+!
+! eth2 faces the core: the IPv6 underlay link.
+interface eth2
+ ipv6 address 2001:db8:3::1/64
+exit
+!
+! Static underlay routes: pe-tokyo's loopback and Vinbero's locator block.
+ipv6 route 2001:db8:ff::1/128 2001:db8:3::2
+ipv6 route fd00:100::/48 2001:db8:3::2
+!
+segment-routing
+ srv6
+  locators
+   locator LOC1
+    prefix fd00:300::/48
+   exit
+  exit
+ exit
+exit
+!
+router bgp 65100
+ bgp router-id 10.255.0.3
+ no bgp ebgp-requires-policy
+ no bgp default ipv4-unicast
+ !
+ neighbor 2001:db8:ff::1 remote-as 65100
+ neighbor 2001:db8:ff::1 update-source lo
+ neighbor 2001:db8:ff::1 timers 3 10
+ neighbor 2001:db8:ff::1 timers connect 1
+ neighbor 2001:db8:ff::1 capability extended-nexthop
+ !
+ segment-routing srv6
+  locator LOC1
+ exit
+ !
+ address-family ipv4 vpn
+  neighbor 2001:db8:ff::1 activate
+ exit-address-family
+ !
+ address-family ipv6 vpn
+  neighbor 2001:db8:ff::1 activate
+ exit-address-family
+exit
+!
+router bgp 65100 vrf vrf-cust
+ bgp router-id 10.255.0.3
+ !
+ address-family ipv4 unicast
+  redistribute connected
+  sid vpn export 1
+  rd vpn export 65300:200
+  rt vpn both 65000:200
+  import vpn
+  export vpn
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  redistribute connected
+  sid vpn export 2
+  rd vpn export 65300:206
+  rt vpn both 65000:206
+  import vpn
+  export vpn
+ exit-address-family
+exit
+!
+line vty
+!

--- a/examples/interop-clab/scenarios/ecmp-2site/frr/start.sh
+++ b/examples/interop-clab/scenarios/ecmp-2site/frr/start.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Bring up one of the two FRR PEs of the ecmp-2site scenario. The two
+# nodes differ only in their addresses, so the per-node values arrive as
+# arguments (see clab.yml):
+#
+#   $1  loopback        (iBGP peering / SRv6 transport, /128 on lo)
+#   $2  underlay addr   (eth2 towards the core, /64)
+#   $3  customer addr   (eth1 on the dual-homed site LAN, /24, in vrf-cust)
+#
+# The customer VRF must exist in the kernel *before* FRR loads
+# frr.conf -- zebra binds to existing devices, it does not create the
+# VRF master itself.
+LOOPBACK=$1
+UNDERLAY=$2
+CUSTOMER=$3
+
+# SRv6 needs IPv6 forwarding and the seg6 dataplane knobs. These are
+# namespace-scoped, so they must be set inside the container.
+sysctl -w net.ipv4.ip_forward=1 2>/dev/null || true
+sysctl -w net.ipv6.conf.all.forwarding=1 2>/dev/null || true
+sysctl -w net.ipv6.conf.all.seg6_enabled=1 2>/dev/null || true
+sysctl -w net.ipv6.conf.default.seg6_enabled=1 2>/dev/null || true
+sysctl -w net.ipv6.conf.eth1.seg6_enabled=1 2>/dev/null || true
+sysctl -w net.ipv6.conf.eth2.seg6_enabled=1 2>/dev/null || true
+sysctl -w net.ipv4.conf.all.rp_filter=0 2>/dev/null || true
+sysctl -w net.ipv4.conf.default.rp_filter=0 2>/dev/null || true
+# VRF strict mode is required by the kernel before FRR's auto-installed
+# seg6local End.DT4 localsid (which uses `vrftable`) can come up.
+sysctl -w net.vrf.strict_mode=1 2>/dev/null || true
+
+# --- customer VRF + customer-facing port -----------------------------------
+if ! ip link show vrf-cust >/dev/null 2>&1; then
+    ip link add vrf-cust type vrf table 100
+fi
+if ! ip link show vrf-cust >/dev/null 2>&1; then
+    echo "ERROR: failed to create VRF vrf-cust -- is the kernel 'vrf' module loaded on the host? (modprobe vrf)" >&2
+    exit 1
+fi
+ip link set vrf-cust up
+ip link set eth1 master vrf-cust
+ip link set eth1 up
+
+# --- addressing ------------------------------------------------------------
+# frr.conf repeats these (interface stanzas), but assigning them here too
+# keeps the node reachable even before the daemons settle.
+ip -6 addr add "$LOOPBACK"/128 dev lo 2>/dev/null || true
+ip -6 addr add "$UNDERLAY"/64 dev eth2 nodad 2>/dev/null || true
+ip addr add "$CUSTOMER"/24 dev eth1 2>/dev/null || true
+
+# --- underlay link towards the core ----------------------------------------
+ip link set eth2 up 2>/dev/null || true
+
+# NOTE: unlike the l3vpn-2site scenario, Vinbero's locator block is NOT
+# added as a connected prefix here. FRR 10.2.1 validates the received
+# service SID against the static fd00:100::/48 route just fine, and the
+# connected prefix is actively harmful: distance 0 beats the static in
+# the kernel, the post-encap outer packet then resolves the SID as
+# on-link, and its NDP -- which nothing on the core link answers --
+# fails, blackholing every return packet.
+
+# FRR ships an entrypoint that starts the daemons selected in
+# /etc/frr/daemons. watchfrr then keeps them alive.
+/usr/lib/frr/frrinit.sh start
+
+# Give the daemons a moment, then load the integrated config so that
+# any ordering-sensitive SRv6/BGP statements apply cleanly.
+sleep 4
+vtysh -b || true

--- a/examples/interop-clab/scenarios/ecmp-2site/lan/start.sh
+++ b/examples/interop-clab/scenarios/ecmp-2site/lan/start.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# L2 bridge for the dual-homed customer site: pe-osaka-a (eth1),
+# pe-osaka-b (eth2) and ce-osaka (eth3) share one Ethernet segment, so
+# both PEs see the same connected 10.2.0.0/24 and the CE can reach
+# either gateway.
+set -u
+
+ip link add br0 type bridge 2>/dev/null || true
+ip link set br0 up
+for port in eth1 eth2 eth3; do
+    ip link set "$port" master br0
+    ip link set "$port" up
+done
+
+echo "[start.sh] lan-osaka bridge ready"

--- a/examples/interop-clab/scenarios/ecmp-2site/test.sh
+++ b/examples/interop-clab/scenarios/ecmp-2site/test.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# ecmp-2site interop scenario assertions (Vinbero <-> FRR x2).
+#
+# Verifies, against a running `make deploy` lab, the things the scenario
+# exists to prove:
+#   1. both iBGP sessions are ESTABLISHED;
+#   2. Vinbero aggregates the two FRR PEs' advertisements of ONE customer
+#      prefix into a single ECMP group with two members;
+#   3. the prober tracks both paths (their loopbacks) as up;
+#   4. data plane: flows from twelve distinct sources reach ce-osaka and
+#      actually spread over BOTH FRR PEs;
+#   5. fast reroute: cutting pe-osaka-b's underlay mid-path is detected
+#      by the prober (BGP hold time is 30s, deliberately too slow to
+#      help) and every flow keeps working through pe-osaka-a;
+#   6. recovery: restoring the link brings the path back and flows
+#      spread again.
+#
+# Exit non-zero on the first failed assertion.
+set -u
+
+PE_TOKYO=clab-ecmp-2site-pe-tokyo
+PE_OSAKA_A=clab-ecmp-2site-pe-osaka-a
+PE_OSAKA_B=clab-ecmp-2site-pe-osaka-b
+CORE=clab-ecmp-2site-core
+CE_TOKYO=clab-ecmp-2site-ce-tokyo
+CE_OSAKA=clab-ecmp-2site-ce-osaka
+
+OSAKA_PREFIX=10.2.0.0/24
+CE_OSAKA_IP=10.2.0.10
+VIN_LOOPBACK=2001:db8:ff::1
+FRR_A_LOOPBACK=2001:db8:ff::2
+FRR_B_LOOPBACK=2001:db8:ff::3
+# The twelve inner sources the spread test pings from.
+SRCS=$(seq 10 21 | sed 's/^/10.1.0./')
+
+VBCTL="/usr/local/bin/vbctl"
+
+pass=0
+fail=0
+ok()   { echo "  PASS: $1"; pass=$((pass + 1)); }
+ng()   { echo "  FAIL: $1"; fail=$((fail + 1)); }
+
+dexec() { docker exec "$@"; }
+
+retry()   { retry_n 30 "$@"; }
+retry_n() {
+    local n=$1; shift
+    local i
+    for i in $(seq 1 "$n"); do
+        if "$@" >/dev/null 2>&1; then return 0; fi
+        sleep 2
+    done
+    return 1
+}
+
+echo "=============================================="
+echo " ecmp-2site interop scenario test (Vinbero <-> FRR x2)"
+echo "=============================================="
+
+# --- 1. both iBGP sessions ESTABLISHED -------------------------------------
+echo ""
+echo "[1] iBGP sessions ESTABLISHED"
+
+frr_established() {
+    dexec "$1" vtysh -c "show bgp summary json" 2>/dev/null \
+      | python3 -c "import sys,json; d=json.load(sys.stdin); \
+sys.exit(0 if d.get('ipv4Vpn',{}).get('peers',{}).get('$VIN_LOOPBACK',{}).get('state')=='Established' else 1)"
+}
+for pe in "$PE_OSAKA_A" "$PE_OSAKA_B"; do
+    if retry frr_established "$pe"; then
+        ok "$pe sees peer $VIN_LOOPBACK Established (ipv4 vpn)"
+    else
+        ng "$pe peer $VIN_LOOPBACK not Established"
+        dexec "$pe" vtysh -c "show bgp summary" || true
+    fi
+done
+
+# --- 2. one prefix, one group, two members ---------------------------------
+echo ""
+echo "[2] ECMP aggregation (two PEs -> one group)"
+
+group_json() {
+    dexec "$PE_TOKYO" "$VBCTL" --json headend-group list 2>/dev/null
+}
+group_has_two_members() {
+    group_json | python3 -c "
+import sys, json
+groups = json.load(sys.stdin) or []
+for g in groups:
+    if '$OSAKA_PREFIX' in (g.get('prefixes') or []) and len(g.get('members') or []) == 2:
+        sys.exit(0)
+sys.exit(1)"
+}
+if retry group_has_two_members; then
+    ok "one ECMP group holds both PEs' paths for $OSAKA_PREFIX"
+else
+    ng "no two-member group for $OSAKA_PREFIX"
+    group_json || true
+fi
+
+group_member_sids() {
+    group_json | python3 -c "
+import sys, json
+groups = json.load(sys.stdin) or []
+for g in groups:
+    if '$OSAKA_PREFIX' in (g.get('prefixes') or []):
+        for m in g.get('members') or []:
+            print(m.get('segments', [''])[0])
+"
+}
+sids=$(group_member_sids)
+if echo "$sids" | grep -q "fd00:200:" && echo "$sids" | grep -q "fd00:300:"; then
+    ok "group members carry one SID per FRR locator (fd00:200:: / fd00:300::)"
+else
+    ng "group member SIDs do not span both locators: $sids"
+fi
+
+# --- 3. prober tracks both paths -------------------------------------------
+echo ""
+echo "[3] prober state"
+
+prober_json() {
+    dexec "$PE_TOKYO" "$VBCTL" --json prober status 2>/dev/null
+}
+prober_paths_up() {
+    # $1 = expected number of up paths among the group's two.
+    prober_json | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+if not d.get('enabled'):
+    sys.exit(1)
+paths = [p for p in d.get('paths') or [] if p.get('dst') in ('$FRR_A_LOOPBACK', '$FRR_B_LOOPBACK')]
+up = [p for p in paths if p.get('up')]
+sys.exit(0 if len(paths) == 2 and len(up) == $1 else 1)"
+}
+if retry prober_paths_up 2; then
+    ok "prober probes both PE loopbacks and reports them up"
+else
+    ng "prober does not report two up paths"
+    prober_json || true
+fi
+
+# --- 4. data plane: reachability + spread over both PEs ---------------------
+echo ""
+echo "[4] data plane spread"
+
+ping_from() {
+    dexec "$CE_TOKYO" ping -c 1 -W 2 -I "$1" "$CE_OSAKA_IP"
+}
+# Readiness gate: the first source pings through before anything is
+# measured, so slow convergence cannot masquerade as a spread failure.
+if retry ping_from 10.1.0.10; then
+    ok "ce-tokyo reaches ce-osaka through the L3VPN"
+else
+    ng "ce-tokyo cannot reach ce-osaka at all"
+fi
+
+rx_bytes() { dexec "$1" cat "/sys/class/net/eth2/statistics/rx_bytes"; }
+
+# warm_arp resolves every source's ARP entry on the Vinbero PE through the
+# kernel path. The End.DT4 return delivery is a BPF FIB lookup, which
+# reports NO_NEIGH (and the XDP program drops) for a neighbour the kernel
+# has never resolved -- it does not trigger resolution itself.
+warm_arp() {
+    local src
+    for src in $SRCS; do
+        dexec "$PE_TOKYO" ping -c 1 -W 2 "$src" >/dev/null 2>&1 || true
+    done
+}
+
+burst() {
+    # 20 large pings from every source; per flow ~26KB towards its PE.
+    local src rc=0
+    warm_arp
+    for src in $SRCS; do
+        if ! dexec "$CE_TOKYO" ping -c 20 -s 1200 -i 0.05 -W 2 -q -I "$src" "$CE_OSAKA_IP" >/dev/null 2>&1; then
+            echo "    (ping from $src failed)"
+            rc=1
+        fi
+    done
+    return $rc
+}
+
+a0=$(rx_bytes "$PE_OSAKA_A"); b0=$(rx_bytes "$PE_OSAKA_B")
+if burst; then
+    ok "all twelve sources ping through"
+else
+    ng "some sources cannot ping"
+fi
+a1=$(rx_bytes "$PE_OSAKA_A"); b1=$(rx_bytes "$PE_OSAKA_B")
+da=$((a1 - a0)); db=$((b1 - b0))
+# Threshold 40KB: one flow's worth (~26KB) plus background noise clears
+# it, pure noise (probes, keepalives) stays well under it.
+if [ "$da" -gt 40000 ] && [ "$db" -gt 40000 ]; then
+    ok "flows spread over both PEs (pe-a +${da}B, pe-b +${db}B)"
+else
+    ng "flows did not spread (pe-a +${da}B, pe-b +${db}B)"
+fi
+
+# --- 5. fast reroute on a mid-path underlay failure -------------------------
+echo ""
+echo "[5] fast reroute (cut pe-osaka-b's underlay)"
+
+# The cut removes core's routes towards pe-osaka-b rather than downing
+# the link: an admin link-down flushes the IPv6 addresses on BOTH veth
+# ends and nothing restores them, which would break the lab beyond what
+# a path failure means. Route removal is the same mid-path blackhole
+# the prober exists to catch, and is cleanly reversible.
+dexec "$CORE" ip -6 route del 2001:db8:ff::3/128 2>/dev/null || true
+dexec "$CORE" ip -6 route del fd00:300::/48 2>/dev/null || true
+# The prober must notice within a few hundred ms; the retry allows for
+# the slower assertion plumbing, not the detection itself.
+if retry_n 10 prober_paths_up 1; then
+    ok "prober masked the dead path"
+else
+    ng "prober did not mask the dead path"
+    prober_json || true
+fi
+if burst; then
+    ok "every flow still pings through the surviving PE"
+else
+    ng "flows were lost after the path failure"
+fi
+
+# --- 6. recovery ------------------------------------------------------------
+echo ""
+echo "[6] recovery"
+
+dexec "$CORE" ip -6 route replace 2001:db8:ff::3/128 via 2001:db8:3::1 dev eth3
+dexec "$CORE" ip -6 route replace fd00:300::/48 via 2001:db8:3::1 dev eth3
+# If the outage outlived the BGP hold time the session dropped too; give
+# it time to re-establish and re-advertise before judging the prober.
+if retry prober_paths_up 2; then
+    ok "prober brought the path back"
+else
+    ng "path did not recover"
+    prober_json || true
+fi
+a0=$(rx_bytes "$PE_OSAKA_A"); b0=$(rx_bytes "$PE_OSAKA_B")
+if burst; then
+    ok "all sources ping after recovery"
+else
+    ng "some sources cannot ping after recovery"
+fi
+b1=$(rx_bytes "$PE_OSAKA_B")
+if [ $((b1 - b0)) -gt 40000 ]; then
+    ok "traffic returned to the recovered PE (+$((b1 - b0))B)"
+else
+    ng "no traffic on the recovered PE (+$((b1 - b0))B)"
+fi
+
+# --- summary ----------------------------------------------------------------
+echo ""
+echo "=============================================="
+echo " RESULT: $pass passed, $fail failed"
+echo "=============================================="
+[ "$fail" -eq 0 ]

--- a/examples/interop-clab/scenarios/ecmp-2site/test.sh
+++ b/examples/interop-clab/scenarios/ecmp-2site/test.sh
@@ -208,12 +208,21 @@ echo "[5] fast reroute (cut pe-osaka-b's underlay)"
 # the prober exists to catch, and is cleanly reversible.
 dexec "$CORE" ip -6 route del 2001:db8:ff::3/128 2>/dev/null || true
 dexec "$CORE" ip -6 route del fd00:300::/48 2>/dev/null || true
-# The prober must notice within a few hundred ms; the retry allows for
-# the slower assertion plumbing, not the detection itself.
-if retry_n 10 prober_paths_up 1; then
-    ok "prober masked the dead path"
+# The prober must notice within a few hundred ms. The assertion polls
+# fast and bounds the total elapsed time at 5 seconds -- generous for
+# the docker-exec plumbing, still far under the 30s BGP hold time, so a
+# BGP withdraw can never be what passes this check.
+mask_start=$(date +%s%N)
+masked=""
+for i in $(seq 1 25); do
+    if prober_paths_up 1 >/dev/null 2>&1; then masked=yes; break; fi
+    sleep 0.2
+done
+mask_ms=$(( ($(date +%s%N) - mask_start) / 1000000 ))
+if [ -n "$masked" ] && [ "$mask_ms" -lt 5000 ]; then
+    ok "prober masked the dead path in ${mask_ms}ms"
 else
-    ng "prober did not mask the dead path"
+    ng "prober did not mask the dead path within 5s (${mask_ms}ms)"
     prober_json || true
 fi
 if burst; then
@@ -242,11 +251,12 @@ if burst; then
 else
     ng "some sources cannot ping after recovery"
 fi
-b1=$(rx_bytes "$PE_OSAKA_B")
-if [ $((b1 - b0)) -gt 40000 ]; then
-    ok "traffic returned to the recovered PE (+$((b1 - b0))B)"
+a1=$(rx_bytes "$PE_OSAKA_A"); b1=$(rx_bytes "$PE_OSAKA_B")
+da=$((a1 - a0)); db=$((b1 - b0))
+if [ "$da" -gt 40000 ] && [ "$db" -gt 40000 ]; then
+    ok "traffic spreads over both PEs again (pe-a +${da}B, pe-b +${db}B)"
 else
-    ng "no traffic on the recovered PE (+$((b1 - b0))B)"
+    ng "spread did not return (pe-a +${da}B, pe-b +${db}B)"
 fi
 
 # --- summary ----------------------------------------------------------------

--- a/examples/interop-clab/scenarios/ecmp-2site/vinbero/start.sh
+++ b/examples/interop-clab/scenarios/ecmp-2site/vinbero/start.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Bring up the Vinbero PE (pe-tokyo) for the ecmp-2site scenario.
+#
+# Identical in structure to the l3vpn-2site start.sh, with the underlay
+# routes doubled: this PE reaches TWO FRR PEs (loopbacks + locator
+# blocks) through the core, learns the same customer prefix from both,
+# and aggregates them into one ECMP group. See that scenario for the
+# rationale of each step; only the ecmp-specific parts are annotated.
+#
+# Interfaces:
+#   eth1  pe-tokyo <-> core      underlay 2001:db8:1::/64 (pe-tokyo = ::1)
+#   eth2  pe-tokyo <-> ce-tokyo  customer 10.1.0.0/24     (pe-tokyo = .1)
+#   lo    loopback 2001:db8:ff::1  (iBGP peering / SRv6 transport / probe source)
+
+setknob() {
+    sysctl -w "$1=$2" >/dev/null 2>&1 || true
+}
+
+# --- interface addressing --------------------------------------------------
+ip -6 addr add 2001:db8:1::1/64 dev eth1 2>/dev/null || true
+ip link set eth1 up
+ip addr add 10.1.0.1/24 dev eth2 2>/dev/null || true
+ip link set eth2 up
+ip -6 addr add 2001:db8:ff::1/128 dev lo 2>/dev/null || true
+ip link set lo up
+
+# --- SRv6 dataplane knobs --------------------------------------------------
+setknob net.ipv4.ip_forward 1
+setknob net.ipv6.conf.all.forwarding 1
+setknob net.ipv6.conf.all.seg6_enabled 1
+setknob net.ipv6.conf.eth1.seg6_enabled 1
+setknob net.ipv6.conf.eth2.seg6_enabled 1
+setknob net.ipv4.conf.all.rp_filter 0
+setknob net.ipv4.conf.default.rp_filter 0
+setknob net.ipv4.conf.eth2.rp_filter 0
+
+ethtool -K eth1 txvlan off 2>/dev/null || true
+ethtool -K eth1 rxvlan off 2>/dev/null || true
+ethtool -K eth2 txvlan off 2>/dev/null || true
+ethtool -K eth2 rxvlan off 2>/dev/null || true
+
+# --- return-path routing table for the End.DT4 endpoint --------------------
+ip route replace 10.1.0.0/24 dev eth2 table 100
+
+# --- static underlay routes ------------------------------------------------
+# Both FRR PEs' loopbacks (iBGP peers, and the prober's echo targets)
+# and locator blocks, all via the core.
+ip -6 route replace 2001:db8:ff::2/128 via 2001:db8:1::2 dev eth1 \
+    src 2001:db8:ff::1
+ip -6 route replace 2001:db8:ff::3/128 via 2001:db8:1::2 dev eth1 \
+    src 2001:db8:ff::1
+ip -6 route replace fd00:200::/48 via 2001:db8:1::2 dev eth1
+ip -6 route replace fd00:300::/48 via 2001:db8:1::2 dev eth1
+
+mount -t bpf bpf /sys/fs/bpf 2>/dev/null || true
+
+mkdir -p /etc/vinbero
+cp /vinbero.yml /etc/vinbero/vinbero.yaml
+
+/usr/local/bin/vinberod --bgp-enabled -c /etc/vinbero/vinbero.yaml \
+    > /var/log/vinberod.log 2>&1 &
+echo $! > /var/run/vinberod.pid
+
+for i in $(seq 1 30); do
+    if /usr/local/bin/vbctl locator list >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+
+/usr/local/bin/vbctl locator create \
+    --name LOC1 \
+    --prefix fd00:100::/48 \
+    --block-len 32 --node-len 16 --function-len 16 --argument-len 64 \
+    --behavior classic || true
+
+/usr/local/bin/vbctl vrf create \
+    --name vrf-cust \
+    --table-id 100 \
+    --enable-l3mdev-rule || true
+if ! ip link show vrf-cust >/dev/null 2>&1; then
+    echo "ERROR: failed to create VRF vrf-cust -- is the kernel 'vrf' module loaded on the host? (modprobe vrf)" >&2
+    exit 1
+fi
+
+# --- return-path End.DT4 endpoint ------------------------------------------
+/usr/local/bin/vbctl sid create \
+    --trigger-prefix fd00:100:0:1::/128 \
+    --action END_DT4 \
+    --vrf-name vrf-cust || true
+
+# --- advertise the ce-tokyo customer subnet into the L3VPN -----------------
+# Both FRR PEs import RT 65000:200, so both install the return route --
+# whichever gateway ce-osaka uses can reach ce-tokyo.
+/usr/local/bin/vbctl bgp advertise-vpn --family vpnv4 \
+    --prefix 10.1.0.0/24 --rd 65100:200 --rts 65000:200 \
+    --sid fd00:100:0:1:: --next-hop 2001:db8:ff::1 || true
+
+# Pre-resolve neighbours for the XDP BPF FIB lookups.
+ping6 -c 1 -W 2 2001:db8:1::2 >/dev/null 2>&1 || true
+ping -c 1 -W 2 10.1.0.10 >/dev/null 2>&1 || true
+
+echo "[start.sh] pe-tokyo (Vinbero) PE ready"

--- a/examples/interop-clab/scenarios/ecmp-2site/vinbero/vinbero.yml
+++ b/examples/interop-clab/scenarios/ecmp-2site/vinbero/vinbero.yml
@@ -1,0 +1,77 @@
+internal:
+  # eth1 faces the core (SRv6 underlay): End.DT4 decap of return traffic.
+  # eth2 faces ce-tokyo: H.Encaps of plaintext customer traffic, resolved
+  # per flow through the ECMP group the two FRR paths aggregate into.
+  devices:
+    - eth1
+    - eth2
+  bpf:
+    # generic mode: veth links in containerlab do not support native XDP.
+    device_mode: "generic"
+    verifier_log_level: 2
+    verifier_log_size: 1073741823
+  server:
+    bind: "0.0.0.0:8080"
+  logger:
+    level: info
+    format: text
+    no_color: true
+    add_caller: false
+
+settings:
+  enable_stats: false
+  fdb_aging_seconds: 300
+  entries:
+    sid_function:
+      capacity: 1024
+    headendv4:
+      capacity: 1024
+    headendv6:
+      capacity: 1024
+    headend_l2:
+      capacity: 1024
+    fdb:
+      capacity: 8192
+    bd_peer:
+      capacity: 1024
+
+# In-process BGP speaker (vinberod runs with --bgp-enabled). One provider
+# AS 65100; Vinbero peers iBGP with BOTH FRR PEs over loopbacks, multihop
+# past the core. Each FRR PE advertises the same customer prefix under
+# its own RD, and the receive-side aggregation folds the two paths into
+# one ECMP group.
+bgp:
+  global:
+    local_asn: 65100
+    router_id: "10.255.0.1"
+    listen_port: 179
+    source_locator: "LOC1"
+    # Our loopback: the next hop of advertised routes AND the source the
+    # prober's echo probes originate from (replies must come back to an
+    # address the kernel owns and delivers locally).
+    next_hop: "2001:db8:ff::1"
+  peers:
+    - neighbor: "2001:db8:ff::2"
+      peer_asn: 65100
+      hold_time_sec: 30
+      keepalive_sec: 10
+      families:
+        - vpnv4
+        - vpnv6
+    - neighbor: "2001:db8:ff::3"
+      peer_asn: 65100
+      hold_time_sec: 30
+      keepalive_sec: 10
+      families:
+        - vpnv4
+        - vpnv6
+
+# The liveness prober: each ECMP group member is probed over its actual
+# SRv6 path towards the advertising PE's loopback. Three lost probes at
+# 100ms mask the path in ecmp_live_map -- the failover test cuts one FRR
+# PE's underlay and expects traffic to converge on this signal, not on
+# BGP (hold time 30s here, exactly to prove the point).
+prober:
+  enable: true
+  interval_ms: 100
+  multiplier: 3


### PR DESCRIPTION
## 概要

ECMP シリーズの interop シナリオ (plan の PR8) です。#128 (prober) の上に stack しています。遠端サイトを 2 台の独立した FRR PE に dual-home し、同一 prefix の 2 広告を Vinbero が 1 つの ECMP group に集約すること、flow が両 PE に分散すること、そして prober による fast reroute を実ラボで検証します。

## 構成

- pe-tokyo (Vinbero) が pe-osaka-a / pe-osaka-b (FRR 10.2.1) と loopback 間 iBGP。両 FRR PE は共有 L2 セグメント上の同じ 10.2.0.0/24 を各自の RD と locator で export します
- 障害注入は core の経路削除で行います。admin link down は veth 両端の IPv6 address を flush してしまい、path 障害の意味を超えてラボを壊すためです
- iBGP hold time は 30 秒のままにしてあり、収束が prober のマスク (約 300ms) によることを構成として保証します

## test.sh の assert (13 項目)

1. 両 iBGP session Established
2. 10.2.0.0/24 が member 2 本の 1 group に集約され、member SID が両 locator に跨る
3. prober が両 PE loopback を probe して up
4. 12 個の異なる inner source からの ping が全部通り、両 PE の uplink byte counter で実分散を確認
5. core の経路削除後、prober がマスクし、全 flow が生存 PE 経由で継続
6. 経路復旧後、path が復帰して分散が戻る

## 検証と副産物

- ローカルの containerlab で fresh deploy から 13/13 PASS を確認済み (2 回連続)
- ハマりどころ 2 件を潰しています。(1) l3vpn-2site 由来の connected locator hack は FRR 10.2.1 では不要で、かつ有害でした。connected が static に勝って SID が on-link 解決になり、誰も NDP に答えず全返送が blackhole します (`ip -6 neigh` に FAILED が残る)。static だけで SID validation は通ります。(2) End.DT4 の返送は BPF FIB lookup なので、各 inner source の ARP を kernel 経由で温めてから burst しています
- CI の interop matrix に登録済みです