### PR TITLE
feat(benchmark): TRex-driven SRv6 dataplane load-test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,6 @@ examples/interop-clab/scenarios/*/clab-*/
 # stray daemon binary from `go build ./cmd/vinberod/` in the repo root
 # (anchored: must not swallow the cmd/vinberod source directory)
 /vinberod
+
+# benchmark run artifacts
+/benchmark/results/

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,102 @@
+# Vinbero SRv6 データプレーン性能試験
+
+TRex ハードウェア負荷試験機から実 100G 負荷をかけ、Vinbero の SRv6 転送性能を測定する harness です。固定負荷スイープで frame size ごとに一定の offered load をかけ、TRex の受信側 port で forwarding rate と loss を測ります。
+
+## トポロジ
+
+```mermaid
+graph LR
+    subgraph TRex host
+        P0[port 0<br/>tx]
+        P1[port 1<br/>rx]
+    end
+    subgraph DUT
+        F0[ingress NIC<br/>Vinbero XDP]
+        F1[egress NIC]
+    end
+    P0 -- 100G --> F0
+    F0 -- XDP_REDIRECT --> F1
+    F1 -- 100G --> P1
+```
+
+TRex port 0 が DUT の ingress NIC へ送信し、Vinbero が処理した packet を egress NIC から TRex port 1 へ返す snake 構成です。port 0 の `opackets` が offered load、port 1 の `ipackets` が forwarded load になり、両者の差が loss です。
+
+## 前提
+
+- DUT で `make build` 済みであること (`out/bin/vinberod`、`out/bin/vinbero`、ecmp シナリオでは `out/bin/vinbero-ecmpdemo` を使います)
+- TRex host に ssh alias (`ocxma-trex`) で鍵認証ログインできること
+- TRex host で stateless daemon が起動していること
+
+  ```bash
+  cd /opt/trex/v3.08 && sudo ./t-rex-64 -i --cfg /etc/trex_cfg.yaml -c 20
+  ```
+
+- DUT 側 NIC の MTU は setup が 3000 に揃えます。ice の driver mode XDP は multi-buffer 非対応の program だと MTU 約 3050 が attach の上限で、9000 では attach が `operation not supported` で失敗します。ingress 最大 1420B + encap でも 1500B 弱なので 3000 で足ります
+- NIC の MAC address と IP 設計は `pipelines/common.sh` と `trex/vinbero_streams.py` の定数で一致させています。機材を変える場合は両方を更新してください
+
+## シナリオ
+
+| scenario | 経路 | ingress frame |
+|---|---|---|
+| `encaps-v4` | T.Encaps v4 headend (XDP) | IPv4/UDP |
+| `ecmp` | ECMP path group 経由の headend (XDP) | IPv4/UDP (encaps-v4 と同一) |
+| `end` | End transit (XDP) | IPv6 + SRH (SL=1) |
+| `end-dt4` | End.DT4 decap + VRF lookup (XDP) | IPv6 + SRH (SL=0) + inner IPv4 |
+| `l2-unicast` | H.Encaps.L2 (XDP) | VLAN tagged L2 frame (unicast) |
+| `bum` | BUM flood (TC clone-to-self) | VLAN tagged L2 frame (broadcast) |
+
+`ecmp` は `encaps-v4` との差分で ECMP hot path (group/live/path map lookup + weighted 選択) のコストを示します。なお ECMP 基盤の導入以降、headend は group なしでも flow hash を毎 packet 計算するため、`encaps-v4` の数字も ECMP 基盤込みの headend の数字です。
+
+`bum` は登録した bd peer 数 N に応じて出力が入力の N 倍に増幅されます。`rx_mpps` は増幅後の値をそのまま報告し、`loss_pct` は `tx_opackets * N` を期待値として計算します。TC 経由は XDP より大幅に遅い想定のため、`PPS` を低め (例 1000000 から) に設定して段階的に上げてください。
+
+## 実行手順
+
+```bash
+cd benchmark/pipelines
+
+# 1. シナリオをセットアップ (NIC 準備 + vinberod 起動 + map entry 投入)
+sudo -v && ./setup_dut.sh encaps-v4
+
+# 2. ベンチ実行 (size sweep x reps、CSV は benchmark/results/ に出力)
+./run_bench.sh encaps-v4
+
+# 3. 集計
+python3 ../analysis/stats.py ../results/encaps-v4_rep*.csv
+
+# 4. 後始末
+./teardown_dut.sh
+```
+
+パラメータは環境変数で調整します。
+
+```bash
+DURATION=30 REPS=5 PPS=50000000 ./run_bench.sh encaps-v4 64 512
+PEERS=4 ./setup_dut.sh bum --peers 4 && PEERS=4 PPS=5000000 ./run_bench.sh bum
+```
+
+## smoke 確認 (計測前のデータプレーン疎通)
+
+計測用 config は `enable_stats: false` です。経路がただしく通っているかは stats を有効にした config で低レートを流して確認します。
+
+```bash
+./setup_dut.sh encaps-v4 --stats
+PPS=1000 DURATION=5 REPS=1 ./run_bench.sh encaps-v4 64
+../../out/bin/vinbero -s http://127.0.0.1:8082 stats show
+../../out/bin/vinbero -s http://127.0.0.1:8082 stats slot show --all
+./teardown_dut.sh
+```
+
+REDIRECT カウンタが送信 packet 数と一致し、`rx_ipackets` が `tx_opackets` とほぼ一致すれば疎通しています。確認後は必ず stats なしの config で取り直してください (stats 有効時は per-packet カウンタ更新のコストが乗ります)。
+
+## 測定方法の詳細
+
+- flow 分散は 32 本の静的 stream (source address 可変) で行います。TRex の field-engine VM は SRH を再パースできず frame を壊すため、SRH 入り frame は必ず scapy + raw `pkt_buffer` の静的 stream で組みます
+- `bpf_fib_lookup` は neighbor 未解決だと packet を落とすため、TRex port 1 へ向く next-hop は static neighbor entry を投入します (TRex port は ND/ARP に応答しません)。同じ理由で forwarding sysctl も setup が有効化します
+- L2 シナリオの frame は customer MAC 宛で NIC の MAC と一致しないため、setup が ingress NIC を promiscuous mode にします。これがないと hardware の MAC filter が落とし、wire counter には乗るのに XDP に届かないという形で 100% loss になります
+- offered load は既定で line rate (`mult=100%`) です。`PPS` に非ゼロを与えるとその合計 pps で送ります
+- NIC hardware counter (`ethtool -S` の `.nic` 系) の差分を `nic_rx_mpps` / `nic_tx_mpps` として併記します。XDP_REDIRECT は kernel の software counter を通らないため、wire レベルの確認はこちらで行います
+- RSS の queue 数を固定したい場合は `sudo ethtool -X <iface> equal 1` で single queue にしてから流します (per-core 性能の参考系列)
+
+## 結果の読み方
+
+`run_bench.sh` は rep ごとに `results/<scenario>_rep<k>.csv` を書き、`analysis/stats.py` が (scenario, size) ごとに rx_mpps / tx_mpps / loss_pct の mean と sd を出します。offered load が DUT 容量を超えている領域では rx_mpps がそのまま DUT の転送容量を示します。

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -81,7 +81,7 @@ FLOWS=256 ./run_bench.sh encaps-v4 64   # flow 数を増やして全 RSS queue �
 
 ## smoke 確認 (計測前のデータプレーン疎通)
 
-計測用 config は `enable_stats: false` です。経路がただしく通っているかは stats を有効にした config で低レートを流して確認します。
+計測用 config は `enable_stats: false` です。経路が正しく通っているかは stats を有効にした config で低レートを流して確認します。
 
 ```bash
 ./setup_dut.sh encaps-v4 --stats

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -90,7 +90,8 @@ REDIRECT カウンタが送信 packet 数と一致し、`rx_ipackets` が `tx_op
 
 ## 測定方法の詳細
 
-- flow 分散は 32 本の静的 stream (source address 可変) で行います。TRex の field-engine VM は SRH を再パースできず frame を壊すため、SRH 入り frame は必ず scapy + raw `pkt_buffer` の静的 stream で組みます
+- flow 分散は既定で 32 本の静的 stream (source address 可変) で行います。TRex の field-engine VM は SRH を再パースできず frame を壊すため、SRH 入り frame は必ず scapy + raw `pkt_buffer` の静的 stream で組みます
+- 集計 throughput は flow 数と RSS の当たり方に強く依存します。実測では 32 flow は hash 衝突で 64 queue 中 25 queue にしか当たらず、飽和 core あたり約 1.8 Mpps (64B encaps-v4) の積み上げが装置全体の数字になります。driver の `--flows 256` で全 queue に当てると集計値は約 15% 伸びますが、hyperthread 兄弟まで使うため線形には伸びません。集計値を比較するときは flow 数を固定し、per-core の実力は queue counter (`ethtool -S` の `rx_queue_N_packets`) の delta で確認してください
 - `bpf_fib_lookup` は neighbor 未解決だと packet を落とすため、TRex port 1 へ向く next-hop は static neighbor entry を投入します (TRex port は ND/ARP に応答しません)。同じ理由で forwarding sysctl も setup が有効化します
 - L2 シナリオの frame は customer MAC 宛で NIC の MAC と一致しないため、setup が ingress NIC を promiscuous mode にします。これがないと hardware の MAC filter が落とし、wire counter には乗るのに XDP に届かないという形で 100% loss になります
 - offered load は既定で line rate (`mult=100%`) です。`PPS` に非ゼロを与えるとその合計 pps で送ります

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -54,6 +54,10 @@ TRex port 0 が DUT の ingress NIC へ送信し、Vinbero が処理した packe
 ```bash
 cd benchmark/pipelines
 
+# 0. 任意: RX queue を物理 core へ 1:1 pin する (集計値が約 1 割伸びる)
+#    channel 数の変更は XDP attach 前に行う必要があるため setup より先に実行する
+./tune_dut.sh apply        # 戻すときは ./tune_dut.sh revert
+
 # 1. シナリオをセットアップ (NIC 準備 + vinberod 起動 + map entry 投入)
 sudo -v && ./setup_dut.sh encaps-v4
 
@@ -72,6 +76,7 @@ python3 ../analysis/stats.py ../results/encaps-v4_rep*.csv
 ```bash
 DURATION=30 REPS=5 PPS=50000000 ./run_bench.sh encaps-v4 64 512
 PEERS=4 ./setup_dut.sh bum --peers 4 && PEERS=4 PPS=5000000 ./run_bench.sh bum
