### PR TITLE
fix(interop): l3vpn-2site の connected locator hack による RA 毒経路を除去する

### DIFF
--- a/examples/interop-clab/scenarios/l3vpn-2site-auto/core/start.sh
+++ b/examples/interop-clab/scenarios/l3vpn-2site-auto/core/start.sh
@@ -22,6 +22,12 @@ ip link set eth2 up
 ip -6 addr add 2001:db8:2::2/64 dev eth2 2>/dev/null || true
 
 # --- IPv6 forwarding -------------------------------------------------------
+# A router must not learn routes from neighbors' RAs: an RA-carried
+# on-link prefix (FRR advertises its connected prefixes) would install a
+# kernel route that outranks the static underlay routes below.
+sysctl -w net.ipv6.conf.all.accept_ra=0 >/dev/null 2>&1 || true
+sysctl -w net.ipv6.conf.eth1.accept_ra=0 >/dev/null 2>&1 || true
+sysctl -w net.ipv6.conf.eth2.accept_ra=0 >/dev/null 2>&1 || true
 sysctl -w net.ipv6.conf.all.forwarding=1 >/dev/null 2>&1 || true
 sysctl -w net.ipv6.conf.eth1.forwarding=1 >/dev/null 2>&1 || true
 sysctl -w net.ipv6.conf.eth2.forwarding=1 >/dev/null 2>&1 || true

--- a/examples/interop-clab/scenarios/l3vpn-2site-auto/frr/start.sh
+++ b/examples/interop-clab/scenarios/l3vpn-2site-auto/frr/start.sh
@@ -42,12 +42,14 @@ ip link set eth1 up
 # --- underlay link towards the core ----------------------------------------
 ip link set eth2 up 2>/dev/null || true
 
-# Vinbero's locator block as a *connected* prefix on eth2, added before
-# FRR starts so it is already present when the first VPN route arrives.
-# FRR's SRv6 nexthop validation rejects a service SID reachable only via
-# a gateway ("Must be Connected"); without this the 10.1.0.0/24 route
-# Vinbero advertises stays `invalid` and never installs into vrf-cust.
-ip -6 addr add fd00:100::ffff/48 dev eth2 nodad 2>/dev/null || true
+# Vinbero's locator block is deliberately NOT configured as a connected
+# prefix here. FRR 10.2.1 validates the service SID against the static
+# fd00:100::/48 route in frr.conf just fine, and a connected /48 is
+# actively harmful: it makes the whole locator on-link for FRR (the SID
+# gets NDPed on eth2 instead of routed) and leaks into FRR's router
+# advertisements as an on-link prefix, teaching the core a poisonous
+# fd00:100::/48-on-eth2 route that beats its static toward pe-tokyo --
+# a nondeterministic (RA-timing-dependent) blackhole of the return path.
 
 # FRR ships an entrypoint that starts the daemons selected in
 # /etc/frr/daemons. watchfrr then keeps them alive.
@@ -63,15 +65,11 @@ vtysh -b || true
 # static glue the data plane needs.
 sleep 4
 
-# More-specific forwarding route for Vinbero's End.DT4 SID. The
-# connected /48 above would otherwise make FRR treat the SID as on-link
-# and NDP for it on eth2; this /128 sends the encapsulated return
-# traffic to the core (2001:db8:2::2), which routes it on to pe-tokyo.
-# fd00:100:0:10:: == the End.DT4 SID the auto-advertise exporter mints for
-# vrf-cust: LOC1's function_auto_start is 0x10 and End.DT4 is allocated first,
-# so 10.1.0.0/24 is advertised with this SID deterministically (unlike the
-# manual l3vpn-2site scenario, which pins fd00:100:0:1:: via vbctl).
-ip -6 route replace fd00:100:0:10::/128 via 2001:db8:2::2 dev eth2
+# The encapsulated return traffic follows the static fd00:100::/48 route
+# from frr.conf via the core; no per-SID /128 override is needed. (The
+# auto-advertise exporter mints fd00:100:0:10:: as vrf-cust's End.DT4 SID
+# -- LOC1's function_auto_start is 0x10 and End.DT4 is allocated first --
+# and that SID falls inside the /48 like any other.)
 
 # FRR auto-installs its End.DT4 localsid at the transposed full SID
 # (fd00:200:0:0:1::). Vinbero applies RFC 9252 §4 transposition when it

--- a/examples/interop-clab/scenarios/l3vpn-2site/README.ja.md
+++ b/examples/interop-clab/scenarios/l3vpn-2site/README.ja.md
@@ -61,4 +61,4 @@ make all                        # build + deploy + test + destroy
 - **FRR は固定** — `quay.io/frrouting/frr:10.2.1`。SRv6 L3VPN 構文はバージョン依存が大きいので、更新は `frr.conf` のレビューとセットで。
 - **transposition** — FRR は SID の function bits を VPN label に転置するため wire 上の SID は bare locator `fd00:200::`。Vinbero のデコーダ (`pkg/bgp/gobgp/decode.go`) がこれを畳み戻してフル SID `fd00:200:0:1::` を復元する。`test.sh` step 2 がアサートする。
 - XDP は **generic** モードで attach — containerlab の veth は native XDP に非対応。
