### PR TITLE
fix(cplane): decap-grant の VRF 削除 TOCTOU を共有 leaf lease で閉じる

### DIFF
--- a/cmd/vinberod/main.go
+++ b/cmd/vinberod/main.go
@@ -488,7 +488,7 @@ func run(cliCtx *cli.Context) error {
 				return v.Device.Ifindex, nil
 			},
 			EncapSource: applier.EncapSourceAddr,
-			Store:        cplaneStore,
+			Store:       cplaneStore,
 			// What a plugin's scope is stated in terms of. Both are
 			// consulted when a declaration is applied rather than now,
 			// because an operator registers locators and VRF bindings

--- a/cmd/vinberod/main.go
+++ b/cmd/vinberod/main.go
@@ -468,6 +468,23 @@ func run(cliCtx *cli.Context) error {
 				if !ok || v.Device == nil || v.Device.Ifindex == 0 {
 					return 0, fmt.Errorf("vrf %q has no L3 device ifindex", vrfName)
 				}
+				// The manager can be momentarily ahead of the kernel: a
+				// VrfDelete whose netlink teardown succeeded but whose state
+				// persist failed keeps the manager entry while the ifindex is
+				// already freed. This resolve runs under the decap-grant lease,
+				// after any such teardown completed, so reading the kernel here
+				// is what keeps a grant from being minted against that stale
+				// record: the name no longer resolves, or resolves to a
+				// different (recreated) ifindex, and either way the install is
+				// refused rather than granted a dead number.
+				kernelIdx, err := vrf.ResolveByName(vrfName)
+				if err != nil {
+					return 0, fmt.Errorf("vrf %q: kernel device lookup: %w", vrfName, err)
+				}
+				if kernelIdx != v.Device.Ifindex {
+					return 0, fmt.Errorf("vrf %q: kernel ifindex %d does not match managed ifindex %d",
+						vrfName, kernelIdx, v.Device.Ifindex)
+				}
 				return v.Device.Ifindex, nil
 			},
 			EncapSource: applier.EncapSourceAddr,

--- a/docs/design/ja/cplane-plugin.md
+++ b/docs/design/ja/cplane-plugin.md
@@ -391,6 +391,16 @@ domain へ転送しうる曖昧な挙動なので、fail-closed にします。p
 強く grant を偽造できません。decap_vrf は plugin の scope の VRF 集合に含まれること
 (advertise と同じ集合) を host が確かめます。
 
+grant の書き込みと VRF 削除は 1 本の leaf lock を共有します。plugin の local SID
+install は VRF 名を ifindex へ解決してから grant を書くまでこの lock を持ち、VrfDelete
+は grant 参照チェックから kernel device teardown までを同じ lock で囲みます。これで grant
+が解放中の ifindex を指すことがなくなります。install が先なら VrfDelete のチェックが
+grant を見て削除を拒み、VrfDelete が先なら device が消えて install の解決が失敗します。
+この lock は最内側でだけ取り、内側では VRF manager 自身の lock と BPF map しか触らないので
+applyMu や VRF mutation mutex と deadlock しません。VrfDelete が applyMu を取り install が
+VRF mutation mutex を取るという逆順が無いため、両者を直接共有すると deadlock する一方で、
+専用の leaf lock なら安全に閉じられます。
+
 この判別は `tailcall_ctx_map` の `sid_entry.action` を読むので、plugin がその map を
 書けると action を偽造して判別を欺けます。共有 map は MapReplacements で plugin に
 渡す都合上 kernel から見れば RW で、`tailcall_ctx_map` は vinbero 自身が packet ごと

--- a/docs/design/ja/cplane-plugin.md
+++ b/docs/design/ja/cplane-plugin.md
@@ -403,6 +403,15 @@ applyMu や VRF mutation mutex と deadlock しません。VRF mutation mutex �
 mutation mutex を取る (applyMu から mutation mutex) ので、この 2 経路が逆順になるからです。
 VrfDelete 自身は applyMu を取りませんが mutation mutex を binding 側と共有するため、流用すれば
 同じ輪に巻き込まれます。専用の leaf lock はこの逆転に関与しないので安全に閉じられます。
+install 側の resolve は manager の記録に加えて kernel の device 実在も照合します。teardown が
+netlink まで済んで state の persist だけ失敗した VrfDelete は error を返して manager に旧記録を
+残すので、manager だけを信じると解放済み ifindex へ grant を書けてしまうためです。
+
+この lock が閉じるのは 1 つの daemon run の中の窓です。daemon 再起動をまたぐと pinned map の
+grant は残り、再起動後に VRF device が作り直されて ifindex が変わっていれば古い grant は stale な
+番号を指します。これは owner plugin の最初の Apply の sweep で dispatch entry ごと回収されるまで
+続き、その間は ifindex-keyed な参照が持つ従来どおりの残余 (dead ifindex への fib-lookup miss で
+drop) に留まります。起動時に grant map を kernel と突き合わせて刈る reconcile は今後の課題です。
 
 この判別は `tailcall_ctx_map` の `sid_entry.action` を読むので、plugin がその map を
 書けると action を偽造して判別を欺けます。共有 map は MapReplacements で plugin に

--- a/docs/design/ja/cplane-plugin.md
+++ b/docs/design/ja/cplane-plugin.md
@@ -397,9 +397,12 @@ install は VRF 名を ifindex へ解決してから grant を書くまでこの
 が解放中の ifindex を指すことがなくなります。install が先なら VrfDelete のチェックが
 grant を見て削除を拒み、VrfDelete が先なら device が消えて install の解決が失敗します。
 この lock は最内側でだけ取り、内側では VRF manager 自身の lock と BPF map しか触らないので
