### PR TITLE
feat(locator): RFC 9800 uSID SID structure and allocation (uSID phase 1)

### DIFF
--- a/api/vinbero/v1/locator.pb.go
+++ b/api/vinbero/v1/locator.pb.go
@@ -81,9 +81,10 @@ func (LocatorBehaviorMode) EnumDescriptor() ([]byte, []int) {
 // The (block_len + node_len) bits at the front of the prefix identify
 // the PE; the next function_len bits identify the local behavior.
 // Constraints depend on behavior: CLASSIC requires the four lengths to
-// sum to 128 (argument_len holds the remainder); USID requires
-// function_len == 16, argument_len == 0, and a byte-aligned block_len,
-// with the container tail after the function left implicit.
+// sum to 128 (argument_len holds the remainder); USID is fixed to the
+// F3216 structure (block_len == 32, node_len == 16, function_len == 16,
+// argument_len == 0), with the container tail after the function left
+// implicit.
 type Locator struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/api/vinbero/v1/locator.pb.go
+++ b/api/vinbero/v1/locator.pb.go
@@ -79,9 +79,11 @@ func (LocatorBehaviorMode) EnumDescriptor() ([]byte, []int) {
 // and the bit layout used to slice SIDs from it.
 //
 // The (block_len + node_len) bits at the front of the prefix identify
-// the PE; the next function_len bits identify the local behavior; the
-// last argument_len bits are reserved for argument material (END.X
-// neighbor selectors, etc.). Their sum must equal 128.
+// the PE; the next function_len bits identify the local behavior.
+// Constraints depend on behavior: CLASSIC requires the four lengths to
+// sum to 128 (argument_len holds the remainder); USID requires
+// function_len == 16, argument_len == 0, and a byte-aligned block_len,
+// with the container tail after the function left implicit.
 type Locator struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -198,8 +200,10 @@ func (x *Locator) GetFunctionAutoEnd() uint32 {
 // available slot from [function_auto_start, function_auto_end]. When
 // set, any value inside the function_len bit width is accepted -- manual
 // allocations may sit outside the auto-allocator range so operator-
-// reserved low / high slots can still be claimed explicitly. Conflicts
-// (value already in use) surface as a per-entry error.
+// reserved low / high slots can still be claimed explicitly -- except
+// CSID 0 on USID locators, which is reserved as the container
+// terminator and rejected on every allocation path. Conflicts (value
+// already in use) surface as a per-entry error.
 type LocatorRef struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/pkg/bgp/bgp.go
+++ b/pkg/bgp/bgp.go
@@ -595,7 +595,9 @@ type MUPRoute struct {
 // SIDStructure is the SRv6 SID layout signalled by the SRv6 SID Structure
 // Sub-Sub-TLV (RFC 9252 §3.2.1.1). All fields are bit lengths except
 // TranspositionOffset (bit position). LocatorBlockLen + LocatorNodeLen +
-// FunctionLen + ArgumentLen must equal 128.
+// FunctionLen + ArgumentLen is at most 128; ArgumentLen covers only the
+// behavior's actual argument, so a uSID F3216 service SID is 32/16/16/0
+// with the container tail outside the structure.
 type SIDStructure struct {
 	LocatorBlockLen     uint8
 	LocatorNodeLen      uint8

--- a/pkg/locator/allocator.go
+++ b/pkg/locator/allocator.go
@@ -47,12 +47,13 @@ var _ FunctionAllocator = (*bitmapAllocator)(nil)
 // usage finite -- a 16-bit function fits 8 KiB, a 24-bit function 2 MiB,
 // a 32-bit function 512 MiB).
 type bitmapAllocator struct {
-	mu        sync.Mutex
-	bits      []uint64 // bit i set => function i in use
-	max       uint32   // inclusive upper bound on storable function
-	autoStart uint32
-	autoEnd   uint32
-	autoNext  uint32 // hint for the next auto search; rolls forward to avoid scanning from 0 every time
+	mu          sync.Mutex
+	bits        []uint64 // bit i set => function i in use
+	max         uint32   // inclusive upper bound on storable function
+	autoStart   uint32
+	autoEnd     uint32
+	autoNext    uint32 // hint for the next auto search; rolls forward to avoid scanning from 0 every time
+	reserveZero bool   // uSID reserves CSID 0 as the container terminator
 }
 
 // NewBitmapAllocator returns an allocator preconfigured for loc. The
@@ -63,11 +64,12 @@ func NewBitmapAllocator(loc *Locator) FunctionAllocator {
 	max := loc.MaxFunction()
 	words := (uint64(max) + 64) / 64 // round up so the highest bit fits
 	return &bitmapAllocator{
-		bits:      make([]uint64, words),
-		max:       max,
-		autoStart: loc.FunctionAutoStart,
-		autoEnd:   loc.FunctionAutoEnd,
-		autoNext:  loc.FunctionAutoStart,
+		bits:        make([]uint64, words),
+		max:         max,
+		autoStart:   loc.FunctionAutoStart,
+		autoEnd:     loc.FunctionAutoEnd,
+		autoNext:    loc.FunctionAutoStart,
+		reserveZero: loc.Behavior == BehaviorUSID,
 	}
 }
 
@@ -76,6 +78,9 @@ func (a *bitmapAllocator) Allocate(requested *uint32) (uint32, error) {
 	defer a.mu.Unlock()
 	if requested != nil {
 		f := *requested
+		if a.reserveZero && f == 0 {
+			return 0, fmt.Errorf("%w: uSID CSID 0 is the container terminator", ErrFunctionReserved)
+		}
 		if f > a.max {
 			return 0, fmt.Errorf("%w: %d > %d", ErrFunctionOutsideAutoRange, f, a.max)
 		}
@@ -117,6 +122,9 @@ func (a *bitmapAllocator) autoFindLocked(from, to uint32) (uint32, bool) {
 	toBit := to % 64
 	for w := fromWord; w <= toWord; w++ {
 		free := ^a.bits[w]
+		if a.reserveZero && w == 0 {
+			free &^= 1
+		}
 		if w == fromWord && fromBit > 0 {
 			free &^= (uint64(1) << fromBit) - 1
 		}

--- a/pkg/locator/allocator_test.go
+++ b/pkg/locator/allocator_test.go
@@ -88,6 +88,35 @@ func TestAllocator_AutoExhaustion(t *testing.T) {
 	}
 }
 
+func TestAllocator_USIDZeroReserved(t *testing.T) {
+	loc := makeUSID48(t)
+	loc.FunctionAutoStart = 0
+	loc.FunctionAutoEnd = 1
+	a := NewBitmapAllocator(&loc)
+
+	zero := uint32(0)
+	if _, err := a.Allocate(&zero); !errors.Is(err, ErrFunctionReserved) {
+		t.Errorf("manual zero: got %v, want ErrFunctionReserved", err)
+	}
+	got, err := a.Allocate(nil)
+	if err != nil || got != 1 {
+		t.Errorf("auto: got (%d, %v), want (1, nil)", got, err)
+	}
+	if _, err := a.Allocate(nil); !errors.Is(err, ErrPoolExhausted) {
+		t.Errorf("auto exhausted: got %v, want ErrPoolExhausted", err)
+	}
+}
+
+func TestAllocator_ClassicZeroUnchanged(t *testing.T) {
+	loc := makeClassic48(t)
+	loc.FunctionAutoStart = 0
+	loc.FunctionAutoEnd = 0
+	a := NewBitmapAllocator(&loc)
+	if got, err := a.Allocate(nil); err != nil || got != 0 {
+		t.Errorf("classic auto zero: got (%d, %v), want (0, nil)", got, err)
+	}
+}
+
 func TestAllocator_ReleaseUnallocatedIsNoOp(t *testing.T) {
 	loc := makeClassic48(t)
 	a := NewBitmapAllocator(&loc)

--- a/pkg/locator/locator.go
+++ b/pkg/locator/locator.go
@@ -152,18 +152,6 @@ func (l *Locator) Validate() error {
 	return nil
 }
 
-// WireArgumentLen returns the argument length to advertise in the RFC 9252
-// SID Structure. Classic locators carry it explicitly; uSID locators store
-// argument_len == 0 locally (the container tail is implicit), but on the
-// wire the Argument spans everything after LBL+LNL+FL so the four lengths
-// still sum to 128.
-func (l *Locator) WireArgumentLen() uint8 {
-	if l.Behavior == BehaviorUSID {
-		return uint8(128 - uint16(l.BlockLen) - uint16(l.NodeLen) - uint16(l.FunctionLen))
-	}
-	return l.ArgumentLen
-}
-
 // MaxFunction returns the largest value representable in FunctionLen bits.
 func (l *Locator) MaxFunction() uint32 {
 	return uint32((uint64(1) << l.FunctionLen) - 1)

--- a/pkg/locator/locator.go
+++ b/pkg/locator/locator.go
@@ -4,10 +4,9 @@
 // SID was built from which (locator, function) pair so a Delete can
 // return the function to the pool.
 //
-// Today Phase 1 implements RFC 8986 Classic SRv6. RFC 9800 uSID
-// locators (Behavior == BehaviorUSID) are accepted at the config layer
-// but BuildSID / ParseSID return ErrUnimplemented for them; the Phase 2
-// extension of the GoBGP integration plan will fill in uSID encoding.
+// It supports RFC 8986 Classic SRv6 locators and RFC 9800 uSID
+// locators. Data-plane behavior is implemented separately from the SID
+// structure and allocation handled here.
 package locator
 
 import (
@@ -58,7 +57,7 @@ type Locator struct {
 
 var (
 	// ErrUnimplemented surfaces from BuildSID / ParseSID when the locator
-	// uses a Behavior that the current build does not encode (today: USID).
+	// uses a Behavior that the current build does not encode.
 	ErrUnimplemented = errors.New("locator: behavior not yet implemented")
 
 	// ErrInvalidLocator signals a structural problem with the Locator
@@ -68,6 +67,10 @@ var (
 	// ErrFunctionOutOfRange signals a function value that does not fit in
 	// FunctionLen bits.
 	ErrFunctionOutOfRange = errors.New("locator: function value out of range")
+
+	// ErrFunctionReserved signals a function value reserved by the SID
+	// format. uSID reserves CSID 0 as the container terminator.
+	ErrFunctionReserved = errors.New("locator: function value is reserved")
 )
 
 // maxFunctionLenBits caps how large a function field the bitmap allocator
@@ -87,16 +90,35 @@ func (l *Locator) Validate() error {
 	if !l.Prefix.IsValid() || !l.Prefix.Addr().Is6() {
 		return fmt.Errorf("%w: prefix must be a valid IPv6 prefix", ErrInvalidLocator)
 	}
-	total := uint16(l.BlockLen) + uint16(l.NodeLen) + uint16(l.FunctionLen) + uint16(l.ArgumentLen)
-	if total != 128 {
-		return fmt.Errorf("%w: bit lengths must sum to 128 (got %d)", ErrInvalidLocator, total)
-	}
-	if uint16(l.BlockLen)+uint16(l.NodeLen) != uint16(l.Prefix.Bits()) {
+	prefixLen := uint16(l.BlockLen) + uint16(l.NodeLen)
+	if prefixLen != uint16(l.Prefix.Bits()) {
 		return fmt.Errorf("%w: block_len + node_len (%d) must equal prefix bits (%d)",
 			ErrInvalidLocator, l.BlockLen+l.NodeLen, l.Prefix.Bits())
 	}
-	if l.FunctionLen == 0 {
-		return fmt.Errorf("%w: function_len must be > 0", ErrInvalidLocator)
+	switch l.Behavior {
+	case BehaviorClassic:
+		total := prefixLen + uint16(l.FunctionLen) + uint16(l.ArgumentLen)
+		if total != 128 {
+			return fmt.Errorf("%w: bit lengths must sum to 128 (got %d)", ErrInvalidLocator, total)
+		}
+		if l.FunctionLen == 0 {
+			return fmt.Errorf("%w: function_len must be > 0", ErrInvalidLocator)
+		}
+	case BehaviorUSID:
+		if l.BlockLen%8 != 0 {
+			return fmt.Errorf("%w: uSID block_len must be a multiple of 8", ErrInvalidLocator)
+		}
+		if l.FunctionLen != 16 {
+			return fmt.Errorf("%w: uSID function_len must be 16", ErrInvalidLocator)
+		}
+		if l.ArgumentLen != 0 {
+			return fmt.Errorf("%w: uSID argument_len must be 0", ErrInvalidLocator)
+		}
+		if prefixLen+uint16(l.FunctionLen) > 128 {
+			return fmt.Errorf("%w: uSID locator prefix and function exceed 128 bits", ErrInvalidLocator)
+		}
+	default:
+		return fmt.Errorf("%w: unsupported behavior %v", ErrInvalidLocator, l.Behavior)
 	}
 	if l.FunctionLen > maxFunctionLenBits {
 		return fmt.Errorf("%w: function_len > %d is not supported (bitmap memory cost)",
@@ -115,11 +137,6 @@ func (l *Locator) Validate() error {
 		return fmt.Errorf("%w: function_auto_end (%d) < function_auto_start (%d)",
 			ErrInvalidLocator, l.FunctionAutoEnd, l.FunctionAutoStart)
 	}
-	switch l.Behavior {
-	case BehaviorClassic, BehaviorUSID:
-	default:
-		return fmt.Errorf("%w: unsupported behavior %v", ErrInvalidLocator, l.Behavior)
-	}
 	return nil
 }
 
@@ -130,10 +147,14 @@ func (l *Locator) MaxFunction() uint32 {
 
 // BuildSID returns the 128-bit SRv6 SID for (locator, function). The
 // function bits sit immediately after locator-block + locator-node; the
-// argument tail is left zero. uSID layout is deferred to Phase 2.
+// argument tail is left zero. For uSID this builds the zero-filled service
+// uSID form with a 16-bit function.
 func (l *Locator) BuildSID(function uint32) (netip.Addr, error) {
-	if l.Behavior != BehaviorClassic {
+	if l.Behavior != BehaviorClassic && l.Behavior != BehaviorUSID {
 		return netip.Addr{}, fmt.Errorf("%w: behavior %v BuildSID", ErrUnimplemented, l.Behavior)
+	}
+	if l.Behavior == BehaviorUSID && function == 0 {
+		return netip.Addr{}, fmt.Errorf("%w: uSID CSID 0 is the container terminator", ErrFunctionReserved)
 	}
 	if function > l.MaxFunction() {
 		return netip.Addr{}, fmt.Errorf("%w: function %d exceeds %d", ErrFunctionOutOfRange, function, l.MaxFunction())
@@ -153,7 +174,7 @@ func (l *Locator) BuildSID(function uint32) (netip.Addr, error) {
 // prefix and the caller should try a different locator. ParseSID does
 // not consult the binding table.
 func (l *Locator) ParseSID(sid netip.Addr) (function uint32, ok bool, err error) {
-	if l.Behavior != BehaviorClassic {
+	if l.Behavior != BehaviorClassic && l.Behavior != BehaviorUSID {
 		return 0, false, fmt.Errorf("%w: behavior %v ParseSID", ErrUnimplemented, l.Behavior)
 	}
 	if !sid.Is6() {
@@ -165,7 +186,23 @@ func (l *Locator) ParseSID(sid netip.Addr) (function uint32, ok bool, err error)
 	b16 := sid.As16()
 	prefixBits := uint(l.BlockLen) + uint(l.NodeLen)
 	v := readBits(b16[:], prefixBits, uint(l.FunctionLen))
+	if l.Behavior == BehaviorUSID && !bitsZero(b16[:], prefixBits+uint(l.FunctionLen), 128) {
+		return 0, false, nil
+	}
 	return uint32(v), true, nil
+}
+
+// bitsZero reports whether every bit in [start, end) is zero. Reads are
+// chunked because readBits returns at most 64 bits at a time.
+func bitsZero(buf []byte, start, end uint) bool {
+	for start < end {
+		width := min(end-start, 64)
+		if readBits(buf, start, width) != 0 {
+			return false
+		}
+		start += width
+	}
+	return true
 }
 
 // writeBits stores value into buf starting at bit offset start, spanning

--- a/pkg/locator/locator.go
+++ b/pkg/locator/locator.go
@@ -186,8 +186,15 @@ func (l *Locator) ParseSID(sid netip.Addr) (function uint32, ok bool, err error)
 	b16 := sid.As16()
 	prefixBits := uint(l.BlockLen) + uint(l.NodeLen)
 	v := readBits(b16[:], prefixBits, uint(l.FunctionLen))
-	if l.Behavior == BehaviorUSID && !bitsZero(b16[:], prefixBits+uint(l.FunctionLen), 128) {
-		return 0, false, nil
+	if l.Behavior == BehaviorUSID {
+		if !bitsZero(b16[:], prefixBits+uint(l.FunctionLen), 128) {
+			return 0, false, nil
+		}
+		// CSID 0 is the container terminator, so the bare locator prefix
+		// is not a service uSID this locator could have minted.
+		if v == 0 {
+			return 0, false, nil
+		}
 	}
 	return uint32(v), true, nil
 }

--- a/pkg/locator/locator.go
+++ b/pkg/locator/locator.go
@@ -119,6 +119,16 @@ func (l *Locator) Validate() error {
 		if l.ArgumentLen != 0 {
 			return fmt.Errorf("%w: uSID argument_len must be 0", ErrInvalidLocator)
 		}
+		// The 16 bits after the block are this node's own CSID; 0 is the
+		// container terminator (RFC 9800 Section 5), so a locator whose
+		// node field is zero would mint SIDs that start with the reserved
+		// end-of-container marker.
+		if l.Prefix.IsValid() && l.Prefix.Addr().Is6() {
+			p16 := l.Prefix.Masked().Addr().As16()
+			if readBits(p16[:], 32, 16) == 0 {
+				return fmt.Errorf("%w: uSID locator node CSID must be non-zero", ErrInvalidLocator)
+			}
+		}
 	default:
 		return fmt.Errorf("%w: unsupported behavior %v", ErrInvalidLocator, l.Behavior)
 	}
@@ -140,6 +150,18 @@ func (l *Locator) Validate() error {
 			ErrInvalidLocator, l.FunctionAutoEnd, l.FunctionAutoStart)
 	}
 	return nil
+}
+
+// WireArgumentLen returns the argument length to advertise in the RFC 9252
+// SID Structure. Classic locators carry it explicitly; uSID locators store
+// argument_len == 0 locally (the container tail is implicit), but on the
+// wire the Argument spans everything after LBL+LNL+FL so the four lengths
+// still sum to 128.
+func (l *Locator) WireArgumentLen() uint8 {
+	if l.Behavior == BehaviorUSID {
+		return uint8(128 - uint16(l.BlockLen) - uint16(l.NodeLen) - uint16(l.FunctionLen))
+	}
+	return l.ArgumentLen
 }
 
 // MaxFunction returns the largest value representable in FunctionLen bits.

--- a/pkg/locator/locator.go
+++ b/pkg/locator/locator.go
@@ -105,17 +105,19 @@ func (l *Locator) Validate() error {
 			return fmt.Errorf("%w: function_len must be > 0", ErrInvalidLocator)
 		}
 	case BehaviorUSID:
-		if l.BlockLen%8 != 0 {
-			return fmt.Errorf("%w: uSID block_len must be a multiple of 8", ErrInvalidLocator)
+		// F3216 is the only supported uSID structure: 32-bit locator
+		// block, 16-bit uSIDs. The data plane's shift offsets assume it.
+		if l.BlockLen != 32 {
+			return fmt.Errorf("%w: uSID block_len must be 32 (F3216)", ErrInvalidLocator)
+		}
+		if l.NodeLen != 16 {
+			return fmt.Errorf("%w: uSID node_len must be 16 (F3216)", ErrInvalidLocator)
 		}
 		if l.FunctionLen != 16 {
 			return fmt.Errorf("%w: uSID function_len must be 16", ErrInvalidLocator)
 		}
 		if l.ArgumentLen != 0 {
 			return fmt.Errorf("%w: uSID argument_len must be 0", ErrInvalidLocator)
-		}
-		if prefixLen+uint16(l.FunctionLen) > 128 {
-			return fmt.Errorf("%w: uSID locator prefix and function exceed 128 bits", ErrInvalidLocator)
 		}
 	default:
 		return fmt.Errorf("%w: unsupported behavior %v", ErrInvalidLocator, l.Behavior)

--- a/pkg/locator/locator_test.go
+++ b/pkg/locator/locator_test.go
@@ -17,6 +17,16 @@ func makeClassic48(t *testing.T) Locator {
 	}
 }
 
+func makeUSID48(t *testing.T) Locator {
+	t.Helper()
+	return Locator{
+		Name: "USID1", Prefix: netip.MustParsePrefix("fd00:0:0:aa::/48"),
+		BlockLen: 32, NodeLen: 16, FunctionLen: 16, ArgumentLen: 0,
+		Behavior:          BehaviorUSID,
+		FunctionAutoStart: 1, FunctionAutoEnd: 0xFFFE,
+	}
+}
+
 func TestValidate_OK(t *testing.T) {
 	loc := makeClassic48(t)
 	if err := loc.Validate(); err != nil {
@@ -41,6 +51,32 @@ func TestValidate_Errors(t *testing.T) {
 			tc.mutate(&loc)
 			if err := loc.Validate(); err == nil {
 				t.Errorf("expected error")
+			}
+		})
+	}
+}
+
+func TestValidate_USID(t *testing.T) {
+	loc := makeUSID48(t)
+	if err := loc.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(*Locator)
+	}{
+		{"prefix-length", func(l *Locator) { l.NodeLen = 8 }},
+		{"function-length", func(l *Locator) { l.FunctionLen = 15 }},
+		{"argument-length", func(l *Locator) { l.ArgumentLen = 64 }},
+		{"block-byte-alignment", func(l *Locator) { l.BlockLen = 31; l.NodeLen = 17 }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			loc := makeUSID48(t)
+			tc.mutate(&loc)
+			if err := loc.Validate(); !errors.Is(err, ErrInvalidLocator) {
+				t.Errorf("Validate: got %v, want ErrInvalidLocator", err)
 			}
 		})
 	}
@@ -79,13 +115,42 @@ func TestBuildSID_OutOfRange(t *testing.T) {
 	}
 }
 
-func TestUSID_Unimplemented(t *testing.T) {
-	loc := makeClassic48(t)
-	loc.Behavior = BehaviorUSID
-	if _, err := loc.BuildSID(0x10); !errors.Is(err, ErrUnimplemented) {
-		t.Errorf("BuildSID uSID: want ErrUnimplemented, got %v", err)
+func TestBuildSID_USIDRoundTrip(t *testing.T) {
+	loc := makeUSID48(t)
+	for _, fn := range []uint32{1, 0xaa, 0xf321, 0xffff} {
+		sid, err := loc.BuildSID(fn)
+		if err != nil {
+			t.Fatalf("BuildSID(%#x): %v", fn, err)
+		}
+		got, ok, err := loc.ParseSID(sid)
+		if err != nil || !ok || got != fn {
+			t.Errorf("ParseSID(%s) = (%#x, %v, %v), want (%#x, true, nil)", sid, got, ok, err, fn)
+		}
 	}
-	if _, _, err := loc.ParseSID(netip.MustParseAddr("fd00:1:1::1")); !errors.Is(err, ErrUnimplemented) {
-		t.Errorf("ParseSID uSID: want ErrUnimplemented, got %v", err)
+	sid, err := loc.BuildSID(0xaa)
+	if err != nil {
+		t.Fatalf("BuildSID(0xaa): %v", err)
+	}
+	if want := netip.MustParseAddr("fd00:0:0:aa::"); sid != want {
+		t.Errorf("BuildSID(0xaa) = %s, want %s", sid, want)
+	}
+}
+
+func TestParseSID_USIDRejectsNonZeroRemainder(t *testing.T) {
+	loc := makeUSID48(t)
+	for _, sid := range []netip.Addr{
+		netip.MustParseAddr("fd00:0:0:aa::1"),
+		netip.MustParseAddr("fd00:0:0:aa:8000::"),
+	} {
+		if _, ok, err := loc.ParseSID(sid); err != nil || ok {
+			t.Errorf("ParseSID(%s) = (ok=%v, err=%v), want (false, nil)", sid, ok, err)
+		}
+	}
+}
+
+func TestBuildSID_USIDZeroReserved(t *testing.T) {
+	loc := makeUSID48(t)
+	if _, err := loc.BuildSID(0); !errors.Is(err, ErrFunctionReserved) {
+		t.Errorf("BuildSID(0): got %v, want ErrFunctionReserved", err)
 	}
 }

--- a/pkg/locator/locator_test.go
+++ b/pkg/locator/locator_test.go
@@ -20,7 +20,7 @@ func makeClassic48(t *testing.T) Locator {
 func makeUSID48(t *testing.T) Locator {
 	t.Helper()
 	return Locator{
-		Name: "USID1", Prefix: netip.MustParsePrefix("fd00:0:0:aa::/48"),
+		Name: "USID1", Prefix: netip.MustParsePrefix("fd00:0:b001::/48"),
 		BlockLen: 32, NodeLen: 16, FunctionLen: 16, ArgumentLen: 0,
 		Behavior:          BehaviorUSID,
 		FunctionAutoStart: 1, FunctionAutoEnd: 0xFFFE,
@@ -70,6 +70,7 @@ func TestValidate_USID(t *testing.T) {
 		{"function-length", func(l *Locator) { l.FunctionLen = 15 }},
 		{"argument-length", func(l *Locator) { l.ArgumentLen = 64 }},
 		{"non-f3216-block", func(l *Locator) { l.BlockLen = 40; l.NodeLen = 8 }},
+		{"node-csid-zero", func(l *Locator) { l.Prefix = netip.MustParsePrefix("fd00:0:0::/48") }},
 		{"non-f3216-node", func(l *Locator) {
 			l.BlockLen = 24
 			l.NodeLen = 24
@@ -136,7 +137,7 @@ func TestBuildSID_USIDRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildSID(0xaa): %v", err)
 	}
-	if want := netip.MustParseAddr("fd00:0:0:aa::"); sid != want {
+	if want := netip.MustParseAddr("fd00:0:b001:aa::"); sid != want {
 		t.Errorf("BuildSID(0xaa) = %s, want %s", sid, want)
 	}
 }
@@ -144,8 +145,8 @@ func TestBuildSID_USIDRoundTrip(t *testing.T) {
 func TestParseSID_USIDRejectsNonZeroRemainder(t *testing.T) {
 	loc := makeUSID48(t)
 	for _, sid := range []netip.Addr{
-		netip.MustParseAddr("fd00:0:0:aa::1"),
-		netip.MustParseAddr("fd00:0:0:aa:8000::"),
+		netip.MustParseAddr("fd00:0:b001:aa::1"),
+		netip.MustParseAddr("fd00:0:b001:aa:8000::"),
 	} {
 		if _, ok, err := loc.ParseSID(sid); err != nil || ok {
 			t.Errorf("ParseSID(%s) = (ok=%v, err=%v), want (false, nil)", sid, ok, err)
@@ -158,7 +159,7 @@ func TestParseSID_USIDRejectsZeroFunction(t *testing.T) {
 	// The bare locator prefix carries CSID 0 (the container terminator),
 	// which BuildSID and the allocator refuse to mint; ParseSID must not
 	// report it as a valid service uSID either.
-	bare := netip.MustParseAddr("fd00:0:0::")
+	bare := netip.MustParseAddr("fd00:0:b001::")
 	if _, ok, err := loc.ParseSID(bare); err != nil || ok {
 		t.Errorf("ParseSID(%s) = (ok=%v, err=%v), want (false, nil)", bare, ok, err)
 	}

--- a/pkg/locator/locator_test.go
+++ b/pkg/locator/locator_test.go
@@ -69,7 +69,12 @@ func TestValidate_USID(t *testing.T) {
 		{"prefix-length", func(l *Locator) { l.NodeLen = 8 }},
 		{"function-length", func(l *Locator) { l.FunctionLen = 15 }},
 		{"argument-length", func(l *Locator) { l.ArgumentLen = 64 }},
-		{"block-byte-alignment", func(l *Locator) { l.BlockLen = 31; l.NodeLen = 17 }},
+		{"non-f3216-block", func(l *Locator) { l.BlockLen = 40; l.NodeLen = 8 }},
+		{"non-f3216-node", func(l *Locator) {
+			l.BlockLen = 24
+			l.NodeLen = 24
+			l.Prefix = netip.MustParsePrefix("fd00::/48")
+		}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/locator/locator_test.go
+++ b/pkg/locator/locator_test.go
@@ -148,6 +148,17 @@ func TestParseSID_USIDRejectsNonZeroRemainder(t *testing.T) {
 	}
 }
 
+func TestParseSID_USIDRejectsZeroFunction(t *testing.T) {
+	loc := makeUSID48(t)
+	// The bare locator prefix carries CSID 0 (the container terminator),
+	// which BuildSID and the allocator refuse to mint; ParseSID must not
+	// report it as a valid service uSID either.
+	bare := netip.MustParseAddr("fd00:0:0::")
+	if _, ok, err := loc.ParseSID(bare); err != nil || ok {
+		t.Errorf("ParseSID(%s) = (ok=%v, err=%v), want (false, nil)", bare, ok, err)
+	}
+}
+
 func TestBuildSID_USIDZeroReserved(t *testing.T) {
 	loc := makeUSID48(t)
 	if _, err := loc.BuildSID(0); !errors.Is(err, ErrFunctionReserved) {

--- a/pkg/locator/locator_test.go
+++ b/pkg/locator/locator_test.go
@@ -172,19 +172,3 @@ func TestBuildSID_USIDZeroReserved(t *testing.T) {
 	}
 }
 
-func TestWireArgumentLen(t *testing.T) {
-	classic := makeClassic48(t)
-	if got := classic.WireArgumentLen(); got != classic.ArgumentLen {
-		t.Errorf("classic WireArgumentLen = %d, want %d", got, classic.ArgumentLen)
-	}
-	usid := makeUSID48(t)
-	// The advertised SID Structure must sum to 128 bits even though the
-	// uSID locator stores argument_len == 0 locally.
-	if got := usid.WireArgumentLen(); got != 64 {
-		t.Errorf("uSID WireArgumentLen = %d, want 64", got)
-	}
-	total := uint16(usid.BlockLen) + uint16(usid.NodeLen) + uint16(usid.FunctionLen) + uint16(usid.WireArgumentLen())
-	if total != 128 {
-		t.Errorf("advertised lengths sum to %d, want 128", total)
-	}
-}

--- a/pkg/locator/locator_test.go
+++ b/pkg/locator/locator_test.go
@@ -171,3 +171,20 @@ func TestBuildSID_USIDZeroReserved(t *testing.T) {
 		t.Errorf("BuildSID(0): got %v, want ErrFunctionReserved", err)
 	}
 }
+
+func TestWireArgumentLen(t *testing.T) {
+	classic := makeClassic48(t)
+	if got := classic.WireArgumentLen(); got != classic.ArgumentLen {
+		t.Errorf("classic WireArgumentLen = %d, want %d", got, classic.ArgumentLen)
+	}
+	usid := makeUSID48(t)
+	// The advertised SID Structure must sum to 128 bits even though the
+	// uSID locator stores argument_len == 0 locally.
+	if got := usid.WireArgumentLen(); got != 64 {
+		t.Errorf("uSID WireArgumentLen = %d, want 64", got)
+	}
+	total := uint16(usid.BlockLen) + uint16(usid.NodeLen) + uint16(usid.FunctionLen) + uint16(usid.WireArgumentLen())
+	if total != 128 {
+		t.Errorf("advertised lengths sum to %d, want 128", total)
+	}
+}

--- a/pkg/server/mup.go
+++ b/pkg/server/mup.go
@@ -107,7 +107,7 @@ func fillMUPSIDStructure(mr bgp.MUPRoute, locators *locator.Manager) bgp.SIDStru
 		LocatorBlockLen: loc.BlockLen,
 		LocatorNodeLen:  loc.NodeLen,
 		FunctionLen:     loc.FunctionLen,
-		ArgumentLen:     loc.ArgumentLen,
+		ArgumentLen:     loc.WireArgumentLen(),
 	}
 }
 

--- a/pkg/server/mup.go
+++ b/pkg/server/mup.go
@@ -107,7 +107,11 @@ func fillMUPSIDStructure(mr bgp.MUPRoute, locators *locator.Manager) bgp.SIDStru
 		LocatorBlockLen: loc.BlockLen,
 		LocatorNodeLen:  loc.NodeLen,
 		FunctionLen:     loc.FunctionLen,
-		ArgumentLen:     loc.WireArgumentLen(),
+		// ArgumentLen is the behavior's actual argument width (RFC 9252
+		// 3.2.1.1); the lengths need not sum to 128, so a uSID locator
+		// correctly advertises 32/16/16/0 with the container tail outside
+		// the structure.
+		ArgumentLen:     loc.ArgumentLen,
 	}
 }
 

--- a/proto/vinbero/v1/locator.proto
+++ b/proto/vinbero/v1/locator.proto
@@ -37,9 +37,11 @@ enum LocatorBehaviorMode {
 // and the bit layout used to slice SIDs from it.
 //
 // The (block_len + node_len) bits at the front of the prefix identify
-// the PE; the next function_len bits identify the local behavior; the
-// last argument_len bits are reserved for argument material (END.X
-// neighbor selectors, etc.). Their sum must equal 128.
+// the PE; the next function_len bits identify the local behavior.
+// Constraints depend on behavior: CLASSIC requires the four lengths to
+// sum to 128 (argument_len holds the remainder); USID requires
+// function_len == 16, argument_len == 0, and a byte-aligned block_len,
+// with the container tail after the function left implicit.
 message Locator {
   string name = 1; // Operator-chosen locator name, e.g. "LOC1-CLASSIC".
   string prefix = 2; // IPv6 prefix, e.g. "fd00:1:1::/48".
@@ -57,8 +59,10 @@ message Locator {
 // available slot from [function_auto_start, function_auto_end]. When
 // set, any value inside the function_len bit width is accepted -- manual
 // allocations may sit outside the auto-allocator range so operator-
-// reserved low / high slots can still be claimed explicitly. Conflicts
-// (value already in use) surface as a per-entry error.
+// reserved low / high slots can still be claimed explicitly -- except
+// CSID 0 on USID locators, which is reserved as the container
+// terminator and rejected on every allocation path. Conflicts (value
+// already in use) surface as a per-entry error.
 message LocatorRef {
   string name = 1;
   optional uint32 function = 2;

--- a/proto/vinbero/v1/locator.proto
+++ b/proto/vinbero/v1/locator.proto
@@ -12,10 +12,9 @@ option go_package = "github.com/takehaya/vinbero/api/vinbero/v1;vinberov1";
 // advertise can encode the SRv6 SID Structure sub-sub-TLV (RFC 9252)
 // directly from the locator's metadata.
 //
-// Phase 1 implements Classic SRv6 (RFC 8986). uSID locators
-// (RFC 9800) are accepted at the API surface but reject SID build /
-// parse with Unimplemented; full support arrives in Phase 2 of the
-// GoBGP integration plan.
+// Classic SRv6 (RFC 8986) and uSID (RFC 9800, F3216) locators are both
+// supported: uSID locators build and parse 16-bit service uSIDs with
+// CSID 0 reserved as the container terminator.
 service LocatorService {
   rpc LocatorCreate(LocatorCreateRequest) returns (LocatorCreateResponse);
   rpc LocatorDelete(LocatorDeleteRequest) returns (LocatorDeleteResponse);

--- a/proto/vinbero/v1/locator.proto
+++ b/proto/vinbero/v1/locator.proto
@@ -39,9 +39,10 @@ enum LocatorBehaviorMode {
 // The (block_len + node_len) bits at the front of the prefix identify
 // the PE; the next function_len bits identify the local behavior.
 // Constraints depend on behavior: CLASSIC requires the four lengths to
-// sum to 128 (argument_len holds the remainder); USID requires
-// function_len == 16, argument_len == 0, and a byte-aligned block_len,
-// with the container tail after the function left implicit.
+// sum to 128 (argument_len holds the remainder); USID is fixed to the
+// F3216 structure (block_len == 32, node_len == 16, function_len == 16,
+// argument_len == 0), with the container tail after the function left
+// implicit.
 message Locator {
   string name = 1; // Operator-chosen locator name, e.g. "LOC1-CLASSIC".
   string prefix = 2; // IPv6 prefix, e.g. "fd00:1:1::/48".


### PR DESCRIPTION
## 概要
RFC 9800 uSID サポートの Phase 1 として、locator manager に BehaviorUSID の実体を実装する。

- Validate に USID branch を追加 (block+node == prefix bits、function_len 16 固定、argument_len 0、block は byte 境界)
- BuildSID / ParseSID の USID 実装 (function bits は block+node 直後、残余 zero fill。ParseSID は残余非 0 を拒否)
- CSID 0x0000 を container 終端の予約値として BuildSID / manual / auto 割当の全経路で拒否

## テスト
- go test ./pkg/locator/... green (F3216 往復、validation 違反、CSID 0 拒否、classic 不変)

Stack: phase 1 (this) → #145 → #146。base は feature/usid-support。