-- `core/`・`frr/`・`vinbero/` の `start.sh` が残りのセットアップ（VRF 作成順、source locator 登録、loopback ソースの iBGP、FRR の SRv6 nexthop validation 用 connected 経路、`net.vrf.strict_mode`）を担う — 詳細は各スクリプトのインラインコメント参照。
+- `core/`・`frr/`・`vinbero/` の `start.sh` が残りのセットアップ（VRF 作成順、source locator 登録、loopback ソースの iBGP、FRR が SRv6 nexthop validation に使う static 経路、`net.vrf.strict_mode`）を担う — 詳細は各スクリプトのインラインコメント参照。

--- a/examples/interop-clab/scenarios/l3vpn-2site/README.ja.md
+++ b/examples/interop-clab/scenarios/l3vpn-2site/README.ja.md
@@ -61,4 +61,4 @@ make all                        # build + deploy + test + destroy
 - **FRR は固定** — `quay.io/frrouting/frr:10.2.1`。SRv6 L3VPN 構文はバージョン依存が大きいので、更新は `frr.conf` のレビューとセットで。
 - **transposition** — FRR は SID の function bits を VPN label に転置するため wire 上の SID は bare locator `fd00:200::`。Vinbero のデコーダ (`pkg/bgp/gobgp/decode.go`) がこれを畳み戻してフル SID `fd00:200:0:1::` を復元する。`test.sh` step 2 がアサートする。
 - XDP は **generic** モードで attach — containerlab の veth は native XDP に非対応。
-- `core/`・`frr/`・`vinbero/` の `start.sh` が残りのセットアップ（VRF 作成順、source locator 登録、loopback ソースの iBGP、FRR が SRv6 nexthop validation に使う static 経路、`net.vrf.strict_mode`）を担う — 詳細は各スクリプトのインラインコメント参照。
+- `core/`・`frr/`・`vinbero/` の `start.sh` と `frr/frr.conf` が残りのセットアップ（VRF 作成順、source locator 登録、loopback ソースの iBGP、FRR が SRv6 nexthop validation に使う static の `fd00:100::/48` 経路は `frr.conf` 側、`net.vrf.strict_mode`）を担う — 詳細は各ファイルのインラインコメント参照。

--- a/examples/interop-clab/scenarios/l3vpn-2site/README.md
+++ b/examples/interop-clab/scenarios/l3vpn-2site/README.md
@@ -90,8 +90,8 @@ precondition before pinging — a slow settle cannot cause a spurious
   `fd00:200:0:1::`. `test.sh` step 2 asserts this.
 - XDP attaches in **generic** mode — containerlab veth links have no
   native XDP.
-- The `core/`, `frr/` and `vinbero/` `start.sh` scripts carry the
-  remaining setup glue — VRF creation order, source-locator
-  registration, loopback-sourced iBGP, the static route FRR validates
-  the SRv6 service SID against, `net.vrf.strict_mode` — documented in
-  their inline comments.
+- The `core/`, `frr/` and `vinbero/` `start.sh` scripts and `frr/frr.conf`
+  carry the remaining setup glue — VRF creation order, source-locator
+  registration, loopback-sourced iBGP, the static `fd00:100::/48` route
+  (in `frr.conf`) that FRR validates the SRv6 service SID against,
+  `net.vrf.strict_mode` — documented in their inline comments.

--- a/examples/interop-clab/scenarios/l3vpn-2site/README.md
+++ b/examples/interop-clab/scenarios/l3vpn-2site/README.md
@@ -92,6 +92,6 @@ precondition before pinging — a slow settle cannot cause a spurious
   native XDP.
 - The `core/`, `frr/` and `vinbero/` `start.sh` scripts carry the
   remaining setup glue — VRF creation order, source-locator
-  registration, loopback-sourced iBGP, FRR's connected-route requirement
-  for SRv6 nexthop validation, `net.vrf.strict_mode` — documented in
+  registration, loopback-sourced iBGP, the static route FRR validates
+  the SRv6 service SID against, `net.vrf.strict_mode` — documented in
   their inline comments.

--- a/examples/interop-clab/scenarios/l3vpn-2site/core/start.sh
+++ b/examples/interop-clab/scenarios/l3vpn-2site/core/start.sh
@@ -22,6 +22,12 @@ ip link set eth2 up
 ip -6 addr add 2001:db8:2::2/64 dev eth2 2>/dev/null || true
 
 # --- IPv6 forwarding -------------------------------------------------------
