### PR TITLE
feat(prober): SR Policy transport を probe の journey に反映する

### DIFF
--- a/docs/design/ja/ecmp.md
+++ b/docs/design/ja/ecmp.md
@@ -181,7 +181,11 @@ applier は group を書き込むたびに `Register(groupID, targets)` で memb
 
 設定は `prober: {enable, interval_ms, multiplier}` で、BGP applier と encap source が前提です。状態は `ProberService` / `vbctl prober status` で per-path の up/down、miss streak、RTT を見られます。
 
-steered path (SR Policy 合成) の probe は transport 部分のみで、policy が prepend する経路は検証しません。policy 経路の liveness は後続です。
+steered path (SR Policy 合成) の probe は、member が参照する policy の installed transport を journey の先頭に埋め込みます。XDP が service SID の前に prepend するのと同じ waypoint 列を probe も辿るので、waypoint の End が死ぬと、PE 自体への疎通が生きていても path が down になります。policy の transport が入れ替わったとき (candidate の交代、withdraw、local CRUD) は `srPolicyTable` の transport-change hook が該当 group の probe target を再登録します。data plane のエントリは policy を id で参照するので書き換え不要ですが、probe の登録は transport そのものを含むため、放置すると traffic が通らない旧経路を probe し続けるからです。
+
+transport 自身の終端 segment は journey に含めません。SR Policy の最終 segment は endpoint に着地する segment で、Linux endpoint の End はループ防止として自ノードが所有する address への転送を拒否します (post-End の経路 lookup が local route を除外し、packet は discard dst に落ちます。実 traffic は End の後に service SID という route へ進むので踏みません)。終端 End を journey に残すと、その次 hop が同一ノードの loopback (Dst) になる probe が恒久的に drop され、健全な path を false-down させます。Dst で journey を終えれば同じノードに同じ生死の質問を届けられます。代償として、endpoint 以外のノードに置かれた終端 transport segment は probe の対象外になります。
+
+interop 検証は sr-policy-2site の failure-injection (waypoint End SID の削除で down、復元で up) が担います。
 
 probe の宛先は PE の loopback であり、service SID (locator 配下) そのものではありません。L3VPN と EVPN の member entry は service SID 1 個なので、probe は素の echo に縮退します。したがって underlay で loopback への経路は生きているのに locator prefix への経路だけが失われる障害は検出できません。この shared-fate 前提 (loopback と locator は同じ underlay 経路を辿る) は一般的な PE 設計では成り立ちますが、意図的に分けている網では prober の保証が弱まります。locator 配下の routable address を probe する拡張は後続です。
 

--- a/examples/interop-clab/scenarios/sr-policy-2site/README.ja.md
+++ b/examples/interop-clab/scenarios/sr-policy-2site/README.ja.md
@@ -51,8 +51,9 @@ make all SCENARIO=sr-policy-2site     # build + deploy + test + destroy
 4. color 経路が policy に解決します。FRR の `10.2.0.0/24`（color 100）が Vinbero の `headend_v4` map に入り、SR Policy に active candidate が付きます。
 5. steered チェインのデータ面を確認します。`ce-tokyo → ce-osaka` の ping が通り、tokyo→core では outer DA が core の End `fd00:300:0:ee::1`、core→osaka では FRR の End `fd00:200:0:ee::1` に書き換わります。outer DA がホップごとに変わることが、セグメントを 1 つずつ辿るサービスチェインの証明になります。
 6. negative を確認します。color を持たず policy にマッチしない逆方向（`ce-osaka → ce-tokyo`）も通常の L3VPN として転送されます。color steering が無 color トラフィックを壊しません。
+7. prober の probe が steered チェインを辿ることを確認します。SRv6 self-probe は policy の非終端 transport（core End）を埋め込んでから FRR の loopback に到達するので、core の waypoint End SID を消すと、PE 自体への疎通は完全に生きているのに数 probe 間隔で path が down になります。SID を戻すと path と steered データ面が復旧します。PE へ直行する probe ではこの故障は観測できません。transport の終端 segment（FRR 自身の End）は probe に含めません。endpoint ノードに着地する segment であり、Linux の End は自ノードが所有する address への転送を拒否するため、そこを通り抜けて loopback へ届く probe は成立しないからです。
 
-pass すると `RESULT: 9 passed, 0 failed` が出ます。
+pass すると `RESULT: 13 passed, 0 failed` が出ます。
 
 ## 注記
 

--- a/examples/interop-clab/scenarios/sr-policy-2site/README.md
+++ b/examples/interop-clab/scenarios/sr-policy-2site/README.md
@@ -93,8 +93,18 @@ state. Shared images live in `../../images/`.
 6. Negative — the return direction (`ce-osaka → ce-tokyo`), which carries no
    color and matches no policy, still forwards as a plain L3VPN: color
    steering must not break un-colored traffic.
+7. The prober rides the steered chain — the SRv6 self-probe embeds the
+   policy's non-terminal transport (`core End`) before terminating at FRR's
+   loopback, so removing the core waypoint's End SID flips the path down
+   within a few probe intervals even though the PE itself stays perfectly
+   reachable; restoring the SID brings the path (and the steered data
+   plane) back. A probe that went straight to the PE could never see this
+   failure. The transport's terminal segment (FRR's own End) is excluded
+   from the probe: it lands on the endpoint node, and a Linux End refuses
+   to forward to an address the node itself owns, so probing "through" it
+   to the loopback could never succeed.
 
-A pass prints `RESULT: 9 passed, 0 failed`.
+A pass prints `RESULT: 13 passed, 0 failed`.
 
 ## Notes
 

--- a/examples/interop-clab/scenarios/sr-policy-2site/core/start.sh
+++ b/examples/interop-clab/scenarios/sr-policy-2site/core/start.sh
@@ -27,6 +27,12 @@ ip link set eth2 up
 ip -6 addr add 2001:db8:2::2/64 dev eth2 2>/dev/null || true
 
 # --- IPv6 forwarding + SRv6 dataplane --------------------------------------