+FLOWS=256 ./run_bench.sh encaps-v4 64   # flow 数を増やして全 RSS queue に当てる
 ```
 
 ## smoke 確認 (計測前のデータプレーン疎通)

--- a/benchmark/analysis/stats.py
+++ b/benchmark/analysis/stats.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Aggregate benchmark reps into mean/sd per (scenario, size).
+
+Input : one or more <scenario>_rep<k>.csv produced by
+        pipelines/run_bench.sh (one row per frame size).
+Output: CSV to stdout with mean and sd across reps for rx_mpps
+        (forwarded rate), loss_pct, and tx_mpps (offered rate).
+
+Usage: python3 benchmark/analysis/stats.py results/encaps-v4_rep*.csv
+"""
+import csv
+import statistics as st
+import sys
+
+
+def load(path):
+    rows = {}
+    with open(path) as f:
+        for r in csv.DictReader(f):
+            key = (r["scenario"], int(r["size"]))
+            rows[key] = {
+                "rx_mpps": float(r["rx_mpps"]),
+                "tx_mpps": float(r["tx_mpps"]),
+                "loss_pct": float(r["loss_pct"]),
+            }
+    return rows
+
+
+def msd(xs):
+    return st.mean(xs), (st.stdev(xs) if len(xs) > 1 else 0.0)
+
+
+def main(argv):
+    paths = argv[1:]
+    if not paths:
+        sys.exit("usage: stats.py rep1.csv [rep2.csv ...]")
+    reps = [load(p) for p in paths]
+    keys = sorted(set().union(*[set(r) for r in reps]))
+
+    print(f"# n={len(reps)} reps from: {', '.join(paths)}")
+    print("scenario,size,n,"
+          "rx_mpps_mean,rx_mpps_sd,tx_mpps_mean,tx_mpps_sd,"
+          "loss_pct_mean,loss_pct_sd")
+    for key in keys:
+        cells = [r[key] for r in reps if key in r]
+        rx_m, rx_s = msd([c["rx_mpps"] for c in cells])
+        tx_m, tx_s = msd([c["tx_mpps"] for c in cells])
+        lo_m, lo_s = msd([c["loss_pct"] for c in cells])
+        print(f"{key[0]},{key[1]},{len(cells)},"
+              f"{rx_m:.3f},{rx_s:.4f},{tx_m:.3f},{tx_s:.4f},"
+              f"{lo_m:.3f},{lo_s:.4f}")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/benchmark/analysis/stats.py
+++ b/benchmark/analysis/stats.py
@@ -37,7 +37,8 @@ def main(argv):
     reps = [load(p) for p in paths]
     keys = sorted(set().union(*[set(r) for r in reps]))
 
-    print(f"# n={len(reps)} reps from: {', '.join(paths)}")
+    # Keep stdout pure CSV so it can be piped into other tools.
+    print(f"n={len(reps)} reps from: {', '.join(paths)}", file=sys.stderr)
     print("scenario,size,n,"
           "rx_mpps_mean,rx_mpps_sd,tx_mpps_mean,tx_mpps_sd,"
           "loss_pct_mean,loss_pct_sd")

--- a/benchmark/configs/vinbero-bench-stats.yml
+++ b/benchmark/configs/vinbero-bench-stats.yml
@@ -1,6 +1,6 @@
 internal:
   devices:
-    - enp138s0f0
+    - enp138s0f0np0
     - enp138s0f1np1
   bpf:
     device_mode: "driver"

--- a/benchmark/configs/vinbero-bench-stats.yml
+++ b/benchmark/configs/vinbero-bench-stats.yml
@@ -1,0 +1,36 @@
+internal:
+  devices:
+    - enp138s0f0
+    - enp138s0f1np1
+  bpf:
+    device_mode: "driver"
+    verifier_log_level: 0
+    verifier_log_size: 1073741823
+  server:
+    bind: "127.0.0.1:8082"
+  logger:
+    level: info
+    format: text
+    no_color: true
+    add_caller: false
+
+settings:
+  # Keep stats off for measurement runs; the smoke phase flips this to
+  # true via configs/vinbero-bench-stats.yml to verify the datapath.
+  enable_stats: true
+  fdb_aging_seconds: 0
+  entries:
+    sid_function:
+      capacity: 1024
+    headendv4:
+      capacity: 1024
+    headendv6:
+      capacity: 1024
+    headend_l2:
+      capacity: 1024
+    fdb:
+      capacity: 8192
+    bd_peer:
+      capacity: 1024
+    sr_policy:
+      capacity: 1024

--- a/benchmark/configs/vinbero-bench-stats.yml
+++ b/benchmark/configs/vinbero-bench-stats.yml
@@ -18,6 +18,9 @@ settings:
   # Smoke/debug config: stats stay on so the datapath can be verified
   # at low rate; measurement runs use vinbero-bench.yml (stats off).
   enable_stats: true
+  # Isolate from the host's operational state file so the harness never
+  # reconciles or clobbers /var/lib/vinbero/state.json.
+  state_path: /tmp/vinbero-bench-state.json
   fdb_aging_seconds: 0
   entries:
     sid_function:

--- a/benchmark/configs/vinbero-bench-stats.yml
+++ b/benchmark/configs/vinbero-bench-stats.yml
@@ -15,8 +15,8 @@ internal:
     add_caller: false
 
 settings:
-  # Keep stats off for measurement runs; the smoke phase flips this to
-  # true via configs/vinbero-bench-stats.yml to verify the datapath.
+  # Smoke/debug config: stats stay on so the datapath can be verified
+  # at low rate; measurement runs use vinbero-bench.yml (stats off).
   enable_stats: true
   fdb_aging_seconds: 0
   entries:

--- a/benchmark/configs/vinbero-bench.yml
+++ b/benchmark/configs/vinbero-bench.yml
@@ -1,6 +1,6 @@
 internal:
   devices:
-    - enp138s0f0
+    - enp138s0f0np0
     - enp138s0f1np1
   bpf:
     device_mode: "driver"

--- a/benchmark/configs/vinbero-bench.yml
+++ b/benchmark/configs/vinbero-bench.yml
@@ -18,6 +18,9 @@ settings:
   # Keep stats off for measurement runs; the smoke phase flips this to
   # true via configs/vinbero-bench-stats.yml to verify the datapath.
   enable_stats: false
+  # Isolate from the host's operational state file so the harness never
+  # reconciles or clobbers /var/lib/vinbero/state.json.
+  state_path: /tmp/vinbero-bench-state.json
   fdb_aging_seconds: 0
   entries:
     sid_function:

--- a/benchmark/configs/vinbero-bench.yml
+++ b/benchmark/configs/vinbero-bench.yml
@@ -1,0 +1,36 @@
+internal:
+  devices:
+    - enp138s0f0
+    - enp138s0f1np1
+  bpf:
+    device_mode: "driver"
+    verifier_log_level: 0
+    verifier_log_size: 1073741823
+  server:
+    bind: "127.0.0.1:8082"
+  logger:
+    level: info
+    format: text
+    no_color: true
+    add_caller: false
+
+settings:
+  # Keep stats off for measurement runs; the smoke phase flips this to
+  # true via configs/vinbero-bench-stats.yml to verify the datapath.
+  enable_stats: false
+  fdb_aging_seconds: 0
+  entries:
+    sid_function:
+      capacity: 1024
+    headendv4:
+      capacity: 1024
+    headendv6:
+      capacity: 1024
+    headend_l2:
+      capacity: 1024
+    fdb:
+      capacity: 8192
+    bd_peer:
+      capacity: 1024
+    sr_policy:
+      capacity: 1024

--- a/benchmark/pipelines/common.sh
+++ b/benchmark/pipelines/common.sh
@@ -38,6 +38,7 @@ DURATION=${DURATION:-30}
 REPS=${REPS:-5}
 PPS=${PPS:-0}          # 0 = line rate (mult=100%)
 PEERS=${PEERS:-1}
+FLOWS=${FLOWS:-32}
 RESULT_DIR=${RESULT_DIR:-$REPO_ROOT/benchmark/results}
 
 vbctl() {

--- a/benchmark/pipelines/common.sh
+++ b/benchmark/pipelines/common.sh
@@ -3,7 +3,10 @@
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-# DUT NICs (E810-C 100G, direct-cabled to the TRex host)
+# DUT NICs (E810-C 100G, direct-cabled to the TRex host).
+# Overriding these only moves the pipeline's NIC prep and counters;
+# vinberod attaches XDP to the devices named in
+# benchmark/configs/vinbero-bench*.yml, so change those in lockstep.
 IN_IF=${IN_IF:-enp138s0f0np0}       # TRex port 0 -> Vinbero ingress
 OUT_IF=${OUT_IF:-enp138s0f1np1}     # Vinbero egress -> TRex port 1
 

--- a/benchmark/pipelines/common.sh
+++ b/benchmark/pipelines/common.sh
@@ -1,0 +1,67 @@
+# Shared settings for the Vinbero TRex benchmark pipelines.
+# Source this from setup_dut.sh / run_bench.sh / teardown_dut.sh.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# DUT NICs (E810-C 100G, direct-cabled to the TRex host)
+IN_IF=${IN_IF:-enp138s0f0}          # TRex port 0 -> Vinbero ingress
+OUT_IF=${OUT_IF:-enp138s0f1np1}     # Vinbero egress -> TRex port 1
+
+# TRex host
+TREX_HOST=${TREX_HOST:-ocxma-trex}
+TREX_PORT1_MAC=${TREX_PORT1_MAC:-40:a6:b7:82:cd:d9}
+TREX_DRIVER_DIR=${TREX_DRIVER_DIR:-vinbero-bench}
+
+# Benchmark addressing (self-contained; must match trex/vinbero_streams.py)
+SID_END=fc00:a::1
+SID_DT4=fc00:a::d4
+SEG_REMOTE=fd00:c::1
+EGRESS_ADDR6=fd00:b::1/64
+NH6=fd00:b::2
+REMOTE_SID_PREFIX=fd00:c::/64
+EGRESS_ADDR4=192.0.2.1/24
+NH4=192.0.2.2
+VRF_NAME=vrf100
+VRF_TABLE=100
+BD_ID=100
+VLAN_ID=100
+ECMP_GROUP_ID=1
+
+RPC=${RPC:-http://127.0.0.1:8082}
+VINBEROD_BIN="$REPO_ROOT/out/bin/vinberod"
+VINBERO_BIN="$REPO_ROOT/out/bin/vinbero"
+ECMPDEMO_BIN="$REPO_ROOT/out/bin/vinbero-ecmpdemo"
+PID_FILE=/tmp/vinbero-bench.pid
+LOG_FILE=/tmp/vinbero-bench.log
+
+DURATION=${DURATION:-30}
+REPS=${REPS:-5}
+PPS=${PPS:-0}          # 0 = line rate (mult=100%)
+PEERS=${PEERS:-1}
+RESULT_DIR=${RESULT_DIR:-$REPO_ROOT/benchmark/results}
+
+vbctl() {
+    "$VINBERO_BIN" -s "$RPC" "$@"
+}
+
+# Sum of the wire-level MAC counters (unicast+multicast+broadcast) for
+# one direction. XDP_REDIRECT bypasses the kernel software stats, so
+# only the .nic hardware counters see the forwarded packets.
+nic_pkts() {
+    local ifname="$1" dir="$2"  # dir: rx|tx
+    sudo ethtool -S "$ifname" \
+        | awk -v d="$dir" '$1 ~ d"_(unicast|multicast|broadcast).nic:" {s += $NF} END {print s+0}'
+}
+
+wait_health() {
+    local addr="${RPC#http://}" timeout="${1:-15}" elapsed=0
+    while [ "$elapsed" -lt "$timeout" ]; do
+        if curl -sf "http://${addr}/health" > /dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    echo "vinberod not ready after ${timeout}s" >&2
+    return 1
+}

--- a/benchmark/pipelines/common.sh
+++ b/benchmark/pipelines/common.sh
@@ -4,7 +4,7 @@
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 # DUT NICs (E810-C 100G, direct-cabled to the TRex host)
-IN_IF=${IN_IF:-enp138s0f0}          # TRex port 0 -> Vinbero ingress
+IN_IF=${IN_IF:-enp138s0f0np0}       # TRex port 0 -> Vinbero ingress
 OUT_IF=${OUT_IF:-enp138s0f1np1}     # Vinbero egress -> TRex port 1
 
 # TRex host

--- a/benchmark/pipelines/run_bench.sh
+++ b/benchmark/pipelines/run_bench.sh
@@ -4,7 +4,8 @@
 #
 # Usage: run_bench.sh <scenario> [size ...]
 #   Env: DURATION (s/run, default 30), REPS (default 5),
-#        PPS (offered total, default 200e6), PEERS (bum amplification),
+#        PPS (offered total, default 0 = line rate),
+#        PEERS (bum amplification), FLOWS (default 32),
 #        RESULT_DIR (default benchmark/results)
 #
 # One CSV per rep: <scenario>_rep<k>.csv with a row per size.
@@ -32,7 +33,7 @@ ssh "$TREX_HOST" "mkdir -p ~/$TREX_DRIVER_DIR"
 scp -q "$REPO_ROOT/benchmark/trex/vinbero_streams.py" \
     "$TREX_HOST:$TREX_DRIVER_DIR/vinbero_streams.py"
 
-HEADER="scenario,size,rep,duration_s,peers,tx_opackets,rx_ipackets,tx_mpps,rx_mpps,tx_gbps,loss_pct,nic_rx_mpps,nic_tx_mpps"
+HEADER="scenario,size,rep,duration_s,peers,flows,tx_opackets,rx_ipackets,tx_mpps,rx_mpps,tx_gbps,loss_pct,nic_rx_mpps,nic_tx_mpps"
 
 for rep in $(seq 1 "$REPS"); do
     CSV="$RESULT_DIR/${SCENARIO}_rep${rep}.csv"
@@ -56,7 +57,10 @@ import sys, json
 scen, size, rep, trex_json, rb, ra, tb, ta, csv = sys.argv[1:10]
 t = json.loads(trex_json)
 dur = float(t["duration_s"])
-row = (f'{scen},{size},{rep},{t["duration_s"]},{t["peers"]},'
+# t["size"] is the effective wire length the driver actually sent,
+# which can exceed the requested size for scenarios with a larger
+# minimum frame.
+row = (f'{scen},{t["size"]},{rep},{t["duration_s"]},{t["peers"]},{t["flows"]},'
        f'{t["tx_opackets"]},{t["rx_ipackets"]},{t["tx_mpps"]},{t["rx_mpps"]},'
        f'{t["tx_gbps"]},{t["loss_pct"]},'
        f'{(int(ra) - int(rb)) / dur / 1e6:.3f},'

--- a/benchmark/pipelines/run_bench.sh
+++ b/benchmark/pipelines/run_bench.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Run one scenario across a frame-size sweep with repetitions.
+# setup_dut.sh for the same scenario must have completed first.
+#
+# Usage: run_bench.sh <scenario> [size ...]
+#   Env: DURATION (s/run, default 30), REPS (default 5),
+#        PPS (offered total, default 200e6), PEERS (bum amplification),
+#        RESULT_DIR (default benchmark/results)
+#
+# One CSV per rep: <scenario>_rep<k>.csv with a row per size.
+set -euo pipefail
+cd "$(dirname "$0")"
+. ./common.sh
+
+SCENARIO="${1:?usage: run_bench.sh <scenario> [size ...]}"
+shift
+if [ $# -gt 0 ]; then
+    SIZES=("$@")
+else
+    case "$SCENARIO" in
+        encaps-v4|ecmp) SIZES=(64 128 256 512 1024 1420) ;;
+        end|end-dt4)    SIZES=(118 160 256 512 1024 1420) ;;
+        l2-unicast|bum) SIZES=(68 512 1420) ;;
+        *) echo "unknown scenario: $SCENARIO" >&2; exit 2 ;;
+    esac
+fi
+
+mkdir -p "$RESULT_DIR"
+
+echo "=== deploy TRex driver to $TREX_HOST ==="
+ssh "$TREX_HOST" "mkdir -p ~/$TREX_DRIVER_DIR"
+scp -q "$REPO_ROOT/benchmark/trex/vinbero_streams.py" \
+    "$TREX_HOST:$TREX_DRIVER_DIR/vinbero_streams.py"
+
+HEADER="scenario,size,rep,duration_s,peers,tx_opackets,rx_ipackets,tx_mpps,rx_mpps,tx_gbps,loss_pct,nic_rx_mpps,nic_tx_mpps"
+
+for rep in $(seq 1 "$REPS"); do
+    CSV="$RESULT_DIR/${SCENARIO}_rep${rep}.csv"
+    echo "$HEADER" > "$CSV"
+    for size in "${SIZES[@]}"; do
+        echo "=== $SCENARIO size=$size rep=$rep/$REPS (${DURATION}s) ==="
+        rx_before=$(nic_pkts "$IN_IF" rx)
+        tx_before=$(nic_pkts "$OUT_IF" tx)
+
+        trex_json=$(ssh "$TREX_HOST" \
+            "python3 ~/$TREX_DRIVER_DIR/vinbero_streams.py \
+             --scenario $SCENARIO --duration $DURATION --size $size \
+             --pps $PPS --peers $PEERS")
+
+        rx_after=$(nic_pkts "$IN_IF" rx)
+        tx_after=$(nic_pkts "$OUT_IF" tx)
+
+        python3 - "$SCENARIO" "$size" "$rep" "$trex_json" \
+            "$rx_before" "$rx_after" "$tx_before" "$tx_after" "$CSV" <<'PY'
+import sys, json
+scen, size, rep, trex_json, rb, ra, tb, ta, csv = sys.argv[1:10]
+t = json.loads(trex_json)
+dur = float(t["duration_s"])
+row = (f'{scen},{size},{rep},{t["duration_s"]},{t["peers"]},'
+       f'{t["tx_opackets"]},{t["rx_ipackets"]},{t["tx_mpps"]},{t["rx_mpps"]},'
+       f'{t["tx_gbps"]},{t["loss_pct"]},'
+       f'{(int(ra) - int(rb)) / dur / 1e6:.3f},'
+       f'{(int(ta) - int(tb)) / dur / 1e6:.3f}')
+print(row)
+open(csv, "a").write(row + "\n")
+PY
+        sleep 2
+    done
+    echo "wrote $CSV"
+done
+
+echo
+echo "aggregate with: python3 $REPO_ROOT/benchmark/analysis/stats.py $RESULT_DIR/${SCENARIO}_rep*.csv"

--- a/benchmark/pipelines/run_bench.sh
+++ b/benchmark/pipelines/run_bench.sh
@@ -23,6 +23,13 @@ case "$SCENARIO" in
 esac
 if [ $# -gt 0 ]; then
     SIZES=("$@")
+    # These values are spliced into the remote ssh command string, so
+    # accept plain integers only.
+    for size in "${SIZES[@]}"; do
+        case "$size" in
+            ''|*[!0-9]*) echo "size must be an integer, got: $size" >&2; exit 2 ;;
+        esac
+    done
 else
     case "$SCENARIO" in
         encaps-v4|ecmp) SIZES=(64 128 256 512 1024 1420) ;;

--- a/benchmark/pipelines/run_bench.sh
+++ b/benchmark/pipelines/run_bench.sh
@@ -45,7 +45,7 @@ for rep in $(seq 1 "$REPS"); do
         trex_json=$(ssh "$TREX_HOST" \
             "python3 ~/$TREX_DRIVER_DIR/vinbero_streams.py \
              --scenario $SCENARIO --duration $DURATION --size $size \
-             --pps $PPS --peers $PEERS")
+             --pps $PPS --peers $PEERS --flows $FLOWS")
 
         rx_after=$(nic_pkts "$IN_IF" rx)
         tx_after=$(nic_pkts "$OUT_IF" tx)

--- a/benchmark/pipelines/run_bench.sh
+++ b/benchmark/pipelines/run_bench.sh
@@ -27,6 +27,9 @@ else
 fi
 
 mkdir -p "$RESULT_DIR"
+# Drop rep files from a previous sweep so the aggregation glob at the
+# end never mixes in stale reps (e.g. REPS=5 followed by REPS=3).
+rm -f "$RESULT_DIR/${SCENARIO}"_rep*.csv
 
 echo "=== deploy TRex driver to $TREX_HOST ==="
 ssh "$TREX_HOST" "mkdir -p ~/$TREX_DRIVER_DIR"

--- a/benchmark/pipelines/run_bench.sh
+++ b/benchmark/pipelines/run_bench.sh
@@ -15,6 +15,12 @@ cd "$(dirname "$0")"
 
 SCENARIO="${1:?usage: run_bench.sh <scenario> [size ...]}"
 shift
+# Validate before the value reaches rm globs and the ssh command
+# string, whether or not explicit sizes bypass the default case below.
+case "$SCENARIO" in
+    encaps-v4|ecmp|end|end-dt4|l2-unicast|bum) ;;
+    *) echo "unknown scenario: $SCENARIO" >&2; exit 2 ;;
+esac
 if [ $# -gt 0 ]; then
     SIZES=("$@")
 else
@@ -22,7 +28,6 @@ else
         encaps-v4|ecmp) SIZES=(64 128 256 512 1024 1420) ;;
         end|end-dt4)    SIZES=(118 160 256 512 1024 1420) ;;
         l2-unicast|bum) SIZES=(68 512 1420) ;;
-        *) echo "unknown scenario: $SCENARIO" >&2; exit 2 ;;
     esac
 fi
 

--- a/benchmark/pipelines/setup_dut.sh
+++ b/benchmark/pipelines/setup_dut.sh
@@ -22,7 +22,14 @@ esac
 CONFIG="$REPO_ROOT/benchmark/configs/vinbero-bench.yml"
 while [ $# -gt 0 ]; do
     case "$1" in
-        --peers) PEERS="$2"; shift 2 ;;
+        --peers)
+            # The dataplane holds at most 8 peers per BD; catch bad
+            # values here, before any NIC/daemon side effects.
+            case "$2" in
+                [1-8]) PEERS="$2" ;;
+                *) echo "--peers must be 1..8, got: $2" >&2; exit 2 ;;
+            esac
+            shift 2 ;;
         --stats) CONFIG="$REPO_ROOT/benchmark/configs/vinbero-bench-stats.yml"; shift ;;
         *) echo "unknown arg: $1" >&2; exit 2 ;;
     esac
@@ -67,7 +74,10 @@ case "$SCENARIO" in
         sudo ip link add "$VRF_NAME" type vrf table "$VRF_TABLE" 2>/dev/null || true
         sudo ip link set "$VRF_NAME" up
         sudo ip addr replace "$EGRESS_ADDR4" dev "$OUT_IF"
-        sudo ip route replace 10.98.0.0/24 via "$NH4" dev "$OUT_IF" table "$VRF_TABLE"
+        # onlink: the gateway is a direct-cabled TRex port with a
+        # static neighbor entry, so skip gateway reachability checks.
+        sudo ip route replace 10.98.0.0/24 via "$NH4" dev "$OUT_IF" \
+            onlink table "$VRF_TABLE"
         sudo ip neigh replace "$NH4" lladdr "$TREX_PORT1_MAC" dev "$OUT_IF" nud permanent
         ;;
     l2-unicast|bum)

--- a/benchmark/pipelines/setup_dut.sh
+++ b/benchmark/pipelines/setup_dut.sh
@@ -32,6 +32,16 @@ for bin in "$VINBEROD_BIN" "$VINBERO_BIN"; do
     [ -x "$bin" ] || { echo "$bin not found; run 'make build' first" >&2; exit 1; }
 done
 
+# Any live vinberod holds an XDP attachment on these NICs, so bail out
+# before the force-detach below cuts its dataplane. Catch processes
+# without a PID file too (a previous setup that died before writing it).
+for pid in $(pgrep -x vinberod); do
+    state=$(awk '{print $3}' "/proc/$pid/stat" 2>/dev/null || echo "")
+    [ "$state" = "Z" ] && continue
+    echo "vinberod is running (pid $pid); run teardown_dut.sh first" >&2
+    exit 1
+done
+
 echo "=== NIC preparation ==="
 # Clear any stale XDP attachment (a crashed vinberod leaves its
 # bpf_link attached and blocks re-attachment).
@@ -71,10 +81,6 @@ case "$SCENARIO" in
 esac
 
 echo "=== start vinberod ==="
-if [ -f "$PID_FILE" ] && ps -p "$(cat "$PID_FILE")" > /dev/null 2>&1; then
-    echo "vinberod already running (pid $(cat "$PID_FILE")); run teardown_dut.sh first" >&2
-    exit 1
-fi
 sudo setsid "$VINBEROD_BIN" -c "$CONFIG" > "$LOG_FILE" 2>&1 &
 wait_health 15 || { cat "$LOG_FILE" >&2; exit 1; }
 # $! is the sudo wrapper; vinbero-ecmpdemo reads the daemon's map fds

--- a/benchmark/pipelines/setup_dut.sh
+++ b/benchmark/pipelines/setup_dut.sh
@@ -35,7 +35,9 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-for bin in "$VINBEROD_BIN" "$VINBERO_BIN"; do
+BINS=("$VINBEROD_BIN" "$VINBERO_BIN")
+[ "$SCENARIO" = ecmp ] && BINS+=("$ECMPDEMO_BIN")
+for bin in "${BINS[@]}"; do
     [ -x "$bin" ] || { echo "$bin not found; run 'make build' first" >&2; exit 1; }
 done
 
@@ -105,7 +107,6 @@ case "$SCENARIO" in
             --src-addr "$SID_END" --segments "$SEG_REMOTE"
         ;;
     ecmp)
-        [ -x "$ECMPDEMO_BIN" ] || { echo "$ECMPDEMO_BIN not found; run 'make build' first" >&2; exit 1; }
         vbctl hv4 create --trigger-prefix 10.99.0.0/24 \
             --src-addr "$SID_END" --segments "$SEG_REMOTE"
         sudo "$ECMPDEMO_BIN" group-put --pid "$(cat "$PID_FILE")" \

--- a/benchmark/pipelines/setup_dut.sh
+++ b/benchmark/pipelines/setup_dut.sh
@@ -22,18 +22,19 @@ esac
 CONFIG="$REPO_ROOT/benchmark/configs/vinbero-bench.yml"
 while [ $# -gt 0 ]; do
     case "$1" in
-        --peers)
-            # The dataplane holds at most 8 peers per BD; catch bad
-            # values here, before any NIC/daemon side effects.
-            case "$2" in
-                [1-8]) PEERS="$2" ;;
-                *) echo "--peers must be 1..8, got: $2" >&2; exit 2 ;;
-            esac
-            shift 2 ;;
+        --peers) PEERS="$2"; shift 2 ;;
         --stats) CONFIG="$REPO_ROOT/benchmark/configs/vinbero-bench-stats.yml"; shift ;;
         *) echo "unknown arg: $1" >&2; exit 2 ;;
     esac
 done
+
+# The dataplane holds at most MAX_BUM_NEXTHOPS (8) peers per BD; catch
+# bad values (from --peers or the PEERS env var) before any side
+# effects rather than failing halfway through provisioning.
+case "$PEERS" in
+    [1-8]) ;;
+    *) echo "peers must be 1..8, got: $PEERS" >&2; exit 2 ;;
+esac
 
 BINS=("$VINBEROD_BIN" "$VINBERO_BIN")
 [ "$SCENARIO" = ecmp ] && BINS+=("$ECMPDEMO_BIN")
@@ -50,6 +51,17 @@ for pid in $(pgrep -x vinberod); do
     echo "vinberod is running (pid $pid); run teardown_dut.sh first" >&2
     exit 1
 done
+
+# From the first side effect on, a failure (daemon won't start, vbctl
+# provisioning error) must not leave a half-configured DUT behind; the
+# next run would just error out on the leftover vinberod. teardown is
+# idempotent, so run it on any non-success exit.
+cleanup() {
+    [ -n "${SETUP_OK:-}" ] && return
+    echo "setup failed; running teardown_dut.sh" >&2
+    ./teardown_dut.sh || true
+}
+trap cleanup EXIT
 
 echo "=== NIC preparation ==="
 # Clear any stale XDP attachment (a crashed vinberod leaves its
@@ -141,4 +153,5 @@ case "$SCENARIO" in
         ;;
 esac
 
+SETUP_OK=1
 echo "DUT ready for scenario $SCENARIO (vinberod pid $(cat "$PID_FILE"))"

--- a/benchmark/pipelines/setup_dut.sh
+++ b/benchmark/pipelines/setup_dut.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# Prepare the DUT for one benchmark scenario: NIC state, static
+# route/neigh toward the TRex receive port, vinberod, and the
+# scenario's map entries.
+#
+# Usage: setup_dut.sh <scenario> [--peers N] [--stats]
+#   scenario: encaps-v4 | end | end-dt4 | ecmp | l2-unicast | bum
+#   --peers N   bum only: number of bd peers to install (default 1)
+#   --stats     use the enable_stats: true config (smoke/debug runs)
+set -euo pipefail
+cd "$(dirname "$0")"
+. ./common.sh
+
+SCENARIO="${1:?usage: setup_dut.sh <scenario> [--peers N] [--stats]}"
+shift
+CONFIG="$REPO_ROOT/benchmark/configs/vinbero-bench.yml"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --peers) PEERS="$2"; shift 2 ;;
+        --stats) CONFIG="$REPO_ROOT/benchmark/configs/vinbero-bench-stats.yml"; shift ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+for bin in "$VINBEROD_BIN" "$VINBERO_BIN"; do
+    [ -x "$bin" ] || { echo "$bin not found; run 'make build' first" >&2; exit 1; }
+done
+
+echo "=== NIC preparation ==="
+# Clear any stale XDP attachment (a crashed vinberod leaves its
+# bpf_link attached and blocks re-attachment).
+for ifname in "$IN_IF" "$OUT_IF"; do
+    sudo ip link set dev "$ifname" xdp off 2>/dev/null || true
+    sudo ip link set dev "$ifname" xdpgeneric off 2>/dev/null || true
+    sudo ip link set dev "$ifname" mtu 3000
+    sudo ip link set dev "$ifname" up
+done
+
+# bpf_fib_lookup fails with FWD_DISABLED unless forwarding is on.
+sudo sysctl -q -w net.ipv6.conf.all.forwarding=1 net.ipv4.ip_forward=1
+
+# Egress toward TRex port 1. The TRex port never answers ND/ARP, so
+# the neighbor entries must be static.
+sudo ip -6 addr replace "$EGRESS_ADDR6" dev "$OUT_IF"
+sudo ip -6 route replace "$REMOTE_SID_PREFIX" via "$NH6" dev "$OUT_IF"
+sudo ip -6 neigh replace "$NH6" lladdr "$TREX_PORT1_MAC" dev "$OUT_IF" nud permanent
+
+case "$SCENARIO" in
+    end-dt4)
+        # End.DT4 looks the inner IPv4 packet up in the VRF table.
+        sudo ip link add "$VRF_NAME" type vrf table "$VRF_TABLE" 2>/dev/null || true
+        sudo ip link set "$VRF_NAME" up
+        sudo ip addr replace "$EGRESS_ADDR4" dev "$OUT_IF"
+        sudo ip route replace 10.98.0.0/24 via "$NH4" dev "$OUT_IF" table "$VRF_TABLE"
+        sudo ip neigh replace "$NH4" lladdr "$TREX_PORT1_MAC" dev "$OUT_IF" nud permanent
+        ;;
+    l2-unicast|bum)
+        # XDP reads the VLAN tag from packet data; rx offload would
+        # strip it into the skb before XDP sees the frame.
+        sudo ethtool -K "$IN_IF" rxvlan off
+        # L2 frames carry customer MACs, not the NIC MAC; without
+        # promiscuous mode the MAC filter drops them in hardware.
+        sudo ip link set dev "$IN_IF" promisc on
+        ;;
+esac
+
+echo "=== start vinberod ==="
+if [ -f "$PID_FILE" ] && ps -p "$(cat "$PID_FILE")" > /dev/null 2>&1; then
+    echo "vinberod already running (pid $(cat "$PID_FILE")); run teardown_dut.sh first" >&2
+    exit 1
+fi
+sudo setsid "$VINBEROD_BIN" -c "$CONFIG" > "$LOG_FILE" 2>&1 &
+wait_health 15 || { cat "$LOG_FILE" >&2; exit 1; }
+# $! is the sudo wrapper; vinbero-ecmpdemo reads the daemon's map fds
+# via /proc/<pid>/fdinfo, so record the actual vinberod pid.
+pgrep -x -n vinberod | sudo tee "$PID_FILE" > /dev/null
+[ -s "$PID_FILE" ] || { echo "failed to resolve vinberod pid" >&2; exit 1; }
+
+echo "=== scenario config: $SCENARIO ==="
+case "$SCENARIO" in
+    encaps-v4)
+        vbctl hv4 create --trigger-prefix 10.99.0.0/24 \
+            --src-addr "$SID_END" --segments "$SEG_REMOTE"
+        ;;
+    ecmp)
+        [ -x "$ECMPDEMO_BIN" ] || { echo "$ECMPDEMO_BIN not found; run 'make build' first" >&2; exit 1; }
+        vbctl hv4 create --trigger-prefix 10.99.0.0/24 \
+            --src-addr "$SID_END" --segments "$SEG_REMOTE"
+        sudo "$ECMPDEMO_BIN" group-put --pid "$(cat "$PID_FILE")" \
+            --group-id "$ECMP_GROUP_ID" --from-trigger 10.99.0.0/24 \
+            --path "fd00:c::1@1" --path "fd00:c::2@1" \
+            --path "fd00:c::3@1" --path "fd00:c::4@1"
+        sudo "$ECMPDEMO_BIN" attach --pid "$(cat "$PID_FILE")" \
+            --group-id "$ECMP_GROUP_ID" --trigger 10.99.0.0/24
+        ;;
+    end)
+        vbctl sid create --trigger-prefix "$SID_END/128" --action END
+        ;;
+    end-dt4)
+        vbctl sid create --trigger-prefix "$SID_DT4/128" \
+            --action END_DT4 --vrf-name "$VRF_NAME"
+        ;;
+    l2-unicast)
+        vbctl hl2 create --interface "$IN_IF" --vlan-id "$VLAN_ID" \
+            --src-addr "$SID_END" --segments "$SEG_REMOTE"
+        ;;
+    bum)
+        vbctl hl2 create --interface "$IN_IF" --vlan-id "$VLAN_ID" \
+            --src-addr "$SID_END" --segments "$SEG_REMOTE" --bd-id "$BD_ID"
+        for k in $(seq 1 "$PEERS"); do
+            vbctl peer create --bd-id "$BD_ID" --src-addr "$SID_END" \
+                --segments "fd00:c::$k"
+        done
+        ;;
+    *)
+        echo "unknown scenario: $SCENARIO" >&2
+        exit 2
+        ;;
+esac
+
+echo "DUT ready for scenario $SCENARIO (vinberod pid $(cat "$PID_FILE"))"

--- a/benchmark/pipelines/setup_dut.sh
+++ b/benchmark/pipelines/setup_dut.sh
@@ -13,6 +13,12 @@ cd "$(dirname "$0")"
 
 SCENARIO="${1:?usage: setup_dut.sh <scenario> [--peers N] [--stats]}"
 shift
+# Reject typos before any NIC/route mutation or daemon start; the
+# per-scenario case below runs only after those side effects.
+case "$SCENARIO" in
+    encaps-v4|ecmp|end|end-dt4|l2-unicast|bum) ;;
+    *) echo "unknown scenario: $SCENARIO" >&2; exit 2 ;;
+esac
 CONFIG="$REPO_ROOT/benchmark/configs/vinbero-bench.yml"
 while [ $# -gt 0 ]; do
     case "$1" in

--- a/benchmark/pipelines/teardown_dut.sh
+++ b/benchmark/pipelines/teardown_dut.sh
@@ -11,7 +11,16 @@ if [ -f "$PID_FILE" ]; then
     sleep 1
     sudo rm -f "$PID_FILE"
 fi
-sudo pkill -x vinberod 2>/dev/null || true
+# Catch strays from a setup that died before writing the PID file, but
+# only ones running this repo's binary; an unrelated vinberod on the
+# host is not ours to kill. The prefix match keeps covering a binary
+# rebuilt since start (/proc exe then reads "... (deleted)").
+for pid in $(pgrep -x vinberod); do
+    exe=$(sudo readlink "/proc/$pid/exe" 2>/dev/null || echo "")
+    case "$exe" in
+        "$VINBEROD_BIN"*) sudo kill "$pid" 2>/dev/null || true ;;
+    esac
+done
 sleep 1
 
 echo "=== clear XDP / restore NICs ==="

--- a/benchmark/pipelines/teardown_dut.sh
+++ b/benchmark/pipelines/teardown_dut.sh
@@ -6,15 +6,13 @@ cd "$(dirname "$0")"
 . ./common.sh
 
 echo "=== stop vinberod ==="
-if [ -f "$PID_FILE" ]; then
-    sudo pkill -F "$PID_FILE" 2>/dev/null || true
-    sleep 1
-    sudo rm -f "$PID_FILE"
-fi
-# Catch strays from a setup that died before writing the PID file, but
-# only ones running this repo's binary; an unrelated vinberod on the
-# host is not ours to kill. The prefix match keeps covering a binary
-# rebuilt since start (/proc exe then reads "... (deleted)").
+# The PID file is only bookkeeping: a stale PID may have been reused by
+# an unrelated process, so never kill by it. The exe-verified loop
+# below stops every vinberod that is actually ours — including strays
+# from a setup that died before writing the PID file — and skips any
+# unrelated vinberod on the host. The prefix match keeps covering a
+# binary rebuilt since start (/proc exe then reads "... (deleted)").
+sudo rm -f "$PID_FILE"
 for pid in $(pgrep -x vinberod); do
     exe=$(sudo readlink "/proc/$pid/exe" 2>/dev/null || echo "")
     case "$exe" in

--- a/benchmark/pipelines/teardown_dut.sh
+++ b/benchmark/pipelines/teardown_dut.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Undo setup_dut.sh: stop vinberod, clear XDP, remove the benchmark
+# route/neigh/VRF state, and restore NIC offloads.
+set -uo pipefail
+cd "$(dirname "$0")"
+. ./common.sh
+
+echo "=== stop vinberod ==="
+if [ -f "$PID_FILE" ]; then
+    sudo pkill -F "$PID_FILE" 2>/dev/null || true
+    sleep 1
+    sudo rm -f "$PID_FILE"
+fi
+sudo pkill -x vinberod 2>/dev/null || true
+sleep 1
+
+echo "=== clear XDP / restore NICs ==="
+# A crashed vinberod leaves its bpf_link attached; always force-detach.
+for ifname in "$IN_IF" "$OUT_IF"; do
+    sudo ip link set dev "$ifname" xdp off 2>/dev/null || true
+    sudo ip link set dev "$ifname" xdpgeneric off 2>/dev/null || true
+done
+sudo ethtool -K "$IN_IF" rxvlan on 2>/dev/null || true
+sudo ip link set dev "$IN_IF" promisc off 2>/dev/null || true
+
+echo "=== remove benchmark route/neigh/VRF state ==="
+sudo ip -6 neigh del "$NH6" dev "$OUT_IF" 2>/dev/null || true
+sudo ip -6 route del "$REMOTE_SID_PREFIX" via "$NH6" dev "$OUT_IF" 2>/dev/null || true
+sudo ip -6 addr del "$EGRESS_ADDR6" dev "$OUT_IF" 2>/dev/null || true
+sudo ip neigh del "$NH4" dev "$OUT_IF" 2>/dev/null || true
+sudo ip route del 10.98.0.0/24 table "$VRF_TABLE" 2>/dev/null || true
+sudo ip addr del "$EGRESS_ADDR4" dev "$OUT_IF" 2>/dev/null || true
+sudo ip link del "$VRF_NAME" 2>/dev/null || true
+
+echo "teardown complete (MTU left at 3000; reset manually if needed)"

--- a/benchmark/pipelines/tune_dut.sh
+++ b/benchmark/pipelines/tune_dut.sh
@@ -29,10 +29,14 @@ QUEUES=${QUEUES:-32}
 COALESCE_US=${COALESCE_US:-}
 MODE="${1:-apply}"
 
-if pgrep -x vinberod > /dev/null; then
-    echo "vinberod is running; run teardown_dut.sh first (channel changes need XDP detached)" >&2
+for pid in $(pgrep -x vinberod); do
+    # A defunct vinberod (e.g. inside a stale lab container) holds no NIC
+    # resources; only a live process blocks the channel change.
+    state=$(awk '{print $3}' "/proc/$pid/stat" 2>/dev/null || echo "")
+    [ "$state" = "Z" ] && continue
+    echo "vinberod is running (pid $pid); run teardown_dut.sh first (channel changes need XDP detached)" >&2
     exit 1
-fi
+done
 if systemctl is-active --quiet irqbalance; then
     echo "stopping irqbalance (it would rewrite the pinned affinities)"
     sudo systemctl stop irqbalance
@@ -40,6 +44,17 @@ fi
 
 case "$MODE" in
     apply)
+        # The irdma auxiliary driver pins the queue layout of ice ports it is
+        # bound to, and ethtool -L then fails with "Device or resource busy".
+        # Unbind the RoCE aux devices (module removal would take ice down with
+        # it). Rebind manually via .../bind if RDMA on these ports is needed.
+        if [ -d /sys/bus/auxiliary/drivers/irdma.gen_2 ]; then
+            for aux in /sys/bus/auxiliary/drivers/irdma.gen_2/ice.roce.*; do
+                [ -e "$aux" ] || continue
+                basename "$aux" | sudo tee /sys/bus/auxiliary/drivers/irdma.gen_2/unbind > /dev/null
+                echo "unbound $(basename "$aux") from irdma (was pinning the queue layout)"
+            done
+        fi
         sudo ethtool -L "$IN_IF" combined "$QUEUES"
         sleep 2
         i=0

--- a/benchmark/pipelines/tune_dut.sh
+++ b/benchmark/pipelines/tune_dut.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Pin the ingress NIC's RX queues 1:1 onto physical cores.
+#
+# Aggregate forwarding at small frame sizes is bounded by which cores
+# the RSS queues land on. Measured on the E810 + Xeon 8362 DUT with
+# 64B T.Encaps at line rate (256 flows):
+#
+#   default (64q, unpinned)          47.5 Mpps
+#   32q pinned to physical cores     51.3 Mpps   <- this script
+#   32q pinned + fixed coalescing    51.8 Mpps
+#   64q, all 34 MSI-X vectors pinned 50.3 Mpps
+#
+# Per-core throughput drops as cores are added (1.89 Mpps/core at 16
+# cores, 1.60 at 32), so the ceiling comes from shared resources, not
+# queue count; more vectors than physical cores does not help.
+#
+# Run BEFORE setup_dut.sh: changing the channel count while the XDP
+# program is attached fails. HT sibling layout is CPU N / N+32 on this
+# host; queue i goes to CPU i, one per physical core.
+#
+# Usage: tune_dut.sh [apply|revert]
+#   QUEUES=32     queue/core count for apply
+#   COALESCE_US=  set to e.g. 25 to also fix interrupt coalescing
+set -euo pipefail
+cd "$(dirname "$0")"
+. ./common.sh
+
+QUEUES=${QUEUES:-32}
+COALESCE_US=${COALESCE_US:-}
+MODE="${1:-apply}"
+
+if pgrep -x vinberod > /dev/null; then
+    echo "vinberod is running; run teardown_dut.sh first (channel changes need XDP detached)" >&2
+    exit 1
+fi
+if systemctl is-active --quiet irqbalance; then
+    echo "stopping irqbalance (it would rewrite the pinned affinities)"
+    sudo systemctl stop irqbalance
+fi
+
+case "$MODE" in
+    apply)
+        sudo ethtool -L "$IN_IF" combined "$QUEUES"
+        sleep 2
+        i=0
+        for irq in $(awk -F: "/ice-${IN_IF}-TxRx-/{gsub(/ /,\"\",\$1); print \$1}" /proc/interrupts); do
+            [ "$i" -ge "$QUEUES" ] && break
+            echo "$i" | sudo tee "/proc/irq/$irq/smp_affinity_list" > /dev/null
+            i=$((i + 1))
+        done
+        if [ -n "$COALESCE_US" ]; then
+            sudo ethtool -C "$IN_IF" adaptive-rx off adaptive-tx off \
+                rx-usecs "$COALESCE_US" tx-usecs "$COALESCE_US"
+        fi
+        echo "pinned $i TxRx IRQs of $IN_IF to CPUs 0..$((i - 1))"
+        ;;
+    revert)
+        sudo ethtool -L "$IN_IF" combined 64
+        sudo ethtool -C "$IN_IF" adaptive-rx on adaptive-tx on \
+            rx-usecs 50 tx-usecs 50 2>/dev/null || true
+        echo "restored $IN_IF to 64 combined queues, adaptive coalescing"
+        ;;
+    *)
+        echo "usage: tune_dut.sh [apply|revert]" >&2
+        exit 2
+        ;;
+esac

--- a/benchmark/pipelines/tune_dut.sh
+++ b/benchmark/pipelines/tune_dut.sh
@@ -46,7 +46,7 @@ case "$MODE" in
         # The irdma auxiliary driver pins the queue layout of ice ports it is
         # bound to, and ethtool -L then fails with "Device or resource busy".
         # Unbind the RoCE aux devices (module removal would take ice down with
-        # it). Rebind manually via .../bind if RDMA on these ports is needed.
+        # it); revert rebinds them.
         if [ -d /sys/bus/auxiliary/drivers/irdma.gen_2 ]; then
             for aux in /sys/bus/auxiliary/drivers/irdma.gen_2/ice.roce.*; do
                 [ -e "$aux" ] || continue
@@ -72,6 +72,17 @@ case "$MODE" in
         sudo ethtool -L "$IN_IF" combined 64
         sudo ethtool -C "$IN_IF" adaptive-rx on adaptive-tx on \
             rx-usecs 50 tx-usecs 50 2>/dev/null || true
+        # Rebind the RoCE aux devices that apply unbound from irdma —
+        # after the channel restore, since a bound irdma pins the queue
+        # layout again. Binding an already-bound device just fails, so
+        # no state file is needed.
+        if [ -d /sys/bus/auxiliary/drivers/irdma.gen_2 ]; then
+            for aux in /sys/bus/auxiliary/devices/ice.roce.*; do
+                [ -e "$aux" ] || continue
+                basename "$aux" | sudo tee /sys/bus/auxiliary/drivers/irdma.gen_2/bind > /dev/null 2>&1 \
+                    && echo "rebound $(basename "$aux") to irdma" || true
+            done
+        fi
         # apply stops irqbalance so it cannot rewrite the pinned
         # affinities; bring it back so the host returns to normal
         # IRQ spreading.

--- a/benchmark/pipelines/tune_dut.sh
+++ b/benchmark/pipelines/tune_dut.sh
@@ -37,13 +37,12 @@ for pid in $(pgrep -x vinberod); do
     echo "vinberod is running (pid $pid); run teardown_dut.sh first (channel changes need XDP detached)" >&2
     exit 1
 done
-if systemctl is-active --quiet irqbalance; then
-    echo "stopping irqbalance (it would rewrite the pinned affinities)"
-    sudo systemctl stop irqbalance
-fi
-
 case "$MODE" in
     apply)
+        if systemctl is-active --quiet irqbalance; then
+            echo "stopping irqbalance (it would rewrite the pinned affinities)"
+            sudo systemctl stop irqbalance
+        fi
         # The irdma auxiliary driver pins the queue layout of ice ports it is
         # bound to, and ethtool -L then fails with "Device or resource busy".
         # Unbind the RoCE aux devices (module removal would take ice down with
@@ -73,7 +72,11 @@ case "$MODE" in
         sudo ethtool -L "$IN_IF" combined 64
         sudo ethtool -C "$IN_IF" adaptive-rx on adaptive-tx on \
             rx-usecs 50 tx-usecs 50 2>/dev/null || true
-        echo "restored $IN_IF to 64 combined queues, adaptive coalescing"
+        # apply stops irqbalance so it cannot rewrite the pinned
+        # affinities; bring it back so the host returns to normal
+        # IRQ spreading.
+        sudo systemctl start irqbalance 2>/dev/null || true
+        echo "restored $IN_IF to 64 combined queues, adaptive coalescing, irqbalance"
         ;;
     *)
         echo "usage: tune_dut.sh [apply|revert]" >&2

--- a/benchmark/trex/vinbero_streams.py
+++ b/benchmark/trex/vinbero_streams.py
@@ -74,7 +74,7 @@ def pad(frame, size):
 
 
 def frame(scenario, i, size):
-    src4 = "10.%d.0.2" % (8 + i)
+    src4 = "10.%d.0.%d" % (8 + i % 200, 2 + i // 200)
     if scenario in ("encaps-v4", "ecmp"):
         return pad(bytes(
             Ether(src=SRC_MAC, dst=DST_MAC)
@@ -114,11 +114,11 @@ def frame(scenario, i, size):
     raise ValueError("unknown scenario: %s" % scenario)
 
 
-def build_streams(scenario, size, per_stream_pps):
+def build_streams(scenario, size, per_stream_pps, flows):
     return [
         STLStream(packet=STLPktBuilder(pkt_buffer=frame(scenario, i, size)),
                   mode=STLTXCont(pps=per_stream_pps))
-        for i in range(N_FLOWS)
+        for i in range(flows)
     ]
 
 
@@ -134,6 +134,9 @@ def main():
     ap.add_argument("--pps", type=float, default=0,
                     help="total offered pps across all flows; 0 (default) "
                          "offers 100%% of line rate")
+    ap.add_argument("--flows", type=int, default=N_FLOWS,
+                    help="number of static streams; more flows engage "
+                         "more RSS queues (and DUT cores)")
     ap.add_argument("--peers", type=int, default=1,
                     help="bum only: configured bd peer count, recorded as "
                          "the expected amplification factor")
@@ -145,9 +148,10 @@ def main():
     c.reset(ports=[0, 1])
     # mult scales the stream pps: "100%" normalizes the total to line
     # rate (ignoring the per-stream pps), while "1" honors --pps as-is.
-    per_stream = (args.pps or 1e6) / N_FLOWS
+    per_stream = (args.pps or 1e6) / args.flows
     mult = "1" if args.pps else "100%"
-    c.add_streams(build_streams(args.scenario, args.size, per_stream),
+    c.add_streams(build_streams(args.scenario, args.size, per_stream,
+                                args.flows),
                   ports=[0])
     c.clear_stats()
     c.start(ports=[0], mult=mult)
@@ -174,6 +178,7 @@ def main():
         "size":         args.size,
         "duration_s":   args.duration,
         "peers":        args.peers,
+        "flows":        args.flows,
         "tx_opackets":  opackets,
         "tx_oerrors":   tx.get("oerrors", 0),
         "rx_ipackets":  ipackets,

--- a/benchmark/trex/vinbero_streams.py
+++ b/benchmark/trex/vinbero_streams.py
@@ -21,7 +21,8 @@ Scenarios (ingress frame the DUT sees):
 
 --size is the ingress wire frame length in bytes (without FCS); frames
 are padded with zero payload up to it. Each scenario has a minimum
-below which the value is clamped up.
+below which the value is clamped up; the effective wire length is what
+gets reported as "size" in the output.
 
 Flow spread: NO STLScVmRaw randomization. TRex's field-engine VM
 re-parses the frame, fails on the SRH (routing type 4), and silently
@@ -114,11 +115,15 @@ def frame(scenario, i, size):
     raise ValueError("unknown scenario: %s" % scenario)
 
 
-def build_streams(scenario, size, per_stream_pps, flows):
+def build_frames(scenario, size, flows):
+    return [frame(scenario, i, size) for i in range(flows)]
+
+
+def build_streams(frames, per_stream_pps):
     return [
-        STLStream(packet=STLPktBuilder(pkt_buffer=frame(scenario, i, size)),
+        STLStream(packet=STLPktBuilder(pkt_buffer=f),
                   mode=STLTXCont(pps=per_stream_pps))
-        for i in range(flows)
+        for f in frames
     ]
 
 
@@ -141,6 +146,15 @@ def main():
                     help="bum only: configured bd peer count, recorded as "
                          "the expected amplification factor")
     args = ap.parse_args()
+    # unwrap() below corrects at most one 2^32 wrap of the 32-bit port
+    # counters; at 64B line rate a second wrap becomes possible past
+    # ~57s, so refuse durations where it would go undetected.
+    if args.duration > 55:
+        sys.exit("--duration > 55 can wrap the 32-bit port counters "
+                 "twice; split into shorter runs")
+
+    frames = build_frames(args.scenario, args.size, args.flows)
+    wire_len = len(frames[0])
 
     c = STLClient(server="127.0.0.1")
     c.connect()
@@ -150,9 +164,7 @@ def main():
     # rate (ignoring the per-stream pps), while "1" honors --pps as-is.
     per_stream = (args.pps or 1e6) / args.flows
     mult = "1" if args.pps else "100%"
-    c.add_streams(build_streams(args.scenario, args.size, per_stream,
-                                args.flows),
-                  ports=[0])
+    c.add_streams(build_streams(frames, per_stream), ports=[0])
     c.clear_stats()
     c.start(ports=[0], mult=mult)
     time.sleep(args.duration)
@@ -166,8 +178,9 @@ def main():
     def unwrap(v):
         # The port counters come from 32-bit hardware registers; when
         # the raw counter crosses 2^32 during the run the delta against
-        # the clear_stats reference goes negative by exactly 2^32. A
-        # 30s run at 100G wraps at most once, so one correction is exact.
+        # the clear_stats reference goes negative by exactly 2^32.
+        # Within the 55s duration cap the counter wraps at most once,
+        # so one correction is exact.
         return v + 2**32 if v < 0 else v
 
     opackets = unwrap(tx.get("opackets", 0))
@@ -175,7 +188,9 @@ def main():
     expected = opackets * (args.peers if args.scenario == "bum" else 1)
     print(json.dumps({
         "scenario":     args.scenario,
-        "size":         args.size,
+        # Effective wire length: pad() only grows frames, so a --size
+        # below the scenario minimum ends up larger than requested.
+        "size":         wire_len,
         "duration_s":   args.duration,
         "peers":        args.peers,
         "flows":        args.flows,
@@ -185,7 +200,10 @@ def main():
         "rx_ibytes":    rx.get("ibytes", 0),
         "tx_mpps":      round(opackets / args.duration / 1e6, 3),
         "rx_mpps":      round(ipackets / args.duration / 1e6, 3),
-        "tx_gbps":      round(tx.get("tx_bps", 0) / 1e9, 3),
+        # tx_bps from get_stats() is an instantaneous rate and reads 0
+        # after stop, so derive the run average from the counters.
+        "tx_gbps":      round(opackets * wire_len * 8
+                              / args.duration / 1e9, 3),
         "loss_pct":     round((1.0 - ipackets / expected) * 100.0, 4)
                         if expected else 0.0,
     }))

--- a/benchmark/trex/vinbero_streams.py
+++ b/benchmark/trex/vinbero_streams.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""TRex stream driver for the Vinbero SRv6 dataplane benchmark.
+
+Runs on the TRex host (lab-kiba-ocxma-trex-01). Transmits on port 0
+toward the DUT ingress NIC and counts what the DUT forwards back into
+port 1, so a single invocation yields offered load, forwarded load,
+and loss for one cell.
+
+Usage:
+  vinbero_streams.py --scenario <name> --duration <sec> [--size N]
+                     [--pps TOTAL] [--peers N]
+
+Scenarios (ingress frame the DUT sees):
+  encaps-v4   Ether/IPv4(dst 10.99.0.0/24)/UDP      -> T.Encaps v4 headend
+  ecmp        same frames as encaps-v4              -> ECMP path-group headend
+  end         Ether/IPv6(dst fc00:a::1)/SRH(SL=1)   -> End transit
+  end-dt4     Ether/IPv6(dst fc00:a::d4)/SRH(SL=0)/IPv4(dst 10.98.0.0/24)/UDP
+                                                    -> End.DT4 decap
+  l2-unicast  Ether(unicast)/Dot1Q(100)/IPv4/UDP    -> H.Encaps.L2 (XDP path)
+  bum         Ether(broadcast)/Dot1Q(100)/IPv4/UDP  -> BUM flood (TC path)
+
+--size is the ingress wire frame length in bytes (without FCS); frames
+are padded with zero payload up to it. Each scenario has a minimum
+below which the value is clamped up.
+
+Flow spread: NO STLScVmRaw randomization. TRex's field-engine VM
+re-parses the frame, fails on the SRH (routing type 4), and silently
+truncates it. Every scenario instead emits N_FLOWS static streams with
+distinct source addresses/MACs, which spreads RSS on the DUT. SRH is
+raw bytes; all packets go in via pkt_buffer.
+
+Output: one JSON line with tx (port 0) and rx (port 1) counters plus
+loss. For the bum scenario pass --peers so the expected amplification
+factor is recorded alongside.
+"""
+import argparse
+import json
+import socket
+import struct
+import sys
+import time
+
+sys.path.insert(
+    0, "/opt/trex/v3.08/scripts/automation/trex_control_plane/interactive")
+from trex.stl.api import (  # noqa: E402
+    Dot1Q, Ether, IP, IPv6, STLClient, STLPktBuilder, STLStream, STLTXCont,
+    UDP)
+
+SRC_MAC = "40:a6:b7:82:cd:d8"   # TRex port 0
+DST_MAC = "40:a6:b7:95:a2:d0"   # DUT enp138s0f0
+
+SID_END = "fc00:a::1"
+SID_DT4 = "fc00:a::d4"
+SEG_REMOTE = "fd00:c::1"
+VLAN_ID = 100
+
+N_FLOWS = 32
+
+
+def ip6(a):
+    return socket.inet_pton(socket.AF_INET6, a)
+
+
+def srh_bytes(segs, segments_left, nh):
+    # RFC 8754 SRH: nh, hdr_ext_len (8B units excl. first 8), routing
+    # type 4, segments_left, last_entry, flags, tag, then 16B segments.
+    body = b"".join(ip6(s) for s in segs)
+    return struct.pack("!BBBBBBH", nh, len(body) // 8, 4, segments_left,
+                       len(segs) - 1, 0, 0) + body
+
+
+def pad(frame, size):
+    return frame + b"\x00" * (size - len(frame)) if size > len(frame) else frame
+
+
+def frame(scenario, i, size):
+    src4 = "10.%d.0.2" % (8 + i)
+    if scenario in ("encaps-v4", "ecmp"):
+        return pad(bytes(
+            Ether(src=SRC_MAC, dst=DST_MAC)
+            / IP(src=src4, dst="10.99.0.%d" % (1 + i % 250))
+            / UDP(sport=12345 + i, dport=9)), size)
+    if scenario == "end":
+        # DA = local End SID, SL=1 -> after End the DA becomes SEG_REMOTE
+        # and the packet is routed out the egress port.
+        udp = bytes(UDP(sport=12345 + i, dport=9))
+        srh = srh_bytes([SEG_REMOTE, SID_END], segments_left=1, nh=17)
+        inner_len = max(size - 14 - 40 - len(srh) - len(udp), 0)
+        payload = b"\x00" * inner_len
+        hdr = bytes(Ether(src=SRC_MAC, dst=DST_MAC)
+                    / IPv6(src="2001:db8::%x:2" % i, dst=SID_END, nh=43,
+                           plen=len(srh) + len(udp) + inner_len))
+        return hdr + srh + udp + payload
+    if scenario == "end-dt4":
+        # DA = local End.DT4 SID, SL=0 -> decap, inner IPv4 is looked up
+        # in the VRF table and routed out the egress port.
+        srh = srh_bytes([SID_DT4], segments_left=0, nh=4)
+        pad_len = max(size - 14 - 40 - len(srh) - 20 - 8, 0)
+        inner = bytes(IP(src=src4, dst="10.98.0.%d" % (1 + i % 250))
+                      / UDP(sport=12345 + i, dport=9)
+                      / (b"\x00" * pad_len))
+        hdr = bytes(Ether(src=SRC_MAC, dst=DST_MAC)
+                    / IPv6(src="2001:db8::%x:2" % i, dst=SID_DT4, nh=43,
+                           plen=len(srh) + len(inner)))
+        return hdr + srh + inner
+    if scenario in ("l2-unicast", "bum"):
+        dst = "02:aa:00:00:00:01" if scenario == "l2-unicast" \
+            else "ff:ff:ff:ff:ff:ff"
+        return pad(bytes(
+            Ether(src="02:bb:00:00:%02x:%02x" % (i >> 8, i & 0xFF), dst=dst)
+            / Dot1Q(vlan=VLAN_ID)
+            / IP(src=src4, dst="10.97.0.1")
+            / UDP(sport=12345 + i, dport=9)), size)
+    raise ValueError("unknown scenario: %s" % scenario)
+
+
+def build_streams(scenario, size, per_stream_pps):
+    return [
+        STLStream(packet=STLPktBuilder(pkt_buffer=frame(scenario, i, size)),
+                  mode=STLTXCont(pps=per_stream_pps))
+        for i in range(N_FLOWS)
+    ]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--scenario", required=True,
+                    choices=["encaps-v4", "ecmp", "end", "end-dt4",
+                             "l2-unicast", "bum"])
+    ap.add_argument("--duration", type=int, required=True)
+    ap.add_argument("--size", type=int, default=64,
+                    help="ingress wire frame length in bytes (clamped up "
+                         "to the scenario minimum)")
+    ap.add_argument("--pps", type=float, default=0,
+                    help="total offered pps across all flows; 0 (default) "
+                         "offers 100%% of line rate")
+    ap.add_argument("--peers", type=int, default=1,
+                    help="bum only: configured bd peer count, recorded as "
+                         "the expected amplification factor")
+    args = ap.parse_args()
+
+    c = STLClient(server="127.0.0.1")
+    c.connect()
+    c.acquire(ports=[0, 1], force=True)
+    c.reset(ports=[0, 1])
+    # mult scales the stream pps: "100%" normalizes the total to line
+    # rate (ignoring the per-stream pps), while "1" honors --pps as-is.
+    per_stream = (args.pps or 1e6) / N_FLOWS
+    mult = "1" if args.pps else "100%"
+    c.add_streams(build_streams(args.scenario, args.size, per_stream),
+                  ports=[0])
+    c.clear_stats()
+    c.start(ports=[0], mult=mult)
+    time.sleep(args.duration)
+    c.stop(ports=[0])
+    # Let in-flight frames drain into port 1 before the final read.
+    time.sleep(1)
+    stats = c.get_stats()
+    tx = stats[0]
+    rx = stats[1]
+
+    opackets = tx.get("opackets", 0)
+    ipackets = rx.get("ipackets", 0)
+    expected = opackets * (args.peers if args.scenario == "bum" else 1)
+    print(json.dumps({
+        "scenario":     args.scenario,
+        "size":         args.size,
+        "duration_s":   args.duration,
+        "peers":        args.peers,
+        "tx_opackets":  opackets,
+        "tx_oerrors":   tx.get("oerrors", 0),
+        "rx_ipackets":  ipackets,
+        "rx_ibytes":    rx.get("ibytes", 0),
+        "tx_mpps":      round(opackets / args.duration / 1e6, 3),
+        "rx_mpps":      round(ipackets / args.duration / 1e6, 3),
+        "tx_gbps":      round(tx.get("tx_bps", 0) / 1e9, 3),
+        "loss_pct":     round((1.0 - ipackets / expected) * 100.0, 4)
+                        if expected else 0.0,
+    }))
+    c.release(ports=[0, 1])
+    c.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/trex/vinbero_streams.py
+++ b/benchmark/trex/vinbero_streams.py
@@ -149,31 +149,39 @@ def main():
     # unwrap() below corrects at most one 2^32 wrap of the 32-bit port
     # counters; at 64B line rate a second wrap becomes possible past
     # ~57s, so refuse durations where it would go undetected.
-    if args.duration > 55:
-        sys.exit("--duration > 55 can wrap the 32-bit port counters "
-                 "twice; split into shorter runs")
+    if not 0 < args.duration <= 55:
+        sys.exit("--duration must be 1..55: longer runs can wrap the "
+                 "32-bit port counters twice; split into shorter runs")
 
     frames = build_frames(args.scenario, args.size, args.flows)
     wire_len = len(frames[0])
 
     c = STLClient(server="127.0.0.1")
     c.connect()
-    c.acquire(ports=[0, 1], force=True)
-    c.reset(ports=[0, 1])
-    # mult scales the stream pps: "100%" normalizes the total to line
-    # rate (ignoring the per-stream pps), while "1" honors --pps as-is.
-    per_stream = (args.pps or 1e6) / args.flows
-    mult = "1" if args.pps else "100%"
-    c.add_streams(build_streams(frames, per_stream), ports=[0])
-    c.clear_stats()
-    c.start(ports=[0], mult=mult)
-    time.sleep(args.duration)
-    c.stop(ports=[0])
-    # Let in-flight frames drain into port 1 before the final read.
-    time.sleep(1)
-    stats = c.get_stats()
-    tx = stats[0]
-    rx = stats[1]
+    try:
+        c.acquire(ports=[0, 1], force=True)
+        c.reset(ports=[0, 1])
+        # mult scales the stream pps: "100%" normalizes the total to line
+        # rate (ignoring the per-stream pps), while "1" honors --pps as-is.
+        per_stream = (args.pps or 1e6) / args.flows
+        mult = "1" if args.pps else "100%"
+        c.add_streams(build_streams(frames, per_stream), ports=[0])
+        c.clear_stats()
+        c.start(ports=[0], mult=mult)
+        time.sleep(args.duration)
+        c.stop(ports=[0])
+        # Let in-flight frames drain into port 1 before the final read.
+        time.sleep(1)
+        stats = c.get_stats()
+        tx = stats[0]
+        rx = stats[1]
+    finally:
+        # An exception mid-run must not leave line-rate traffic running
+        # or the ports acquired. stop() on an already-stopped port is a
+        # no-op.
+        c.stop(ports=[0])
+        c.release(ports=[0, 1])
+        c.disconnect()
 
     def unwrap(v):
         # The port counters come from 32-bit hardware registers; when
@@ -207,8 +215,6 @@ def main():
         "loss_pct":     round((1.0 - ipackets / expected) * 100.0, 4)
                         if expected else 0.0,
     }))
-    c.release(ports=[0, 1])
-    c.disconnect()
 
 
 if __name__ == "__main__":

--- a/benchmark/trex/vinbero_streams.py
+++ b/benchmark/trex/vinbero_streams.py
@@ -152,6 +152,8 @@ def main():
     if not 0 < args.duration <= 55:
         sys.exit("--duration must be 1..55: longer runs can wrap the "
                  "32-bit port counters twice; split into shorter runs")
+    if args.flows < 1 or args.pps < 0 or args.peers < 1:
+        sys.exit("--flows and --peers must be >= 1, --pps >= 0")
 
     frames = build_frames(args.scenario, args.size, args.flows)
     wire_len = len(frames[0])

--- a/benchmark/trex/vinbero_streams.py
+++ b/benchmark/trex/vinbero_streams.py
@@ -84,14 +84,21 @@ def frame(scenario, i, size):
     if scenario == "end":
         # DA = local End SID, SL=1 -> after End the DA becomes SEG_REMOTE
         # and the packet is routed out the egress port.
-        udp = bytes(UDP(sport=12345 + i, dport=9))
+        src6 = "2001:db8::%x:2" % i
         srh = srh_bytes([SEG_REMOTE, SID_END], segments_left=1, nh=17)
-        inner_len = max(size - 14 - 40 - len(srh) - len(udp), 0)
-        payload = b"\x00" * inner_len
+        inner_len = max(size - 14 - 40 - len(srh) - 8, 0)
+        # Serialize the UDP datagram with its payload under an IPv6
+        # header whose dst is the final destination (RFC 8200: with a
+        # routing header the pseudo-header uses the last segment), so
+        # scapy fills in the correct length and checksum. Strip the
+        # 40-byte throwaway IPv6 header afterwards.
+        udp = bytes(IPv6(src=src6, dst=SEG_REMOTE)
+                    / UDP(sport=12345 + i, dport=9)
+                    / (b"\x00" * inner_len))[40:]
         hdr = bytes(Ether(src=SRC_MAC, dst=DST_MAC)
-                    / IPv6(src="2001:db8::%x:2" % i, dst=SID_END, nh=43,
-                           plen=len(srh) + len(udp) + inner_len))
-        return hdr + srh + udp + payload
+                    / IPv6(src=src6, dst=SID_END, nh=43,
+                           plen=len(srh) + len(udp)))
+        return hdr + srh + udp
     if scenario == "end-dt4":
         # DA = local End.DT4 SID, SL=0 -> decap, inner IPv4 is looked up
         # in the VRF table and routed out the egress port.

--- a/benchmark/trex/vinbero_streams.py
+++ b/benchmark/trex/vinbero_streams.py
@@ -159,8 +159,15 @@ def main():
     tx = stats[0]
     rx = stats[1]
 
-    opackets = tx.get("opackets", 0)
-    ipackets = rx.get("ipackets", 0)
+    def unwrap(v):
+        # The port counters come from 32-bit hardware registers; when
+        # the raw counter crosses 2^32 during the run the delta against
+        # the clear_stats reference goes negative by exactly 2^32. A
+        # 30s run at 100G wraps at most once, so one correction is exact.
+        return v + 2**32 if v < 0 else v
+
+    opackets = unwrap(tx.get("opackets", 0))
+    ipackets = unwrap(rx.get("ipackets", 0))
     expected = opackets * (args.peers if args.scenario == "bum" else 1)
     print(json.dumps({
         "scenario":     args.scenario,


### PR DESCRIPTION
## Summary

Adds `benchmark/`, a load-test harness that drives real 100G traffic from a TRex hardware traffic generator against a Vinbero DUT and measures SRv6 forwarding performance.

The setup is a snake topology: TRex port 0 sends into the DUT ingress NIC, Vinbero processes the packet in XDP (or TC for BUM) and redirects it out the egress NIC back to TRex port 1. Port 0 `opackets` is the offered load, port 1 `ipackets` is the forwarded load, and the difference is loss. Each run sweeps frame sizes at a fixed offered load and writes per-rep CSVs to `benchmark/results/`.

## What is measured

| scenario | path under test | ingress frame |
|---|---|---|
| `encaps-v4` | T.Encaps v4 headend (XDP) | IPv4/UDP |
| `ecmp` | headend through an ECMP path group | IPv4/UDP (same as encaps-v4) |
| `end` | End transit (XDP) | IPv6 + SRH (SL=1) |
| `end-dt4` | End.DT4 decap + VRF lookup (XDP) | IPv6 + SRH (SL=0) + inner IPv4 |
| `l2-unicast` | H.Encaps.L2 (XDP) | VLAN-tagged L2 unicast frame |
| `bum` | BUM flood (TC clone-to-self) | VLAN-tagged L2 broadcast frame |

`ecmp` vs `encaps-v4` isolates the cost of the ECMP hot path (group/live/path map lookups plus weighted selection). For `bum`, output is amplified by the number of registered bd peers, so loss is computed against `tx_opackets * N`.

## Contents

- `pipelines/setup_dut.sh` / `teardown_dut.sh`: NIC prep, vinberod startup, and map entry provisioning per scenario
- `pipelines/run_bench.sh`: frame-size sweep x repetitions, driven over ssh against the TRex stateless daemon
- `pipelines/tune_dut.sh`: optional RX queue to physical core 1:1 pinning (about 10% higher aggregate throughput); must run before XDP attach
- `trex/vinbero_streams.py`: stream definitions with selectable flow count to control RSS spread, and 32-bit port counter unwrapping for long runs
- `analysis/stats.py`: aggregates per-rep CSVs
- `README.md`: topology, prerequisites, and usage

## Notes

- ice driver-mode XDP caps MTU at about 3050 for non multi-buffer programs, so setup pins MTU to 3000; ingress frames stay under 1500B after encap.
- NIC MAC/IP constants live in both `pipelines/common.sh` and `trex/vinbero_streams.py` and must be kept in sync when hardware changes.