+# A router must not learn routes from neighbors' RAs: an RA-carried
+# on-link prefix (FRR advertises its connected prefixes) would install a
+# kernel route that outranks the static underlay routes below.
+sysctl -w net.ipv6.conf.all.accept_ra=0 >/dev/null 2>&1 || true
+sysctl -w net.ipv6.conf.eth1.accept_ra=0 >/dev/null 2>&1 || true
+sysctl -w net.ipv6.conf.eth2.accept_ra=0 >/dev/null 2>&1 || true
 sysctl -w net.ipv6.conf.all.forwarding=1 >/dev/null 2>&1 || true
 sysctl -w net.ipv6.conf.eth1.forwarding=1 >/dev/null 2>&1 || true
 sysctl -w net.ipv6.conf.eth2.forwarding=1 >/dev/null 2>&1 || true

--- a/examples/interop-clab/scenarios/l3vpn-2site/frr/start.sh
+++ b/examples/interop-clab/scenarios/l3vpn-2site/frr/start.sh
@@ -42,12 +42,14 @@ ip link set eth1 up
 # --- underlay link towards the core ----------------------------------------
 ip link set eth2 up 2>/dev/null || true
 
-# Vinbero's locator block as a *connected* prefix on eth2, added before
-# FRR starts so it is already present when the first VPN route arrives.
-# FRR's SRv6 nexthop validation rejects a service SID reachable only via
-# a gateway ("Must be Connected"); without this the 10.1.0.0/24 route
-# Vinbero advertises stays `invalid` and never installs into vrf-cust.
-ip -6 addr add fd00:100::ffff/48 dev eth2 nodad 2>/dev/null || true
+# Vinbero's locator block is deliberately NOT configured as a connected
+# prefix here. FRR 10.2.1 validates the service SID against the static
+# fd00:100::/48 route in frr.conf just fine, and a connected /48 is
+# actively harmful: it makes the whole locator on-link for FRR (the SID
+# gets NDPed on eth2 instead of routed) and leaks into FRR's router
+# advertisements as an on-link prefix, teaching the core a poisonous
+# fd00:100::/48-on-eth2 route that beats its static toward pe-tokyo --
+# a nondeterministic (RA-timing-dependent) blackhole of the return path.
 
 # FRR ships an entrypoint that starts the daemons selected in
 # /etc/frr/daemons. watchfrr then keeps them alive.
@@ -63,12 +65,8 @@ vtysh -b || true
 # static glue the data plane needs.
 sleep 4
 
-# More-specific forwarding route for Vinbero's End.DT4 SID. The
-# connected /48 above would otherwise make FRR treat the SID as on-link
-# and NDP for it on eth2; this /128 sends the encapsulated return
-# traffic to the core (2001:db8:2::2), which routes it on to pe-tokyo.
-# fd00:100:0:1:: == the SID Vinbero advertises with 10.1.0.0/24.
-ip -6 route replace fd00:100:0:1::/128 via 2001:db8:2::2 dev eth2
+# The encapsulated return traffic follows the static fd00:100::/48 route
+# from frr.conf via the core; no per-SID /128 override is needed.
 
 # FRR auto-installs its End.DT4 localsid at the transposed full SID
 # (fd00:200:0:0:1::). Vinbero applies RFC 9252 §4 transposition when it


### PR DESCRIPTION
## 概要

l3vpn-2site / l3vpn-2site-auto に残っていた connected locator hack の潜在バグを直します。#131 の sr-policy-2site 検証中に実測で確定した欠陥で、そちらは修正済み、本 PR は同じ構造を持つ残り 2 シナリオへの適用です。

## 問題

FRR に付与していた `fd00:100::ffff/48` の connected prefix は 2 点で有害です。

- FRR 自身にとって locator 全体が on-link になり、Vinbero の service SID を eth2 で NDP 解決しようとします (従来は start.sh の /128 override で回避)
- connected prefix が FRR の router advertisement に on-link prefix として載り、accept_ra が有効な core が `fd00:100::/48 dev eth2` の kernel route (metric 256) を学習して static (metric 1024) に勝ち、返送方向が全損します

後者は RA の到着タイミングと lifetime に依存するため、CI で通ったり落ちたりする非決定的な欠陥でした。sr-policy-2site での実測: core の `ip -6 route get` が RA 由来の on-link route を返し、FRR からの返送 encap packet に対して core が redirect と NDP (誰も答えない) を出して blackhole。

## 修正

- hack と /128 override を撤去し、frr.conf に既存の static `fd00:100::/48` に一本化します。FRR 10.2.1 は static だけで SRv6 nexthop validation が通ることを ecmp-2site / sr-policy-2site で確立済みです
- core は router として `accept_ra=0` にします

## テスト

l3vpn-2site / l3vpn-2site-auto ともローカル containerlab で 8/8 pass を確認しました。