+# A router must not learn routes from neighbors' RAs: an RA-carried
+# on-link prefix (FRR advertises its connected prefixes) would install a
+# kernel route that outranks the static underlay routes below.
+sysctl -w net.ipv6.conf.all.accept_ra=0 >/dev/null 2>&1 || true
+sysctl -w net.ipv6.conf.eth1.accept_ra=0 >/dev/null 2>&1 || true
+sysctl -w net.ipv6.conf.eth2.accept_ra=0 >/dev/null 2>&1 || true
 sysctl -w net.ipv6.conf.all.forwarding=1 >/dev/null 2>&1 || true
 sysctl -w net.ipv6.conf.eth1.forwarding=1 >/dev/null 2>&1 || true
 sysctl -w net.ipv6.conf.eth2.forwarding=1 >/dev/null 2>&1 || true

--- a/examples/interop-clab/scenarios/sr-policy-2site/frr/start.sh
+++ b/examples/interop-clab/scenarios/sr-policy-2site/frr/start.sh
@@ -42,12 +42,13 @@ ip link set eth1 up
 # --- underlay link towards the core ----------------------------------------
 ip link set eth2 up 2>/dev/null || true
 
-# Vinbero's locator block as a *connected* prefix on eth2, added before
-# FRR starts so it is already present when the first VPN route arrives.
-# FRR's SRv6 nexthop validation rejects a service SID reachable only via
-# a gateway ("Must be Connected"); without this the 10.1.0.0/24 route
-# Vinbero advertises stays `invalid` and never installs into vrf-cust.
-ip -6 addr add fd00:100::ffff/48 dev eth2 nodad 2>/dev/null || true
+# Vinbero's locator block is deliberately NOT configured as a connected
+# prefix here. FRR 10.2.1 validates the service SID against the static
+# fd00:100::/48 route in frr.conf just fine, and a connected /48 is
+# actively harmful: it makes the whole locator on-link for FRR (the SID
+# gets NDPed on eth2 instead of routed) and leaks into FRR's router
+# advertisements as an on-link prefix, teaching the core a poisonous
+# fd00:100::/48-on-eth2 route that beats its static toward pe-tokyo.
 
 # FRR ships an entrypoint that starts the daemons selected in
 # /etc/frr/daemons. watchfrr then keeps them alive.
@@ -63,12 +64,8 @@ vtysh -b || true
 # static glue the data plane needs.
 sleep 4
 
-# More-specific forwarding route for Vinbero's End.DT4 SID. The
-# connected /48 above would otherwise make FRR treat the SID as on-link
-# and NDP for it on eth2; this /128 sends the encapsulated return
-# traffic to the core (2001:db8:2::2), which routes it on to pe-tokyo.
-# fd00:100:0:1:: == the SID Vinbero advertises with 10.1.0.0/24.
-ip -6 route replace fd00:100:0:1::/128 via 2001:db8:2::2 dev eth2
+# The encapsulated return traffic follows the static fd00:100::/48 route
+# from frr.conf via the core; no per-SID /128 override is needed.
 
 # FRR auto-installs its End.DT4 localsid at the transposed full SID
 # (fd00:200:0:0:1::). Vinbero applies RFC 9252 §4 transposition when it

--- a/examples/interop-clab/scenarios/sr-policy-2site/test.sh
+++ b/examples/interop-clab/scenarios/sr-policy-2site/test.sh
@@ -257,10 +257,19 @@ fi
 # the PE loopbacks stay reachable; only the segment chain is broken.
 dexec "$CORE" ip -6 route del "$CORE_SID/128" >/dev/null 2>&1 || true
 if retry_n 10 steered_path_state down; then
-    ok "prober detects the dead waypoint (path down; PE itself still reachable)"
+    ok "prober detects the dead waypoint (path down)"
 else
     ng "prober kept the path up with the waypoint End SID removed"
     prober_json || true
+fi
+# The claim is transport-awareness, so prove the PE itself is STILL
+# reachable while the path is down: a full underlay outage would flip the
+# path down too, but then this plain loopback-to-loopback ping (which does
+# not ride the segment chain) would fail with it.
+if retry_n 5 gate_underlay; then
+    ok "PE loopback stays reachable during the outage (only the chain is dead)"
+else
+    ng "PE loopback unreachable during the outage; the down state proves nothing"
 fi
 
 # Restore the waypoint and the path must come back.

--- a/examples/interop-clab/scenarios/sr-policy-2site/test.sh
+++ b/examples/interop-clab/scenarios/sr-policy-2site/test.sh
@@ -15,7 +15,10 @@
 #      (core End fd00:300:0:ee::1 -> FRR End fd00:200:0:ee::1 -> End.DT4
 #      service SID), proven by the outer DA changing per hop on the wire;
 #   5. negative: the return direction (ce-osaka -> ce-tokyo), which carries
-#      no color and matches no policy, still forwards as a plain L3VPN.
+#      no color and matches no policy, still forwards as a plain L3VPN;
+#   6. the prober's probe rides the policy's transport chain: removing the
+#      core waypoint's End SID flips the path down (while the PE itself
+#      stays reachable), and restoring it brings the path back up.
 #
 # The data plane settles asynchronously, so every ping is gated on its
 # preconditions and retried generously -- a slow settle cannot flake it.
@@ -212,6 +215,66 @@ if retry_n 45 ce_osaka_to_tokyo; then
 else
     ng "ce-osaka -> ce-tokyo ping failed"
     dexec "$CE_OSAKA" ping -c 3 -W 2 "$CE_TOKYO_ADDR" 2>&1 | sed 's/^/      /' || true