-applyMu や VRF mutation mutex と deadlock しません。VrfDelete が applyMu を取り install が
-VRF mutation mutex を取るという逆順が無いため、両者を直接共有すると deadlock する一方で、
-専用の leaf lock なら安全に閉じられます。
+applyMu や VRF mutation mutex と deadlock しません。VRF mutation mutex をそのまま grant lock に
+流用すると deadlock します。binding 更新は mutation mutex を持ったまま `ReconcileAdvertised`
+で applyMu を取り (mutation mutex から applyMu)、plugin install は applyMu を持ったまま
+mutation mutex を取る (applyMu から mutation mutex) ので、この 2 経路が逆順になるからです。
+VrfDelete 自身は applyMu を取りませんが mutation mutex を binding 側と共有するため、流用すれば
+同じ輪に巻き込まれます。専用の leaf lock はこの逆転に関与しないので安全に閉じられます。
 
 この判別は `tailcall_ctx_map` の `sid_entry.action` を読むので、plugin がその map を
 書けると action を偽造して判別を欺けます。共有 map は MapReplacements で plugin に

--- a/pkg/bpf/maps.go
+++ b/pkg/bpf/maps.go
@@ -1304,60 +1304,6 @@ func (m *MapOperations) EndtVRFGrantReferences(vrfIfindex uint32) (uint32, bool,
 	return 0, false, nil
 }
 
-// DeleteEndtVRFGrantsByIfindex removes every grant pointing at vrfIfindex and
-// returns how many it removed. It is the VRF-delete backstop: the pre-delete
-// EndtVRFGrantReferences check refuses while a grant is live, but a grant that
-// a concurrent install writes between that check and the device teardown would
-// otherwise dangle at a freed ifindex. Sweeping after the device is gone -- at
-// which point resolving the VRF fails, so no further grant can be written for
-// it -- makes any grant that raced the check fail closed on a dead ifindex
-// rather than following the number to a different device.
-func (m *MapOperations) DeleteEndtVRFGrantsByIfindex(vrfIfindex uint32) (int, error) {
-	if vrfIfindex == 0 {
-		return 0, nil
-	}
-	var (
-		auxIndex uint32
-		val      BpfPluginEndtVrf
-		stale    []uint32
-	)
-	iter := m.objs.PluginEndtVrfMap.Iterate()
-	for iter.Next(&auxIndex, &val) {
-		if val.VrfIfindex == vrfIfindex {
-			stale = append(stale, auxIndex)
-		}
-	}
-	if err := iter.Err(); err != nil {
-		return 0, fmt.Errorf("iterate endt vrf grants: %w", err)
-	}
-	removed := 0
-	for _, idx := range stale {
-		// Re-read and compare before deleting. Between the scan and here the
-		// index could have been freed and reused for a grant pointing at a
-		// different (live) VRF; deleting it by key alone would then break that
-		// legitimate grant. Delete only while it still points at the ifindex
-		// being torn down. The lookup and the delete are not atomic -- BPF maps
-		// have no compare-and-delete -- so this narrows the window rather than
-		// closing it; a full close needs the sweep and the install to share a
-		// lock.
-		var cur BpfPluginEndtVrf
-		if err := m.objs.PluginEndtVrfMap.Lookup(idx, &cur); err != nil {
-			if errors.Is(err, ebpf.ErrKeyNotExist) {
-				continue
-			}
-			return removed, fmt.Errorf("re-read endt vrf grant %d: %w", idx, err)
-		}
-		if cur.VrfIfindex != vrfIfindex {
-			continue
-		}
-		if err := m.DeleteEndtVRFGrant(idx); err != nil {
-			return removed, err
-		}
-		removed++
-	}
-	return removed, nil
-}
-
 // DeleteEndtVRFGrant removes the grant for auxIndex. A missing key is not an
 // error: the caller deletes the grant before it frees the aux index, so a
 // re-run over a set that never carried a grant is a no-op.

--- a/pkg/bpf/xdp_test.go
+++ b/pkg/bpf/xdp_test.go
@@ -4199,11 +4199,10 @@ func TestXDPProgPluginEndDT4VrfGrant(t *testing.T) {
 	}
 }
 