+fi
+
+# --- 6. prober walks the policy transport chain ----------------------------
+echo ""
+echo "[6] prober probes THROUGH the steered transport chain"
+# The probe embeds the policy's non-terminal transport (core's End) ahead
+# of its terminal destination (FRR's loopback), mirroring the waypoints the
+# XDP program composes for steered traffic. The transport's own terminal
+# segment (FRR's End) is excluded: it lands on the endpoint node, whose
+# Linux End refuses to forward to its own loopback, so keeping it would
+# fail a healthy path forever. This is what makes a dead waypoint visible:
+# plain PE-to-PE reachability stays perfect when core's End SID goes away,
+# so a probe that went straight to the PE would keep reporting up while the
+# steered traffic blackholes.
+prober_json() {
+    dexec "$PE_TOKYO" vbctl --json prober status 2>/dev/null
+}
+steered_path_state() {
+    # $1 = "up" or "down": the state the FRR-loopback path must be in.
+    prober_json | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+if not d.get('enabled'):
+    sys.exit(1)
+paths = [p for p in d.get('paths') or [] if p.get('dst') == '$FRR_LOOPBACK']
+if len(paths) != 1:
+    sys.exit(1)
+# A false 'up' is omitted from the JSON entirely (proto3 zero-value), so
+# fold the absent key and false together before comparing.
+sys.exit(0 if bool(paths[0].get('up')) == ('$1' == 'up') else 1)"
+}
+if retry steered_path_state up; then
+    ok "prober reports the steered path up (probe rides the transport chain)"
+else
+    ng "prober does not report an up path toward $FRR_LOOPBACK"
+    prober_json || true
+fi
+
+# Failure injection: remove the core waypoint's End SID. The underlay and
+# the PE loopbacks stay reachable; only the segment chain is broken.
+dexec "$CORE" ip -6 route del "$CORE_SID/128" >/dev/null 2>&1 || true
+if retry_n 10 steered_path_state down; then
+    ok "prober detects the dead waypoint (path down; PE itself still reachable)"
+else
+    ng "prober kept the path up with the waypoint End SID removed"
+    prober_json || true
+fi
+
+# Restore the waypoint and the path must come back.
+dexec "$CORE" ip -6 route replace "$CORE_SID/128" encap seg6local action End dev eth2 >/dev/null 2>&1 || true
+if retry_n 10 steered_path_state up; then
+    ok "prober recovers the path after the waypoint returns"
+else
+    ng "path did not recover after restoring the waypoint End SID"
+    prober_json || true
+fi
+if retry_n 15 ce_tokyo_to_osaka; then
+    ok "steered data plane works again after recovery"
+else
+    ng "steered data plane broken after recovery"
 fi
 
 echo ""

--- a/examples/interop-clab/scenarios/sr-policy-2site/vinbero/vinbero.yml
+++ b/examples/interop-clab/scenarios/sr-policy-2site/vinbero/vinbero.yml
@@ -47,6 +47,16 @@ settings:
 # the core router (which is NOT in BGP). iBGP imposes no TTL=1 limit, so
 # the loopback-to-loopback session crosses the core cleanly. The loopback
 # nexthop is reachable via the static underlay routes from start.sh.
+# Liveness prober: each ECMP path member is probed with an SRv6 self-probe
+# that embeds the SR Policy's transport chain (core End -> FRR End) before
+# terminating at the advertising PE's loopback. Killing a waypoint End SID
+# is therefore detected here even while plain PE-to-PE reachability is fine
+# -- the property the test's failure-injection step asserts.
+prober:
+  enable: true
+  interval_ms: 100
+  multiplier: 3
+
 bgp:
   global:
     local_asn: 65100
@@ -57,6 +67,11 @@ bgp:
     # FRR. Registered over RPC by start.sh before the session settles
     # (the applier needs it present to materialise headend entries).
     source_locator: "LOC1"
+    # The prober's probe source. It must be an address the kernel owns
+    # and delivers locally (the echo reply returns as plain IPv6), so the
+    # loopback is used; the locator base is registered over RPC only
+    # after boot and is not a kernel-owned address anyway.
+    next_hop: "2001:db8:ff::1"
   peers:
     # pe-osaka's loopback. Multihop iBGP session via the IPv6 core.
     - neighbor: "2001:db8:ff::2"

--- a/pkg/bgp/apply/applier.go
+++ b/pkg/bgp/apply/applier.go
@@ -82,8 +82,13 @@ type Applier struct {
 	// (default: no-op). Swapped in via SetProber before the session starts.
 	prober prober.Registry
 	// vpnGroups aggregates the paths learned for each VPN prefix into one
-	// ECMP group. Touched only from the route-handler goroutine and from
-	// NewApplier's startup reset, which runs before any route arrives.
+	// ECMP group, guarded by vpnMu: the GoBGP RouteHandler goroutine applies
+	// routes (applyVPN), and an SR Policy transport change re-registers the
+	// affected groups' probe targets (reprobeSRPolicy) -- which the
+	// SRPolicyService CRUD handlers can trigger from an RPC goroutine. Same
+	// pattern as mupMu / evpnMu. NewApplier's startup reset runs before any
+	// of that and needs no lock.
+	vpnMu     sync.Mutex
 	vpnGroups *vpnGroupTable
 	// mupDefaultAllow forces every MUP session route through the historical
 	// default-allow path even when some VRF binding has declared a mup_ipv*
@@ -143,6 +148,9 @@ func NewApplier(dp dataPlane, locators *locator.Manager, vrfBindings *vrfbgp.Man
 		mupGateRefs: make(map[string]int),
 		logger:      logger.Named("bgp.apply"),
 	}
+	// A policy's installed transport changing invalidates the probe journeys
+	// registered for the groups steered onto it; the hook re-registers them.
+	a.srPolicy.onTransportChange = a.reprobeSRPolicy
 	// Runs before the BGP session starts, so it cannot race a route event.
 	// The EVPN sweep goes first: it clears the high-partition group ids so
 	// the VPN table's high-water seed below is not inflated by them.
@@ -218,6 +226,8 @@ func (a *Applier) ApplyLocalSRPolicyCapped(p bgp.SRPolicy, max uint32) error {
 }
 
 func (a *Applier) applyVPN(vr *bgp.VPNRoute, src bgp.PathSource, withdraw bool) {
+	a.vpnMu.Lock()
+	defer a.vpnMu.Unlock()
 	dk := vpnDestKey{family: vr.Family, prefix: vr.Prefix}
 	pk := vpnPathKey{rd: vr.RD, source: src}
 	if withdraw {

--- a/pkg/bgp/apply/evpn_alias.go
+++ b/pkg/bgp/apply/evpn_alias.go
@@ -578,7 +578,7 @@ func (a *Applier) reconcileESKey(dk esDestKey) {
 	for i, m := range members {
 		dsts[i] = m.pe
 	}
-	a.prober.Register(d.groupID, probeTargets(paths, dsts))
+	a.prober.Register(d.groupID, a.probeTargets(paths, dsts))
 
 	// The ES peer mirrors the first member so the group-unresolvable
 	// fallback forwards the way the first path would (same shape as the VPN

--- a/pkg/bgp/apply/probe.go
+++ b/pkg/bgp/apply/probe.go
@@ -2,6 +2,7 @@ package apply
 
 import (
 	"net/netip"
+	"slices"
 
 	"github.com/takehaya/vinbero/pkg/bpf"
 	"github.com/takehaya/vinbero/pkg/prober"
@@ -82,9 +83,13 @@ func (a *Applier) reprobeSRPolicy(key policyKey) {
 	a.vpnMu.Lock()
 	defer a.vpnMu.Unlock()
 	for dk, d := range a.vpnGroups.dests {
-		if d.installed == nil {
-			// Never programmed (or the last write failed): there is no
-			// registration to refresh and reconcile owns the retry.
+		if !d.probed {
+			// No live registration to refresh: the group was never
+			// programmed, or its last write failed and reconcile already
+			// dropped the registration to keep the mixed-generation group
+			// fail-open. Re-registering here from the desired member set
+			// would impose a bitmap whose bit positions do not match the
+			// data plane; reconcile owns the retry.
 			continue
 		}
 		ms := d.members()
@@ -96,6 +101,17 @@ func (a *Applier) reprobeSRPolicy(key policyKey) {
 			}
 		}
 		if !steered {
+			continue
+		}
+		if !slices.Equal(memberFingerprint(ms), d.installed) {
+			// The desired members have drifted from what the data plane
+			// holds (a reconcile retry is owed, e.g. an earlier reconcile
+			// bailed before writing). The standing registration matches the
+			// installed layout but its journey now embeds a dead transport,
+			// and the installed member set can no longer be rebuilt from
+			// state -- fail open rather than probe either wrong shape.
+			a.prober.Unregister(d.groupID)
+			d.probed = false
 			continue
 		}
 		paths := make([]bpf.EcmpPath, 0, len(ms))
@@ -117,6 +133,7 @@ func (a *Applier) reprobeSRPolicy(key policyKey) {
 			// A registration that cannot be refreshed describes the old
 			// journey; failing open beats failing a healthy member on it.
 			a.prober.Unregister(d.groupID)
+			d.probed = false
 			continue
 		}
 		dsts := make([]string, len(ms))

--- a/pkg/bgp/apply/probe.go
+++ b/pkg/bgp/apply/probe.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/takehaya/vinbero/pkg/bpf"
 	"github.com/takehaya/vinbero/pkg/prober"
+	"go.uber.org/zap"
 )
 
 // SetProber hands the applier the liveness prober to keep in sync with the
@@ -18,14 +19,17 @@ func (a *Applier) SetProber(p prober.Registry) {
 //
 // The probe traverses the member's transport segments and terminates at
 // dsts[i] -- the advertising PE's routable address (its BGP next hop), the
-// liveness question the group actually asks. The member's terminal segment
-// is the remote service SID and is deliberately not part of the probe
-// journey: a service SID is not an End behavior, and per RFC 8986 its
-// endpoint drops SRH-carrying packets with segments left, so probing
-// "through" it could never succeed. A member whose next hop is unknown or
-// unparseable yields a target with no destination, which the prober pins
-// permanently up rather than failing it on probes that cannot be sent.
-func probeTargets(paths []bpf.EcmpPath, dsts []string) []prober.Target {
+// liveness question the group actually asks. A member steered onto an SR
+// Policy prepends the policy's installed transport, mirroring what the XDP
+// program composes ahead of the service SID, so the probe walks the same
+// waypoints the traffic does. The member's terminal segment is the remote
+// service SID and is deliberately not part of the probe journey: a service
+// SID is not an End behavior, and per RFC 8986 its endpoint drops
+// SRH-carrying packets with segments left, so probing "through" it could
+// never succeed. A member whose next hop is unknown or unparseable yields a
+// target with no destination, which the prober pins permanently up rather
+// than failing it on probes that cannot be sent.
+func (a *Applier) probeTargets(paths []bpf.EcmpPath, dsts []string) []prober.Target {
 	out := make([]prober.Target, 0, len(paths))
 	for i, p := range paths {
 		t := prober.Target{PathIndex: uint8(i)}
@@ -37,6 +41,25 @@ func probeTargets(paths []bpf.EcmpPath, dsts []string) []prober.Target {
 				t.Dst = addr
 			}
 		}
+		// An id whose policy is not (yet) installed contributes nothing: the
+		// XDP lookup-miss falls the member back to its bare service SID, and
+		// the probe matches that by going straight to the PE.
+		//
+		// The transport's own terminal segment is dropped too, for a reason
+		// specific to the probe's shape: an SR Policy's last segment lands on
+		// the policy endpoint, and a Linux endpoint's End behavior refuses to
+		// forward to an address the node itself owns (the post-End lookup
+		// excludes local routes as an anti-loop measure and the packet hits a
+		// discard dst). Traffic never notices -- after that End it proceeds
+		// to the service SID, a route, not a local address -- but a probe
+		// whose next hop after the terminal End is the same node's loopback
+		// would be dropped there forever, permanently failing a healthy
+		// path. Ending the journey at Dst instead asks the same node the
+		// same liveness question. The cost is real but bounded: a terminal
+		// transport segment on a node other than the endpoint goes unprobed.
+		if tr := a.srPolicy.transportOf(p.Entry.PolicyId); len(tr) > 1 {
+			t.Segments = append(t.Segments, tr[:len(tr)-1]...)
+		}
 		n := int(p.Entry.NumSegments)
 		for s := 0; s < n-1; s++ {
 			t.Segments = append(t.Segments, netip.AddrFrom16(p.Entry.Segments[s]))
@@ -44,6 +67,64 @@ func probeTargets(paths []bpf.EcmpPath, dsts []string) []prober.Target {
 		out = append(out, t)
 	}
 	return out
+}
+
+// reprobeSRPolicy re-registers the probe targets of every VPN group with a
+// member steered onto key, after that policy's installed transport changed.
+// The groups' data-plane entries need no rewrite -- they reference the policy
+// by its stable id -- but a probe registration embeds the transport itself,
+// so leaving the old one standing would probe a journey the traffic no
+// longer takes: it could fail a member that forwards fine, or keep reporting
+// a dead transport as up. Invoked from the srPolicyTable's transport-change
+// hook, on whichever goroutine changed the policy (the BGP route handler or
+// an SRPolicyService RPC).
+func (a *Applier) reprobeSRPolicy(key policyKey) {
+	a.vpnMu.Lock()
+	defer a.vpnMu.Unlock()
+	for dk, d := range a.vpnGroups.dests {
+		if d.installed == nil {
+			// Never programmed (or the last write failed): there is no
+			// registration to refresh and reconcile owns the retry.
+			continue
+		}
+		ms := d.members()
+		steered := false
+		for _, m := range ms {
+			if m.steer != nil && *m.steer == key {
+				steered = true
+				break
+			}
+		}
+		if !steered {
+			continue
+		}
+		paths := make([]bpf.EcmpPath, 0, len(ms))
+		rebuilt := true
+		for _, m := range ms {
+			entry, err := a.buildHeadendEntry(m.sid)
+			if err != nil {
+				a.logger.Error("rebuild probe targets after SR Policy transport change",
+					zap.String("prefix", dk.prefix), zap.String("sid", m.sid), zap.Error(err))
+				rebuilt = false
+				break
+			}
+			if m.steer != nil {
+				entry.PolicyId = a.srPolicy.idOf(m.steer.color, m.steer.endpoint)
+			}
+			paths = append(paths, bpf.EcmpPath{Entry: entry, Weight: 1})
+		}
+		if !rebuilt {
+			// A registration that cannot be refreshed describes the old
+			// journey; failing open beats failing a healthy member on it.
+			a.prober.Unregister(d.groupID)
+			continue
+		}
+		dsts := make([]string, len(ms))
+		for i, m := range ms {
+			dsts[i] = m.nh
+		}
+		a.prober.Register(d.groupID, a.probeTargets(paths, dsts))
+	}
 }
 
 // EncapSourceAddr resolves the SRv6 encapsulation source as an address, for

--- a/pkg/bgp/apply/probe_test.go
+++ b/pkg/bgp/apply/probe_test.go
@@ -1,6 +1,7 @@
 package apply
 
 import (
+	"errors"
 	"net/netip"
 	"slices"
 	"testing"
@@ -180,6 +181,55 @@ func TestProberWiring_PolicyTransportChangeReprobes(t *testing.T) {
 	}})
 	if got := fp.registered[trigger.GroupId]; len(got) != 1 || len(got[0].Segments) != 0 {
 		t.Fatalf("post-withdraw registration = %+v, want one bare target", got)
+	}
+}
+
+// A group whose last write FAILED is fail-open over mixed-generation slots
+// and its registration was dropped. A later policy transport change must not
+// re-register it from the desired member set: those bit positions do not
+// match the data plane, and re-imposing a bitmap would break fail-open.
+func TestProberWiring_ReprobeSkipsGroupWhoseWriteFailed(t *testing.T) {
+	fh := newFakeHeadend()
+	a := NewApplier(fh, testLocatorManager(t), vrfbgp.NewManager(), &fakeFib{}, "LOC1", 65000, zap.NewNop())
+	fp := newFakeProber()
+	a.SetProber(fp)
+
+	endpoint := netip.MustParseAddr("fd00::2")
+	a.Apply(coloredVPNEvent("10.0.0.0/24", "65000:1", "fd00:1:1:a::", "fd00::2", 100))
+	trigger := fh.v4created["10.0.0.0/24"]
+	if _, ok := fp.registered[trigger.GroupId]; !ok {
+		t.Fatalf("initial registration missing")
+	}
+
+	// A member update whose group write fails: reconcile unregisters and
+	// the group is left fail-open.
+	fh.putEcmpErr = errors.New("boom")
+	a.Apply(coloredVPNEvent("10.0.0.0/24", "65000:2", "fd00:1:1:b::", "fd00::2", 100))
+	if _, ok := fp.registered[trigger.GroupId]; ok {
+		t.Fatalf("failed group write must drop the registration")
+	}
+
+	// The policy arriving now must NOT resurrect a registration for the
+	// broken group.
+	a.Apply(bgp.RouteEvent{SRPolicy: &bgp.SRPolicy{
+		Color: 100, Endpoint: endpoint,
+		Candidates: []bgp.CandidatePath{{
+			Origin: bgp.OriginBGP, Distinguisher: 1,
+			Preference: bgp.SRPolicyDefaultPreference,
+			SegmentList: []netip.Addr{
+				netip.MustParseAddr("fd00:ee::1"), netip.MustParseAddr("fd00:ee::2"),
+			},
+		}},
+	}})
+	if got, ok := fp.registered[trigger.GroupId]; ok {
+		t.Fatalf("policy change re-registered a group whose write failed: %+v", got)
+	}
+
+	// Once a reconcile succeeds again, the registration comes back.
+	fh.putEcmpErr = nil
+	a.Apply(coloredVPNEvent("10.0.0.0/24", "65000:2", "fd00:1:1:b::", "fd00::2", 100))
+	if got := fp.registered[trigger.GroupId]; len(got) != 2 {
+		t.Fatalf("recovered group registration = %+v, want both members", got)
 	}
 }
 

--- a/pkg/bgp/apply/probe_test.go
+++ b/pkg/bgp/apply/probe_test.go
@@ -2,6 +2,7 @@ package apply
 
 import (
 	"net/netip"
+	"slices"
 	"testing"
 
 	"go.uber.org/zap"
@@ -90,6 +91,95 @@ func TestProberWiring_EVPNSegmentRegistersPEs(t *testing.T) {
 	a.Apply(withdrawn(perEVIAD("65000:100:3", "fd00::3", "fd00:3:3:ad::", esi)))
 	if len(fp.registered) != 0 {
 		t.Errorf("registrations survived the dissolve: %v", fp.registered)
+	}
+}
+
+// coloredVPNEvent is a VPNv4 advertisement steered onto {color, nh}.
+func coloredVPNEvent(prefix, rd, sid, nh string, color uint32) bgp.RouteEvent {
+	return bgp.RouteEvent{Family: bgp.FamilyVPNv4, VPN: &bgp.VPNRoute{
+		Family: bgp.FamilyVPNv4, Prefix: prefix, RD: rd,
+		SRv6SID: sid, Color: color, NextHop: nh,
+	}}
+}
+
+func TestProberWiring_SteeredMemberEmbedsPolicyTransport(t *testing.T) {
+	fh := newFakeHeadend()
+	a := NewApplier(fh, testLocatorManager(t), vrfbgp.NewManager(), &fakeFib{}, "LOC1", 65000, zap.NewNop())
+	fp := newFakeProber()
+	a.SetProber(fp)
+
+	endpoint := netip.MustParseAddr("fd00::2")
+	transport := []netip.Addr{
+		netip.MustParseAddr("fd00:ee::1"),
+		netip.MustParseAddr("fd00:ee::2"),
+	}
+	a.ApplyLocalSRPolicy(LocalSRPolicy(100, endpoint, transport, 0), false)
+	a.Apply(coloredVPNEvent("10.0.0.0/24", "65000:1", "fd00:1:1:a::", "fd00::2", 100))
+
+	trigger := fh.v4created["10.0.0.0/24"]
+	targets := fp.registered[trigger.GroupId]
+	if len(targets) != 1 {
+		t.Fatalf("registered %d targets, want 1", len(targets))
+	}
+	// The probe must walk the policy's waypoints -- the same ones the XDP
+	// program prepends -- minus the transport's own terminal segment: that
+	// one lands on the endpoint, whose End would refuse to forward to its
+	// own loopback (the probe's next hop), permanently failing the path.
+	if !slices.Equal(targets[0].Segments, transport[:1]) {
+		t.Errorf("probe segments = %v, want the non-terminal transport %v", targets[0].Segments, transport[:1])
+	}
+	if targets[0].Dst != endpoint {
+		t.Errorf("probe dst = %v, want the PE %v", targets[0].Dst, endpoint)
+	}
+}
+
+func TestProberWiring_PolicyTransportChangeReprobes(t *testing.T) {
+	fh := newFakeHeadend()
+	a := NewApplier(fh, testLocatorManager(t), vrfbgp.NewManager(), &fakeFib{}, "LOC1", 65000, zap.NewNop())
+	fp := newFakeProber()
+	a.SetProber(fp)
+
+	endpoint := netip.MustParseAddr("fd00::2")
+
+	// Route first: the policy is only reserved, so the probe goes straight
+	// to the PE.
+	a.Apply(coloredVPNEvent("10.0.0.0/24", "65000:1", "fd00:1:1:a::", "fd00::2", 100))
+	trigger := fh.v4created["10.0.0.0/24"]
+	if got := fp.registered[trigger.GroupId]; len(got) != 1 || len(got[0].Segments) != 0 {
+		t.Fatalf("pre-policy registration = %+v, want one bare target", got)
+	}
+
+	// The policy arriving over BGP must re-register the group's targets with
+	// the non-terminal transport embedded, without any route event.
+	transport := []netip.Addr{netip.MustParseAddr("fd00:ee::1"), netip.MustParseAddr("fd00:ee::2")}
+	a.Apply(bgp.RouteEvent{SRPolicy: &bgp.SRPolicy{
+		Color: 100, Endpoint: endpoint,
+		Candidates: []bgp.CandidatePath{{
+			Origin: bgp.OriginBGP, Distinguisher: 1,
+			Preference: bgp.SRPolicyDefaultPreference, SegmentList: transport,
+		}},
+	}})
+	if got := fp.registered[trigger.GroupId]; len(got) != 1 || !slices.Equal(got[0].Segments, transport[:1]) {
+		t.Fatalf("post-policy registration = %+v, want transport %v", got, transport[:1])
+	}
+
+	// A local candidate replacing the active path (the RPC goroutine's
+	// entry point) must reprobe too.
+	better := []netip.Addr{netip.MustParseAddr("fd00:ee::9"), netip.MustParseAddr("fd00:ee::a")}
+	a.ApplyLocalSRPolicy(LocalSRPolicy(100, endpoint, better, 300), false)
+	if got := fp.registered[trigger.GroupId]; len(got) != 1 || !slices.Equal(got[0].Segments, better[:1]) {
+		t.Fatalf("post-replace registration = %+v, want transport %v", got, better[:1])
+	}
+
+	// Withdrawing every candidate empties the transport: the data plane
+	// falls back to the bare service SID and the probe must follow it.
+	a.ApplyLocalSRPolicy(LocalSRPolicy(100, endpoint, better, 300), true)
+	a.Apply(bgp.RouteEvent{IsWithdraw: true, SRPolicy: &bgp.SRPolicy{
+		Color: 100, Endpoint: endpoint,
+		Candidates: []bgp.CandidatePath{{Origin: bgp.OriginBGP, Distinguisher: 1}},
+	}})
+	if got := fp.registered[trigger.GroupId]; len(got) != 1 || len(got[0].Segments) != 0 {
+		t.Fatalf("post-withdraw registration = %+v, want one bare target", got)
 	}
 }
 

--- a/pkg/bgp/apply/srpolicy.go
+++ b/pkg/bgp/apply/srpolicy.go
@@ -97,6 +97,12 @@ type srPolicyTable struct {
 	freeIDs []uint32 // ids freed by gc, handed out before nextID grows
 	byKey   map[policyKey]*policyState
 	logger  *zap.Logger
+	// onTransportChange, when set, is invoked -- outside the table lock --
+	// after a reconcile changes the transport installed for a key. Steered
+	// data-plane entries reference the policy by id and need no rewrite, but
+	// the liveness prober's registrations embed the transport itself, so the
+	// applier uses this hook to re-register the affected groups.
+	onTransportChange func(policyKey)
 }
 
 func newSRPolicyTable(mapOps policyMapOps, logger *zap.Logger) *srPolicyTable {
@@ -185,19 +191,23 @@ func (t *srPolicyTable) idOf(color uint32, endpoint netip.Addr) uint32 {
 // reconciles the data plane. The same path serves BGP reception and local
 // CRUD; withdraw removes the candidate.
 func (t *srPolicyTable) apply(p bgp.SRPolicy, withdraw bool) {
+	key := policyKey{color: p.Color, endpoint: p.Endpoint}
 	t.mu.Lock()
-	defer t.mu.Unlock()
-	t.applyLocked(p, withdraw)
+	changed := t.applyLocked(p, withdraw)
+	t.mu.Unlock()
+	t.notifyTransportChange(changed, key)
 }
 
 // applyLocked is apply with t.mu already held, so a caller that must decide and
 // mutate atomically (applyLocalCapped) can do so under one lock acquisition.
-func (t *srPolicyTable) applyLocked(p bgp.SRPolicy, withdraw bool) {
+// It reports whether the installed transport changed; the caller owes a
+// notifyTransportChange AFTER releasing t.mu (the hook re-enters the table).
+func (t *srPolicyTable) applyLocked(p bgp.SRPolicy, withdraw bool) bool {
 	key := policyKey{color: p.Color, endpoint: p.Endpoint}
 	st := t.byKey[key]
 	if st == nil {
 		if withdraw {
-			return // nothing to remove
+			return false // nothing to remove
 		}
 		st = t.ensureState(key)
 	}
@@ -209,11 +219,21 @@ func (t *srPolicyTable) applyLocked(p bgp.SRPolicy, withdraw bool) {
 			st.candidates[cid] = cp
 		}
 	}
-	t.reconcile(key, st)
+	changed := t.reconcile(key, st)
 	if withdraw {
 		// Reap the policy if that removed its last candidate and no route
 		// references it; reconcile has already dropped the map entry.
 		t.gc(key, st)
+	}
+	return changed
+}
+
+// notifyTransportChange fires the transport-change hook. Must be called
+// without t.mu held: the hook rebuilds probe registrations, which reads the
+// table back (idOf / transportOf).
+func (t *srPolicyTable) notifyTransportChange(changed bool, key policyKey) {
+	if changed && t.onTransportChange != nil {
+		t.onTransportChange(key)
 	}
 }
 
@@ -227,7 +247,6 @@ var ErrSRPolicyLimitReached = errors.New("local SR Policy limit reached")
 // cannot both pass an under-cap check and exceed the limit.
 func (t *srPolicyTable) applyLocalCapped(p bgp.SRPolicy, max uint32) error {
 	t.mu.Lock()
-	defer t.mu.Unlock()
 	if max > 0 && !t.hasLocalLocked(p.Color, p.Endpoint) {
 		n := 0
 		for _, st := range t.byKey {
@@ -236,10 +255,13 @@ func (t *srPolicyTable) applyLocalCapped(p bgp.SRPolicy, max uint32) error {
 			}
 		}
 		if uint32(n) >= max {
+			t.mu.Unlock()
 			return ErrSRPolicyLimitReached
 		}
 	}
-	t.applyLocked(p, false)
+	changed := t.applyLocked(p, false)
+	t.mu.Unlock()
+	t.notifyTransportChange(changed, policyKey{color: p.Color, endpoint: p.Endpoint})
 	return nil
 }
 
@@ -308,8 +330,10 @@ func (t *srPolicyTable) gc(key policyKey, st *policyState) {
 }
 
 // reconcile recomputes the active candidate and writes it to the data
-// plane only when the installed transport list changed. Caller holds t.mu.
-func (t *srPolicyTable) reconcile(key policyKey, st *policyState) {
+// plane only when the installed transport list changed, reporting whether it
+// did. Caller holds t.mu and owes a notifyTransportChange after releasing it
+// when the result is true.
+func (t *srPolicyTable) reconcile(key policyKey, st *policyState) bool {
 	best, ok := bestCandidate(st.candidates)
 	if !ok {
 		// No usable candidate: drop the map entry so referencing routes
@@ -318,19 +342,20 @@ func (t *srPolicyTable) reconcile(key policyKey, st *policyState) {
 			if err := t.mapOps.DeleteSRPolicy(st.id); err != nil {
 				t.logger.Error("delete sr_policy_map entry",
 					zap.Uint32("policy_id", st.id), zap.Error(err))
-				return
+				return false
 			}
 			st.installed = nil
+			return true
 		}
-		return
+		return false
 	}
 	if slices.Equal(st.installed, best.SegmentList) {
-		return // active path unchanged; skip a redundant write
+		return false // active path unchanged; skip a redundant write
 	}
 	if err := t.mapOps.UpsertSRPolicy(st.id, best.SegmentList); err != nil {
 		t.logger.Error("upsert sr_policy_map entry",
 			zap.Uint32("policy_id", st.id), zap.Error(err))
-		return
+		return false
 	}
 	// Clone so `installed` does not alias the candidate's slice: the
 	// diff-skip above must compare against a stable snapshot.
@@ -338,6 +363,25 @@ func (t *srPolicyTable) reconcile(key policyKey, st *policyState) {
 	t.logger.Info("SR Policy active path installed",
 		zap.Uint32("color", key.color), zap.Stringer("endpoint", key.endpoint),
 		zap.Uint32("policy_id", st.id), zap.Int("segments", len(best.SegmentList)))
+	return true
+}
+
+// transportOf returns (a copy of) the transport list currently installed for
+// policyID, or nil when the id is unknown or nothing is installed. The prober
+// path uses it to embed a steered member's real forwarding journey into its
+// probe.
+func (t *srPolicyTable) transportOf(policyID uint32) []netip.Addr {
+	if policyID == 0 {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, st := range t.byKey {
+		if st.id == policyID {
+			return slices.Clone(st.installed)
+		}
+	}
+	return nil
 }
 
 // bestCandidate selects the active candidate path (RFC 9256 §2.9 subset).

--- a/pkg/bgp/apply/vpngroup.go
+++ b/pkg/bgp/apply/vpngroup.go
@@ -59,6 +59,14 @@ type vpnDest struct {
 	// installed is the member SID list last written, used to skip
 	// reconciles that would rewrite an unchanged group.
 	installed []string // memberFingerprint of the last write
+	// probed reports whether the prober currently holds a registration
+	// that matches the group's actual data-plane layout. It turns false
+	// when a group write fails (reconcile unregisters and the group is
+	// fail-open over mixed-generation slots) and true again only after a
+	// successful write + Register. reprobeSRPolicy keys on it: a non-nil
+	// `installed` alone only says a write once succeeded, and re-imposing
+	// a bitmap over a group whose last write failed would break fail-open.
+	probed bool
 }
 
 // ecmpOps is the subset of bpf.MapOperations the VPN group path needs.
@@ -335,6 +343,7 @@ func (a *Applier) reconcileVPNGroup(dk vpnDestKey, d *vpnDest) {
 		// bit positions mask the wrong members. Unregister drops the bitmap
 		// and returns the group to fail-open until a retry rebuilds it.
 		a.prober.Unregister(d.groupID)
+		d.probed = false
 		return
 	}
 	// Registered immediately after the group write: PutEcmpGroup resets the
@@ -347,6 +356,7 @@ func (a *Applier) reconcileVPNGroup(dk vpnDestKey, d *vpnDest) {
 		dsts[i] = m.nh
 	}
 	a.prober.Register(d.groupID, a.probeTargets(paths, dsts))
+	d.probed = true
 
 	// The trigger mirrors the first member so the fallback forwards the same
 	// way the group's first path would, steering included.

--- a/pkg/bgp/apply/vpngroup.go
+++ b/pkg/bgp/apply/vpngroup.go
@@ -346,7 +346,7 @@ func (a *Applier) reconcileVPNGroup(dk vpnDestKey, d *vpnDest) {
 	for i, m := range ms {
 		dsts[i] = m.nh
 	}
-	a.prober.Register(d.groupID, probeTargets(paths, dsts))
+	a.prober.Register(d.groupID, a.probeTargets(paths, dsts))
 
 	// The trigger mirrors the first member so the fallback forwards the same
 	// way the group's first path would, steering included.


### PR DESCRIPTION
## 概要

ECMP path group の prober (#128) は steered member でも PE の loopback へ直行する probe を送っており、SR Policy が prepend する waypoint の死を検知できませんでした (#129 完了時の繰越し)。probe の journey に policy の installed transport を埋め込み、XDP が service SID の前に合成するのと同じ waypoint 列を probe も辿るようにします。sr-policy-2site に failure-injection の E2E 検証を追加します。

base は #130 に stack しています。

## 変更点

### probe journey への transport 埋め込み

- `probeTargets` を Applier method 化し、`entry.PolicyId != 0` の member は `srPolicyTable.transportOf` で installed transport を逆引きして journey の先頭に足します
- transport の終端 segment は journey に含めません。SR Policy の最終 segment は endpoint に着地し、Linux endpoint の End は自ノードが所有する address への転送を拒否します (post-End の lookup が local route を除外して discard dst に落ちる。lab で bpftrace により `input_action_end` → `dst_discard` を実測)。終端 End を残すと次 hop が同一ノードの loopback になる probe が恒久 drop され、健全な path を false-down させます。Dst 終端なら同じノードに同じ生死の質問を届けられます。代償は endpoint 以外のノードに置かれた終端 transport segment が probe 対象外になることです (docs に明記)

### transport 変更時の再登録

- `srPolicyTable` に transport-change hook を追加し、candidate の交代 / withdraw / local CRUD で installed transport が変わったら該当 VPN group の probe target を再登録します。data plane は policy を id で参照するため書き換え不要ですが、probe 登録は transport そのものを含むため、放置すると traffic が通らない旧経路を probe し続けます
- hook は RPC goroutine (SrPolicyService) からも走るため、`vpnGroups` を `vpnMu` で保護します (mupMu / evpnMu と同じ流儀)。lock 順は常に vpnMu → srPolicy.mu

### interop (sr-policy-2site 拡張)

- prober を有効化 (interval 100ms / multiplier 3、probe source は `bgp.global.next_hop` = loopback)
- assertion 9 → 13: steered path が up、core の waypoint End SID を削除すると PE 自体への疎通が生きたまま down (PE 直行 probe では原理的に見えない故障)、復元で up、data plane 復旧
- scenario の潜在バグ 2 件を修正
  - FRR の connected locator hack (`fd00:100::ffff/48` on eth2) が FRR の RA に on-link prefix として載り、core が `fd00:100::/48 dev eth2` (metric 256) を学習して static (metric 1024) に勝ち、return path が全損する。RA の到着タイミング依存で CI では通ったり通らなかったりする種の欠陥。hack を撤去して frr.conf の static に一本化し (FRR 10.2.1 は static で SID validation が通る、ecmp-2site で確立済み)、core は router として accept_ra=0 にする
  - prober の probe source が未設定で boot 時に無効化される (`next_hop` を設定)

## テスト

- unit: steered member の journey (非終端 transport + Dst)、policy 到着 / 交代 / withdraw での再登録、-race
- interop: sr-policy-2site をローカル containerlab で 13/13 pass を確認