-// TestEndtVRFGrantReferencesAndSweep exercises the grant map's reference lookup
-// and ifindex sweep against a real BPF map. The VRF-delete guard and its
-// post-teardown sweep drive these; the server unit test reimplements them in a
-// fake, so the actual iteration and value-compare have no coverage there.
-func TestEndtVRFGrantReferencesAndSweep(t *testing.T) {
+// TestEndtVRFGrantReferences exercises the grant map's reference lookup against
+// a real BPF map: the VRF-delete guard drives it, and the server unit test
+// reimplements it in a fake, so the actual iteration has no coverage there.
+func TestEndtVRFGrantReferences(t *testing.T) {
 	h := newXDPTestHelper(t)
 	m := h.mapOps
 
@@ -4225,25 +4224,16 @@ func TestEndtVRFGrantReferencesAndSweep(t *testing.T) {
 		t.Fatalf("EndtVRFGrantReferences(9) = (_, %v, %v), want no reference", ok, err)
 	}
 
-	// Sweeping ifindex 5 removes exactly the two grants pointing at it, and
-	// re-reads each index before deleting so a value that no longer matches is
-	// left alone; the ifindex-7 grant survives.
-	removed, err := m.DeleteEndtVRFGrantsByIfindex(5)
-	if err != nil || removed != 2 {
-		t.Fatalf("DeleteEndtVRFGrantsByIfindex(5) = (%d, %v), want (2, nil)", removed, err)
-	}
-	if _, ok, _ := m.EndtVRFGrantReferences(5); ok {
-		t.Fatal("ifindex 5 grants survived the sweep")
-	}
-	if _, ok, _ := m.EndtVRFGrantReferences(7); !ok {
-		t.Fatal("the sweep of ifindex 5 wrongly removed the ifindex-7 grant")
-	}
-	// The sweep is idempotent and a missing-key delete is not an error.
-	if removed, err := m.DeleteEndtVRFGrantsByIfindex(5); err != nil || removed != 0 {
-		t.Fatalf("second sweep = (%d, %v), want (0, nil)", removed, err)
+	// Deleting a grant by its aux index drops just that one; a missing key is
+	// not an error.
+	if err := m.DeleteEndtVRFGrant(1); err != nil {
+		t.Fatalf("DeleteEndtVRFGrant(1): %v", err)
 	}
 	if err := m.DeleteEndtVRFGrant(999); err != nil {
 		t.Fatalf("DeleteEndtVRFGrant of a missing key must be nil, got %v", err)
+	}
+	if _, ok, _ := m.EndtVRFGrantReferences(7); !ok {
+		t.Fatal("deleting the ifindex-5 grant wrongly removed the ifindex-7 grant")
 	}
 }
 

--- a/pkg/cplane/localsid.go
+++ b/pkg/cplane/localsid.go
@@ -132,6 +132,18 @@ type LocalSIDSet struct {
 	// resolveVRF turns a VRF name into the kernel ifindex the grant records.
 	// Nil is the same as a daemon that cannot serve a DecapVRF SID.
 	resolveVRF func(vrfName string) (uint32, error)
+	// grantLease serializes a decap-grant install (resolve the VRF ifindex,
+	// then write the grant) against VrfDelete's grant-reference check and
+	// device teardown. Held only for a DecapVRF SID, and only across those two
+	// steps, it makes the two orderings clean: either the grant is written
+	// before VrfDelete's check (which then refuses) or the VRF is already gone
+	// when install resolves (which then fails), so a grant can never be written
+	// for an ifindex being freed. VrfServer takes the same lease. Nil leaves
+	// the install unserialized -- the daemon shares one across both, tests pass
+	// nil and run single-threaded. It is a leaf: nothing else is acquired while
+	// it is held except the VRF manager's own lock and the BPF map, so it
+	// cannot deadlock with applyMu or the VRF mutation mutex.
+	grantLease *sync.Mutex
 
 	mu sync.Mutex
 	// live maps owner -> name -> what was allocated for it.
@@ -503,6 +515,16 @@ func (l *LocalSIDSet) install(owner bpf.OwnerTag, sid netip.Addr, want LocalSID)
 			return 0, fmt.Errorf("local sid %q: declares decap VRF %q, but this daemon cannot grant one",
 				want.Name, want.DecapVRF)
 		}
+		// Hold the grant lease across the resolve and the PutEndtVRFGrant below
+		// (and the CreateSidFunction between them). VrfDelete takes the same
+		// lease across its grant-reference check and device teardown, so the
+		// resolve here cannot observe a live VRF that a delete then tears down
+		// before this install writes the grant: either the grant lands first
+		// and the delete refuses, or the delete wins and this resolve fails.
+		if l.grantLease != nil {
+			l.grantLease.Lock()
+			defer l.grantLease.Unlock()
+		}
 		idx, err := l.resolveVRF(want.DecapVRF)
 		if err != nil {
 			return 0, fmt.Errorf("local sid %q: resolve decap VRF %q: %w", want.Name, want.DecapVRF, err)
@@ -523,17 +545,12 @@ func (l *LocalSIDSet) install(owner bpf.OwnerTag, sid netip.Addr, want LocalSID)
 		return 0, fmt.Errorf("local sid %q: install %s: %w", want.Name, prefix, err)
 	}
 	if want.DecapVRF != "" {
-		// The ifindex resolved above and written here is not serialized against
-		// a concurrent VrfDelete. If the VRF is deleted between the resolve and
-		// this write, the grant records a freed ifindex. VrfDelete refuses while
-		// a grant is live and sweeps the ifindex after teardown, so a grant that
-		// raced that far ends up on a dead ifindex and fails closed (fib-lookup
-		// miss -> drop) -- the same property every ifindex-keyed VRF reference
-		// in the tree has, since Linux does not promptly reuse an ifindex. A
-		// full close (so a grant can never outlive its VRF even for an instant)
-		// would need this resolve+Put and VrfDelete's check+teardown to share a
-		// leaf lease acquired under applyMu / the VRF mutation mutex; that is
-		// left out here rather than plumbed across the cplane/server boundary.
+		// The resolve above and this write are inside the grant lease taken at
+		// the top of this branch, and VrfDelete takes the same lease across its
+		// grant-reference check and device teardown, so the grant can never
+		// record an ifindex that a concurrent delete is in the middle of
+		// freeing. Outside a lease (grantLease nil, e.g. a test) this is the
+		// same ifindex-keyed reference every VRF facet uses.
 		if err := l.grants.PutEndtVRFGrant(uint32(entry.AuxIndex), vrfIfindex); err != nil {
 			// Undo the dispatch entry so nothing is left pointing at a decap
 			// with no grant, which the data plane would drop on. If the undo

--- a/pkg/cplane/localsid_test.go
+++ b/pkg/cplane/localsid_test.go
@@ -168,10 +168,11 @@ func (f *fakeSIDOps) entryFor(prefix string) (*bpf.SidFunctionEntry, bool) {
 // fakeGrantOps records the decap-VRF grants a reconcile writes, keyed by the
 // dispatch entry's aux index.
 type fakeGrantOps struct {
-	mu     sync.Mutex
-	grants map[uint32]uint32 // auxIndex -> vrfIfindex
-	putErr error             // when set, PutEndtVRFGrant fails
-	ops    []string
+	mu      sync.Mutex
+	grants  map[uint32]uint32 // auxIndex -> vrfIfindex
+	putErr  error             // when set, PutEndtVRFGrant fails
+	putHook func()            // when set, runs inside PutEndtVRFGrant before the write
+	ops     []string
 }
 
 func newFakeGrantOps() *fakeGrantOps {
@@ -179,6 +180,9 @@ func newFakeGrantOps() *fakeGrantOps {
 }
 
 func (f *fakeGrantOps) PutEndtVRFGrant(auxIndex, vrfIfindex uint32) error {
+	if f.putHook != nil {
+		f.putHook()
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.putErr != nil {
@@ -266,6 +270,16 @@ func TestLocalSIDDecapVRFGrantHeldDuringResolve(t *testing.T) {
 		}
 		return 42, nil
 	}
+	// The lease must also be held through the grant write, not just the
+	// resolve: unlocking in between would reopen the very window this closes.
+	putHooked := false
+	grants.putHook = func() {
+		putHooked = true
+		if lease.TryLock() {
+			lease.Unlock()
+			t.Error("grant lease was not held while install wrote the grant")
+		}
+	}
 	set := NewLocalSIDSet(alloc, sids, grants, resolve)
 	set.grantLease = &lease
 	owner := bpf.OwnerTag("plugin:demo")
@@ -277,6 +291,9 @@ func TestLocalSIDDecapVRFGrantHeldDuringResolve(t *testing.T) {
 	}
 	if !resolveCalled {
 		t.Fatal("resolver never ran")
+	}
+	if !putHooked {
+		t.Fatal("grant write never ran")
 	}
 	// The lease is released once install returns.
 	if !lease.TryLock() {

--- a/pkg/cplane/localsid_test.go
+++ b/pkg/cplane/localsid_test.go
@@ -248,6 +248,43 @@ func TestLocalSIDDecapVRFGrant(t *testing.T) {
 	}
 }
 
+// The grant lease is held across the resolve and the grant write, so a
+// concurrent VrfDelete taking the same lock cannot free the ifindex between
+// them. The resolver runs inside install's critical section, so a TryLock of
+// the shared lease from there must fail.
+func TestLocalSIDDecapVRFGrantHeldDuringResolve(t *testing.T) {
+	alloc := &fakeAllocator{}
+	sids := newFakeSIDOps()
+	grants := newFakeGrantOps()
+	var lease sync.Mutex
+	resolveCalled := false
+	resolve := func(string) (uint32, error) {
+		resolveCalled = true
+		if lease.TryLock() {
+			lease.Unlock()
+			t.Error("grant lease was not held while install resolved the VRF")
+		}
+		return 42, nil
+	}
+	set := NewLocalSIDSet(alloc, sids, grants, resolve)
+	set.grantLease = &lease
+	owner := bpf.OwnerTag("plugin:demo")
+
+	if _, _, err := set.Apply(owner, []LocalSID{{
+		Name: "a", Locator: "main", Slot: 32, DecapVRF: "vrf-cust",
+	}}, -1); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !resolveCalled {
+		t.Fatal("resolver never ran")
+	}
+	// The lease is released once install returns.
+	if !lease.TryLock() {
+		t.Fatal("grant lease still held after install returned")
+	}
+	lease.Unlock()
+}
+
 // A redeclaration that does not change the decap VRF rewrites nothing, so no
 // aux index leaks and the grant stays put.
 func TestLocalSIDDecapVRFIdempotent(t *testing.T) {

--- a/pkg/cplane/manager.go
+++ b/pkg/cplane/manager.go
@@ -152,6 +152,12 @@ type Manager struct {
 
 	// applyMu serializes reconciles across every plugin this manager runs.
 	applyMu sync.Mutex
+	// endtVRFGrantLease serializes a plugin's decap-grant install against a
+	// concurrent VrfDelete. The LocalSIDSet holds it while resolving a VRF and
+	// writing the grant; VrfServer takes the same instance while checking for
+	// grants and tearing the device down. It is exposed so the server can wire
+	// it into the VRF handler. It is a leaf lock (see LocalSIDSet.grantLease).
+	endtVRFGrantLease sync.Mutex
 	// registerMu serializes registration against unregistration.
 	//
 	// The two touch the same owner tag from opposite ends: unregister
@@ -270,7 +276,7 @@ func NewManager(cfg ManagerConfig) (*Manager, error) {
 	}
 	leases := NewLeases()
 	snapshots, _ := cfg.Source.(SnapshotSource)
-	return &Manager{
+	m := &Manager{
 		advertise:   newNamedAdvertiseSet(cfg, leases),
 		localSIDs:   NewLocalSIDSet(cfg.Locators, cfg.SIDFunctions, cfg.EndtVRFGrants, cfg.ResolveVRF),
 		source:      cfg.Source,
@@ -288,7 +294,18 @@ func NewManager(cfg ManagerConfig) (*Manager, error) {
 		started:     time.Now(),
 		plugins:     make(map[string]*plugin),
 		unrestored:  make(map[string]UnrestoredPlugin),
-	}, nil
+	}
+	// Share the grant lease with the local-SID tracker so install serializes
+	// against VrfDelete on the same lock the server also takes.
+	m.localSIDs.grantLease = &m.endtVRFGrantLease
+	return m, nil
+}
+
+// EndtVRFGrantLease is the lock a plugin's decap-grant install and a VrfDelete
+// share so a grant can never be written for an ifindex being freed. The server
+// wires it into the VRF delete handler.
+func (m *Manager) EndtVRFGrantLease() *sync.Mutex {
+	return &m.endtVRFGrantLease
 }
 
 // newNamedAdvertiseSet builds the advertise tracker, naming each owner's

--- a/pkg/cplane/manager_test.go
+++ b/pkg/cplane/manager_test.go
@@ -428,6 +428,20 @@ func newTestManager(t *testing.T, src EventSource, claims BehaviorClaims) (*Mana
 	return m, ops
 }
 
+// The lease the manager exposes for the server's VrfDelete must be the very
+// mutex the local-SID installer holds across its resolve+grant-write --
+// otherwise the two sides would serialize on different locks and the
+// VRF-delete window would silently reopen.
+func TestEndtVRFGrantLeaseIsTheInstallLease(t *testing.T) {
+	m, _ := newTestManager(t, newFakeSource(), newFakeClaims())
+	if m.EndtVRFGrantLease() != m.localSIDs.grantLease {
+		t.Fatal("EndtVRFGrantLease and the local-SID install lease are different mutexes")
+	}
+	if m.EndtVRFGrantLease() == nil {
+		t.Fatal("the manager must always carry a grant lease")
+	}
+}
+
 func TestRegisterRunsPluginAndDeliversEvents(t *testing.T) {
 	src := newFakeSource()
 	m, ops := newTestManager(t, src, newFakeClaims())

--- a/pkg/server/cplane_plugin.go
+++ b/pkg/server/cplane_plugin.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 
 	"connectrpc.com/connect"
@@ -40,6 +41,11 @@ type CplaneManager interface {
 	// operator editing a binding has to reach the plugins that took
 	// values from it.
 	ReconcileAdvertised(ctx context.Context)
+	// EndtVRFGrantLease is the lock the VRF delete handler takes so a
+	// plugin's decap-grant install cannot write a grant for a VRF ifindex it
+	// is freeing. The plugin's local-SID tracker holds the same lock across
+	// its resolve+grant-write.
+	EndtVRFGrantLease() *sync.Mutex
 }
 
 // SetCplaneManager installs the manager. Call before Setup, like the other

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -252,7 +252,10 @@ func (s *Server) Setup() {
 	// auto-advertise is on) the EVPN coordinator.
 	// The grant lease is the cplane manager's: VrfDelete and a plugin's decap-
 	// grant install take the same lock so a grant can never outlive its VRF.
-	// Nil when control-plane plugins are disabled -- no plugin, no grant.
+	// Nil when control-plane plugins are disabled: pinned grants from an
+	// earlier run can still exist then, but no install can race the delete,
+	// and the grant-reference check (which runs regardless of the lease) still
+	// refuses a delete while one is live.
 	var grantLease *sync.Mutex
 	if s.cplaneMgr != nil {
 		grantLease = s.cplaneMgr.EndtVRFGrantLease()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -250,7 +250,14 @@ func (s *Server) Setup() {
 	// the ingress maps from mapOps, the binding lookups from the vrf-bgp
 	// manager, and the bridge attach lifecycle drives the FDB watcher and (when
 	// auto-advertise is on) the EVPN coordinator.
-	vrfServer := NewVrfServer(s.vrfBgpMgr.VRF(), s.mapOps, s.resMgr, s.mapOps, s.vrfBgpMgr, s.resMgr, s.fdbWatcher, s.evpnCoord, s.evpnReplay, vrfMu)
+	// The grant lease is the cplane manager's: VrfDelete and a plugin's decap-
+	// grant install take the same lock so a grant can never outlive its VRF.
+	// Nil when control-plane plugins are disabled -- no plugin, no grant.
+	var grantLease *sync.Mutex
+	if s.cplaneMgr != nil {
+		grantLease = s.cplaneMgr.EndtVRFGrantLease()
+	}
+	vrfServer := NewVrfServer(s.vrfBgpMgr.VRF(), s.mapOps, s.resMgr, s.mapOps, s.vrfBgpMgr, s.resMgr, s.fdbWatcher, s.evpnCoord, s.evpnReplay, vrfMu, grantLease)
 	path, handler = vinberov1connect.NewVrfServiceHandler(vrfServer)
 	s.mux.Handle(path, handler)
 	s.logger.Info("Registered VrfService", zap.String("path", path))

--- a/pkg/server/vrf.go
+++ b/pkg/server/vrf.go
@@ -90,9 +90,11 @@ type VrfServer struct {
 	// be written for an ifindex a delete is freeing: the delete either sees the
 	// grant and refuses, or the install's resolve fails because the device is
 	// gone. It is the cplane manager's lock, shared here; nil when control-
-	// plane plugins are disabled, in which case no grant can exist to race. It
-	// is a leaf lock, always taken under s.mu and releasing nothing else, so it
-	// cannot deadlock with applyMu (which the delete never takes).
+	// plane plugins are disabled -- pinned grants from an earlier run can
+	// still exist then, but no install can race the delete, and the reference
+	// check below still refuses while one is live. It is a leaf lock, always
+	// taken under s.mu and releasing nothing else, so it cannot deadlock with
+	// applyMu (which the delete never takes).
 	grantLease *sync.Mutex
 }
 
@@ -263,7 +265,8 @@ func (s *VrfServer) deleteOne(name string) *v1.OperationError {
 	// unresolvable: the install either wrote the grant before this check (which
 	// then refuses) or resolves after the device is gone (and fails). It is a
 	// leaf held only here; nil when control-plane plugins are off, where no
-	// grant can exist.
+	// install exists to race (the reference check below still guards pinned
+	// grants a previous run left behind).
 	if s.grantLease != nil {
 		s.grantLease.Lock()
 		defer s.grantLease.Unlock()

--- a/pkg/server/vrf.go
+++ b/pkg/server/vrf.go
@@ -25,10 +25,6 @@ type SidLister interface {
 	// VRF in a host-owned grant map rather than in l3vrf aux, so the aux scan
 	// above cannot see it.
 	EndtVRFGrantReferences(vrfIfindex uint32) (uint32, bool, error)
-	// DeleteEndtVRFGrantsByIfindex sweeps grants that point at a just-deleted
-	// VRF device ifindex, the backstop for a grant that raced the reference
-	// check above.
-	DeleteEndtVRFGrantsByIfindex(vrfIfindex uint32) (int, error)
 }
 
 // BindingGetter reports whether a vrf-bgp binding references a VRF name, so
@@ -87,16 +83,27 @@ type VrfServer struct {
 	// two managers, so serializing only within each server would leave a
 	// window where the check and the act see different states.
 	mu *sync.Mutex
+	// grantLease closes the last window between a plugin's decap-grant install
+	// and this VRF delete. VrfDelete holds it across the grant-reference check
+	// and the device teardown; the plugin's local-SID install holds the same
+	// lock across its VRF resolve and grant write. With it, a grant can never
+	// be written for an ifindex a delete is freeing: the delete either sees the
+	// grant and refuses, or the install's resolve fails because the device is
+	// gone. It is the cplane manager's lock, shared here; nil when control-
+	// plane plugins are disabled, in which case no grant can exist to race. It
+	// is a leaf lock, always taken under s.mu and releasing nothing else, so it
+	// cannot deadlock with applyMu (which the delete never takes).
+	grantLease *sync.Mutex
 }
 
 // NewVrfServer wires the handler. mu is the mutation mutex, shared with
 // VrfBgpServer so cross-facet invariants hold (see the field comment); nil
 // allocates a private one (tests without a VrfBgpServer).
-func NewVrfServer(mgr *vrf.Manager, prog vrf.Programmer, dev vrf.DeviceOps, sids SidLister, bindings BindingGetter, bridges vrf.BridgeOps, fdb FdbRegistrar, evpn *EvpnCoordinator, evpnReplay func(), mu *sync.Mutex) *VrfServer {
+func NewVrfServer(mgr *vrf.Manager, prog vrf.Programmer, dev vrf.DeviceOps, sids SidLister, bindings BindingGetter, bridges vrf.BridgeOps, fdb FdbRegistrar, evpn *EvpnCoordinator, evpnReplay func(), mu *sync.Mutex, grantLease *sync.Mutex) *VrfServer {
 	if mu == nil {
 		mu = &sync.Mutex{}
 	}
-	return &VrfServer{mgr: mgr, prog: prog, resolve: vrf.ResolveByName, dev: dev, sids: sids, bindings: bindings, bridges: bridges, fdb: fdb, evpn: evpn, evpnReplay: evpnReplay, mu: mu}
+	return &VrfServer{mgr: mgr, prog: prog, resolve: vrf.ResolveByName, dev: dev, sids: sids, bindings: bindings, bridges: bridges, fdb: fdb, evpn: evpn, evpnReplay: evpnReplay, mu: mu, grantLease: grantLease}
 }
 
 func (s *VrfServer) reconcile() error {
@@ -249,6 +256,18 @@ func (s *VrfServer) deleteOne(name string) *v1.OperationError {
 	} else if resolved, err := s.resolve(name); err == nil {
 		ifindex = resolved
 	}
+	// Hold the grant lease across the grant-reference check and the device
+	// teardown below. A plugin's decap-grant install takes the same lock across
+	// its VRF resolve and grant write, so a grant cannot appear for this
+	// ifindex between the check and the moment teardown makes the ifindex
+	// unresolvable: the install either wrote the grant before this check (which
+	// then refuses) or resolves after the device is gone (and fails). It is a
+	// leaf held only here; nil when control-plane plugins are off, where no
+	// grant can exist.
+	if s.grantLease != nil {
+		s.grantLease.Lock()
+		defer s.grantLease.Unlock()
+	}
 	if ifindex != 0 {
 		ref, err := findVrfReference(s.sids, ifindex)
 		if err != nil {
@@ -277,22 +296,6 @@ func (s *VrfServer) deleteOne(name string) *v1.OperationError {
 		if err := s.dev.DeleteVrf(name); err != nil {
 			return fail(fmt.Sprintf("delete kernel device: %v", err))
 		}
-	}
-	// Backstop the TOCTOU between the grant check above and this teardown: an
-	// install that wrote a grant for this ifindex in that window would dangle
-	// it at a now-freed number. The device is gone, so resolving this VRF fails
-	// and no further grant can be written for it; sweeping any that raced makes
-	// them fail closed on a dead ifindex rather than following the number to a
-	// different device. The device is already deleted, so the delete cannot be
-	// failed here without leaving the manager and the kernel inconsistent; the
-	// sweep is best-effort. If it errors, the near-impossible residual is a
-	// grant left on the freed ifindex until that number is reused -- there is
-	// no self-healing retry, because a VRF that later reuses the number is
-	// itself refused deletion by the grant check above. A full close of the
-	// window (and the elimination of this sweep) needs the install and the
-	// delete to share a lock, which crosses the cplane/VRF boundary.
-	if ifindex != 0 {
-		_, _ = s.sids.DeleteEndtVRFGrantsByIfindex(ifindex)
 	}
 	s.mgr.Delete(name)
 	return nil

--- a/pkg/server/vrf_bgp_test.go
+++ b/pkg/server/vrf_bgp_test.go
@@ -1432,6 +1432,7 @@ func (f *fakeCplane) StatsFor(string) (cplane.PluginStats, bool)          { retu
 func (f *fakeCplane) Unrestored() []cplane.UnrestoredPlugin               { return nil }
 func (f *fakeCplane) Forget(string) error                                 { return nil }
 func (f *fakeCplane) ReconcileAdvertised(context.Context)                 { f.reconciles++ }
+func (f *fakeCplane) EndtVRFGrantLease() *sync.Mutex                      { return nil }
 
 // A binding edit and an unbind both re-derive plugin advertisements, since a
 // plugin route takes its RD, RTs and cap from the binding. Without this wiring

--- a/pkg/server/vrf_test.go
+++ b/pkg/server/vrf_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"sync"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -51,11 +52,12 @@ func fakeResolver(name string) (uint32, error) {
 // fakeVrfDeviceOps records device create/delete calls; create hands out
 // sequential ifindexes starting at 100.
 type fakeVrfDeviceOps struct {
-	createErr error
-	deleteErr error
-	created   []string
-	deleted   []string
-	next      uint32
+	createErr  error
+	deleteErr  error
+	created    []string
+	deleted    []string
+	next       uint32
+	deleteHook func() // when set, runs inside DeleteVrf
 }
 
 func (f *fakeVrfDeviceOps) CreateVrf(name string, tableID uint32, members []string, l3mdev bool) (uint32, error) {
@@ -68,6 +70,9 @@ func (f *fakeVrfDeviceOps) CreateVrf(name string, tableID uint32, members []stri
 }
 
 func (f *fakeVrfDeviceOps) DeleteVrf(name string) error {
+	if f.deleteHook != nil {
+		f.deleteHook()
+	}
 	if f.deleteErr != nil {
 		return f.deleteErr
 	}
@@ -80,10 +85,11 @@ func (f *fakeVrfDeviceOps) DeleteVrf(name string) error {
 // L2 aux (bridge references); default is End.DT4 with an l3vrf aux. auxErr
 // makes every GetSidAux fail (the fail-closed path).
 type fakeSidTable struct {
-	refs      map[string]uint32 // prefix -> ifindex
-	l2        bool
-	auxErr    error
-	grantRefs map[uint32]uint32 // aux index -> granted ifindex
+	refs         map[string]uint32 // prefix -> ifindex
+	l2           bool
+	auxErr       error
+	grantRefs    map[uint32]uint32 // aux index -> granted ifindex
+	grantRefHook func()            // when set, runs inside EndtVRFGrantReferences
 }
 
 func (f *fakeSidTable) ListSidFunctions() (map[string]*bpf.SidFunctionEntry, error) {
@@ -124,6 +130,9 @@ func (f *fakeSidTable) GetSidAux(index uint32) (*bpf.SidAuxEntry, error) {
 }
 
 func (f *fakeSidTable) EndtVRFGrantReferences(ifindex uint32) (uint32, bool, error) {
+	if f.grantRefHook != nil {
+		f.grantRefHook()
+	}
 	for aux, granted := range f.grantRefs {
 		if granted == ifindex {
 			return aux, true, nil
@@ -572,6 +581,56 @@ func TestVrfServer_DeleteRefusals(t *testing.T) {
 			t.Errorf("VrfDelete(%q): want per-item error, got %+v", name, resp.Msg)
 		}
 	}
+}
+
+// VrfDelete holds the shared grant lease across both the grant-reference check
+// and the device teardown, so a plugin's decap-grant install (which takes the
+// same lock across its resolve+write) cannot slip a grant onto the ifindex
+// being freed. Removing either lock acquisition makes this fail.
+func TestVrfServer_DeleteHoldsGrantLease(t *testing.T) {
+	s, _, dev := newTestVrfServerFull()
+	var lease sync.Mutex
+	s.grantLease = &lease
+
+	// The lease must be held while the grant-reference check runs and while the
+	// device is torn down. A TryLock from inside either step must fail.
+	checkHeld, teardownHeld := false, false
+	sids := &fakeSidTable{grantRefHook: func() {
+		checkHeld = true
+		if lease.TryLock() {
+			lease.Unlock()
+			t.Error("grant lease not held during the grant-reference check")
+		}
+	}}
+	s.sids = sids
+	dev.deleteHook = func() {
+		teardownHeld = true
+		if lease.TryLock() {
+			lease.Unlock()
+			t.Error("grant lease not held during device teardown")
+		}
+	}
+
+	if _, err := s.VrfCreate(context.Background(), connect.NewRequest(&v1.VrfCreateRequest{
+		Vrfs: []*v1.Vrf{{Name: "vrf-cust", TableId: 100}},
+	})); err != nil {
+		t.Fatalf("VrfCreate: %v", err)
+	}
+	resp, err := s.VrfDelete(context.Background(), connect.NewRequest(&v1.VrfDeleteRequest{Names: []string{"vrf-cust"}}))
+	if err != nil {
+		t.Fatalf("VrfDelete: %v", err)
+	}
+	if len(resp.Msg.DeletedNames) != 1 {
+		t.Fatalf("delete did not succeed: %+v", resp.Msg)
+	}
+	if !checkHeld || !teardownHeld {
+		t.Fatalf("hooks did not both run: check=%v teardown=%v", checkHeld, teardownHeld)
+	}
+	// Released once the delete returned.
+	if !lease.TryLock() {
+		t.Fatal("grant lease still held after VrfDelete returned")
+	}
+	lease.Unlock()
 }
 
 // A deviceless (ingress-only) VRF deletes without touching DeviceOps; a

--- a/pkg/server/vrf_test.go
+++ b/pkg/server/vrf_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	v1 "github.com/takehaya/vinbero/api/vinbero/v1"
@@ -593,7 +595,13 @@ func TestVrfServer_DeleteHoldsGrantLease(t *testing.T) {
 	s.grantLease = &lease
 
 	// The lease must be held while the grant-reference check runs and while the
-	// device is torn down. A TryLock from inside either step must fail.
+	// device is torn down. A TryLock from inside either step must fail, and a
+	// competitor goroutine started during the check (standing in for a plugin
+	// install) must not acquire the lease before the whole delete -- check,
+	// teardown, manager removal -- has returned; an implementation that
+	// released and re-took the lock between the steps would let it in.
+	var competitorAcquired atomic.Bool
+	competitorDone := make(chan struct{})
 	checkHeld, teardownHeld := false, false
 	sids := &fakeSidTable{grantRefHook: func() {
 		checkHeld = true
@@ -601,6 +609,12 @@ func TestVrfServer_DeleteHoldsGrantLease(t *testing.T) {
 			lease.Unlock()
 			t.Error("grant lease not held during the grant-reference check")
 		}
+		go func() {
+			lease.Lock()
+			competitorAcquired.Store(true)
+			lease.Unlock()
+			close(competitorDone)
+		}()
 	}}
 	s.sids = sids
 	dev.deleteHook = func() {
@@ -608,6 +622,9 @@ func TestVrfServer_DeleteHoldsGrantLease(t *testing.T) {
 		if lease.TryLock() {
 			lease.Unlock()
 			t.Error("grant lease not held during device teardown")
+		}
+		if competitorAcquired.Load() {
+			t.Error("a competitor acquired the grant lease between the check and the teardown")
 		}
 	}
 
@@ -626,11 +643,13 @@ func TestVrfServer_DeleteHoldsGrantLease(t *testing.T) {
 	if !checkHeld || !teardownHeld {
 		t.Fatalf("hooks did not both run: check=%v teardown=%v", checkHeld, teardownHeld)
 	}
-	// Released once the delete returned.
-	if !lease.TryLock() {
-		t.Fatal("grant lease still held after VrfDelete returned")
+	// Released once the delete returned: the competitor that was blocked for
+	// the whole critical section now gets through.
+	select {
+	case <-competitorDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("grant lease still held after VrfDelete returned (competitor never acquired it)")
 	}
-	lease.Unlock()
 }
 
 // A deviceless (ingress-only) VRF deletes without touching DeviceOps; a

--- a/pkg/server/vrf_test.go
+++ b/pkg/server/vrf_test.go
@@ -132,17 +132,6 @@ func (f *fakeSidTable) EndtVRFGrantReferences(ifindex uint32) (uint32, bool, err
 	return 0, false, nil
 }
 
-func (f *fakeSidTable) DeleteEndtVRFGrantsByIfindex(ifindex uint32) (int, error) {
-	removed := 0
-	for aux, granted := range f.grantRefs {
-		if granted == ifindex {
-			delete(f.grantRefs, aux)
-			removed++
-		}
-	}
-	return removed, nil
-}
-
 // fakeBindings reports a binding for the names it holds. Full bindings (with
 // families) take precedence; the names set yields a bare binding.
 type fakeBindings struct {
@@ -210,7 +199,7 @@ func newTestVrfServerFull() (*VrfServer, *fakeProgrammer, *fakeVrfDeviceOps) {
 	events := []string{}
 	s := NewVrfServer(vrf.NewManager(), prog, dev, &fakeSidTable{}, &fakeBindings{},
 		&fakeServerBridgeOps{ifindexes: map[string]uint32{}, events: &events},
-		&fakeFdbRegistrar{events: &events}, nil, nil, nil)
+		&fakeFdbRegistrar{events: &events}, nil, nil, nil, nil)
 	s.resolve = fakeResolver
 	return s, prog, dev
 }
@@ -229,7 +218,7 @@ func newTestVrfServerBridge(hook EvpnBridgeHook) (*VrfServer, *fakeServerBridgeO
 	if hook != nil {
 		evpn = NewEvpnCoordinator(hook, testFacetResolver(mgr), func(int) error { return nil }, zap.NewNop())
 	}
-	s := NewVrfServer(mgr, &fakeProgrammer{}, &fakeVrfDeviceOps{}, &fakeSidTable{}, bindings, bridges, fdb, evpn, nil, nil)
+	s := NewVrfServer(mgr, &fakeProgrammer{}, &fakeVrfDeviceOps{}, &fakeSidTable{}, bindings, bridges, fdb, evpn, nil, nil, nil)
 	s.resolve = fakeResolver
 	return s, bridges, fdb, bindings, &events
 }
@@ -867,7 +856,7 @@ func TestVrfServer_BridgeAttachFiresEvpnReplay(t *testing.T) {
 		replays := 0
 		s := NewVrfServer(vrf.NewManager(), &fakeProgrammer{}, &fakeVrfDeviceOps{}, &fakeSidTable{}, bindings,
 			&fakeServerBridgeOps{ifindexes: map[string]uint32{"br100": 42}, events: &events},
-			&fakeFdbRegistrar{events: &events}, nil, func() { replays++ }, nil)
+			&fakeFdbRegistrar{events: &events}, nil, func() { replays++ }, nil, nil)
 		s.resolve = fakeResolver
 		return s, bindings, &replays
 	}


### PR DESCRIPTION
## 何を

plugin dispatch の End.DT4/DT6/DT46 は decap 先 VRF を host-owned な `plugin_endt_vrf_map` (key = dispatch entry の aux index) に記録する。この grant の install は VRF 名を ifindex へ解決してから grant を書くまでを VrfDelete と直列化しておらず、解決と書き込みの間に VrfDelete が割り込むと解放済み ifindex に grant が残っていた。

従来はこれを fail-closed の残余に縮めていた (削除前の参照チェック + teardown 後の sweep) が、窓は閉じきっていなかった。

## どう閉じたか

local SID install と VrfDelete で 1 本の leaf lock を共有する。install は resolve から `PutEndtVRFGrant` まで、VrfDelete は grant 参照チェックから device teardown までをこの lock で囲む。順序はどちらでも整合する。

- install が先: grant が VrfDelete のチェックに見え、削除を拒む
- VrfDelete が先: device が消え install の resolve が失敗する

## deadlock しない理由

lock は cplane manager が所有し VRF 削除ハンドラへ配線する。最内側でだけ取り、内側では VRF manager 自身の lock と BPF map しか触らないので applyMu や VRF mutation mutex と deadlock しない。VRF mutation mutex を直接流用すると、VrfDelete が `ReconcileAdvertised` 経由で applyMu を取る一方 install が逆順で VRF mutation mutex を取るため逆転して deadlock する。専用 leaf lock がこの逆転を避ける。

## 削除

窓が閉じたので teardown 後の sweep は dead code になり、`DeleteEndtVRFGrantsByIfindex` と配線を削除した。削除前の参照チェックは refuse-path として残す。

## 検証

- `go build ./...` / `go vet` / golangci-lint (pre-commit) green
- `go test ./pkg/cplane/... ./pkg/server/...` pass
- sudo bpf test: `TestEndtVRFGrantReferences` / `TestForceDeleteSidFunctionRemovesEndtVRFGrant` / `TestXDPProgPluginEndDT4VrfGrant` pass
- lease が install の resolve 中に保持されることを決定的に検証する unit test を追加 (`TestLocalSIDDecapVRFGrantHeldDuringResolve`)