### PR TITLE
docs(examples): make the netns example READMEs English-first

### DIFF
--- a/examples/end-ad/README.ja.md
+++ b/examples/end-ad/README.ja.md
@@ -1,0 +1,35 @@
+# End.AD (Dynamic Proxy) Example
+
+*(English: [README.md](./README.md))*
+
+draft-ietf-spring-srv6-service-programming の End.AD を netns で検証する example です。End.AS と同じ topology で、静的 CACHE の代わりに往路のパケットから SR encapsulation を動的に学習します。
+
+## Topology
+
+```mermaid
+graph LR
+    host1 --- router1
+    router1 --- router2
+    router2 --- router3
+    router3 --- host2
+    router2 --- svc[svc<br/>SR-unaware IPv4 forwarder]
+```
+
+- forward 方向は router1 が H.Encaps で `fc00:2::100, fc00:3::3` を積みます。
+- `fc00:2::100` は router2 の Vinbero が End.AD として処理します。最初の forward パケットから outer IPv6 + SRH を IFACE-IN circuit 単位で cache し、decap した inner を svc へ渡します。svc から戻ったパケットには cache した encapsulation をそのまま前置します。
+- End.AS と違い、SID の設定に segment list を書きません。chain が変わっても設定変更なしで追従します。hop limit の揺れは `--hop-limit-margin` の範囲まで cache を書き換えません。
+- return 方向 (host2 から host1) は proxy を通らない Linux native の経路です。
+
+## 実行方法
+
+```bash
+sudo ./setup.sh
+sudo ./test.sh
+sudo ./teardown.sh
+```
+
+## テスト内容
+
+- Phase 1 は Linux native の End を baseline にして underlay の疎通を確認します (Linux に End.AD は無いため proxy は bypass)。
+- Phase 2 は Vinbero の End.AD で svc 経由の chain を検証します。最初の forward パケットが cache を seed し、svc 側 veth の rx counter でサービス通過を確認します。
+- 同じ IFACE-IN に 2 つ目の proxy SID を作ると reject されること (return circuit の 1:1 制約) も確認します。

--- a/examples/end-ad/README.md
+++ b/examples/end-ad/README.md
@@ -1,6 +1,10 @@
-# End.AD (Dynamic Proxy) Example
+# SRv6 End.AD
 
-draft-ietf-spring-srv6-service-programming の End.AD を netns で検証する example です。End.AS と同じ topology で、静的 CACHE の代わりに往路のパケットから SR encapsulation を動的に学習します。
+*(日本語: [README.ja.md](./README.ja.md))*
+
+netns example for End.AD from draft-ietf-spring-srv6-service-programming.
+Same topology as End.AS, but the SR encapsulation is learned dynamically
+from the forward packets instead of coming from a static CACHE.
 
 ## Topology
 
@@ -13,12 +17,18 @@ graph LR
     router2 --- svc[svc<br/>SR-unaware IPv4 forwarder]
 ```
 
-- forward 方向は router1 が H.Encaps で `fc00:2::100, fc00:3::3` を積みます。
-- `fc00:2::100` は router2 の Vinbero が End.AD として処理します。最初の forward パケットから outer IPv6 + SRH を IFACE-IN circuit 単位で cache し、decap した inner を svc へ渡します。svc から戻ったパケットには cache した encapsulation をそのまま前置します。
-- End.AS と違い、SID の設定に segment list を書きません。chain が変わっても設定変更なしで追従します。hop limit の揺れは `--hop-limit-margin` の範囲まで cache を書き換えません。
-- return 方向 (host2 から host1) は proxy を通らない Linux native の経路です。
+- In the forward direction router1 pushes `fc00:2::100, fc00:3::3` with H.Encaps.
+- `fc00:2::100` is handled by Vinbero on router2 as End.AD. The first forward
+  packet seeds a per-IFACE-IN-circuit cache of the outer IPv6 + SRH; the
+  decapsulated inner packet goes to svc, and whatever comes back gets that
+  cached encapsulation prepended.
+- Unlike End.AS, the SID carries no segment list, so a changed chain needs no
+  configuration change. Hop limit jitter within `--hop-limit-margin` does not
+  rewrite the cache.
+- The return direction (host2 to host1) is plain Linux forwarding and does
+  not traverse the proxy.
 
-## 実行方法
+## Usage
 
 ```bash
 sudo ./setup.sh
@@ -26,8 +36,12 @@ sudo ./test.sh
 sudo ./teardown.sh
 ```
 
-## テスト内容
+## What is verified
 
-- Phase 1 は Linux native の End を baseline にして underlay の疎通を確認します (Linux に End.AD は無いため proxy は bypass)。
-- Phase 2 は Vinbero の End.AD で svc 経由の chain を検証します。最初の forward パケットが cache を seed し、svc 側 veth の rx counter でサービス通過を確認します。
-- 同じ IFACE-IN に 2 つ目の proxy SID を作ると reject されること (return circuit の 1:1 制約) も確認します。
+- Phase 1 establishes an underlay baseline with Linux native End (Linux has
+  no End.AD, so the proxy is bypassed).
+- Phase 2 exercises the chain through svc with Vinbero's End.AD: the first
+  forward packet seeds the cache, and the rx counter on the svc-side veth
+  confirms the service was traversed.
+- Creating a second proxy SID on the same IFACE-IN is rejected (the return
+  circuit is 1:1).

--- a/examples/end-am/README.ja.md
+++ b/examples/end-am/README.ja.md
@@ -1,0 +1,36 @@
+# End.AM (Masquerading Proxy) Example
+
+*(English: [README.md](./README.md))*
+
+draft-ietf-spring-srv6-service-programming の End.AM を netns で検証する example です。SR-unaware なサービスに SRH 付きのままパケットを渡し、宛先だけを最終 segment に偽装します。
+
+## Topology
+
+```mermaid
+graph LR
+    host1 --- router1
+    router1 --- router2
+    router2 --- router3
+    router3 --- host2
+    router2 --- svc[svc<br/>SR-unaware IPv6 forwarder]
+```
+
+- forward 方向は router1 が H.Encaps で `fc00:2::150, fc00:3::3` を積みます。
+- `fc00:2::150` は router2 の Vinbero が End.AM として処理します。SL を消費して DA を最終 segment (`fc00:3::3`) に書き換え、SRH を残したまま svc へ渡します。
+- svc は素の IPv6 router です。パケットは自分宛てではないため SRH を見ずにそのまま転送し、同じ wire で router2 に返します。
+- 復路は packet 内の SRH から DA を復元します。AS / AD と違い、router2 側に out-of-band の状態を一切持ちません。
+- return 方向 (host2 から host1) は proxy を通らない Linux native の経路です。
+
+## 実行方法
+
+```bash
+sudo ./setup.sh
+sudo ./test.sh
+sudo ./teardown.sh
+```
+
+## テスト内容
+
+- Phase 1 は Linux native の End を baseline にして underlay の疎通を確認します (Linux に End.AM は無いため proxy は bypass)。
+- Phase 2 は Vinbero の End.AM で svc 経由の chain を検証します。svc 側 veth の rx counter でサービス通過を確認します。
+- 同じ IFACE-IN に 2 つ目の proxy SID を作ると reject されること (return circuit の 1:1 制約) も確認します。

--- a/examples/end-am/README.md
+++ b/examples/end-am/README.md
@@ -1,6 +1,10 @@
-# End.AM (Masquerading Proxy) Example
+# SRv6 End.AM
 
-draft-ietf-spring-srv6-service-programming の End.AM を netns で検証する example です。SR-unaware なサービスに SRH 付きのままパケットを渡し、宛先だけを最終 segment に偽装します。
+*(日本語: [README.ja.md](./README.ja.md))*
+
+netns example for End.AM from draft-ietf-spring-srv6-service-programming.
+The packet keeps its SRH on the way to the SR-unaware service; only the
+destination is masqueraded as the last segment.
 
 ## Topology
 
@@ -13,13 +17,19 @@ graph LR
     router2 --- svc[svc<br/>SR-unaware IPv6 forwarder]
 ```
 
-- forward 方向は router1 が H.Encaps で `fc00:2::150, fc00:3::3` を積みます。
-- `fc00:2::150` は router2 の Vinbero が End.AM として処理します。SL を消費して DA を最終 segment (`fc00:3::3`) に書き換え、SRH を残したまま svc へ渡します。
-- svc は素の IPv6 router です。パケットは自分宛てではないため SRH を見ずにそのまま転送し、同じ wire で router2 に返します。
-- 復路は packet 内の SRH から DA を復元します。AS / AD と違い、router2 側に out-of-band の状態を一切持ちません。
-- return 方向 (host2 から host1) は proxy を通らない Linux native の経路です。
+- In the forward direction router1 pushes `fc00:2::150, fc00:3::3` with H.Encaps.
+- `fc00:2::150` is handled by Vinbero on router2 as End.AM. It consumes SL,
+  rewrites the DA to the last segment (`fc00:3::3`), and hands the packet to
+  svc with the SRH still in place.
+- svc is a plain IPv6 router. The packet is not addressed to it, so it
+  forwards it without looking at the SRH and returns it to router2 on the
+  same wire.
+- The return path restores the DA from the SRH carried in the packet itself.
+  Unlike AS and AD, router2 keeps no out-of-band state.
+- The return direction (host2 to host1) is plain Linux forwarding and does
+  not traverse the proxy.
 
-## 実行方法
+## Usage
 
 ```bash
 sudo ./setup.sh
@@ -27,8 +37,11 @@ sudo ./test.sh
 sudo ./teardown.sh
 ```
 
-## テスト内容
+## What is verified
 
-- Phase 1 は Linux native の End を baseline にして underlay の疎通を確認します (Linux に End.AM は無いため proxy は bypass)。
-- Phase 2 は Vinbero の End.AM で svc 経由の chain を検証します。svc 側 veth の rx counter でサービス通過を確認します。
-- 同じ IFACE-IN に 2 つ目の proxy SID を作ると reject されること (return circuit の 1:1 制約) も確認します。
+- Phase 1 establishes an underlay baseline with Linux native End (Linux has
+  no End.AM, so the proxy is bypassed).
+- Phase 2 exercises the chain through svc with Vinbero's End.AM. The rx
+  counter on the svc-side veth confirms the service was traversed.
+- Creating a second proxy SID on the same IFACE-IN is rejected (the return
+  circuit is 1:1).

--- a/examples/end-an/README.ja.md
+++ b/examples/end-an/README.ja.md
@@ -1,0 +1,33 @@
+# End.AN (SR-Aware Native Service) Example
+
+*(English: [README.md](./README.md))*
+
+draft-ietf-spring-srv6-service-programming の End.AN を netns で検証する example です。SR-aware なサービスは SRH を自分で理解するため、proxy の往復や circuit は不要で、パケット処理は End と同一です。
+
+## Topology
+
+```mermaid
+graph LR
+    host1 --- router1
+    router1 --- router2
+    router2 --- router3
+    router3 --- host2
+```
+
+- forward 方向は router1 が H.Encaps で `fc00:2::200, fc00:3::3` を積みます。
+- `fc00:2::200` は router2 の Vinbero が End.AN として処理します。転送は End と同じで、専用 slot は per-SID の統計と将来の service liveness 連動のためにあります。
+- `--service-name` で NF catalog の metadata を登録し、`vbctl sid get` で引けることを確認します。NF discovery はこの SidFunctionList / Get を service の registration point として使います。
+- return 方向 (host2 から host1) は Linux native の経路です。
+
+## 実行方法
+
+```bash
+sudo ./setup.sh
+sudo ./test.sh
+sudo ./teardown.sh
+```
+
+## テスト内容
+
+- Phase 1 は Linux native の End を baseline に underlay の疎通を確認します。
+- Phase 2 は Vinbero の End.AN で同じ chain を検証し、`service_name` が API から round trip することを確認します。

--- a/examples/end-an/README.ja.md
+++ b/examples/end-an/README.ja.md
@@ -16,7 +16,7 @@ graph LR
 
 - forward 方向は router1 が H.Encaps で `fc00:2::200, fc00:3::3` を積みます。
 - `fc00:2::200` は router2 の Vinbero が End.AN として処理します。転送は End と同じで、専用 slot は per-SID の統計と将来の service liveness 連動のためにあります。
-- `--service-name` で NF catalog の metadata を登録し、`vbctl sid get` で引けることを確認します。NF discovery はこの SidFunctionList / Get を service の registration point として使います。
+- `--service-name` で NF catalog の metadata を登録し、`vinbero sid get` で引けることを確認します。netns example のクライアントバイナリは `vinbero` です。`vbctl` は interop-clab の Docker image 内にしかありません。NF discovery はこの SidFunctionList / Get を service の registration point として使います。
 - return 方向 (host2 から host1) は Linux native の経路です。
 
 ## 実行方法

--- a/examples/end-an/README.md
+++ b/examples/end-an/README.md
@@ -1,6 +1,10 @@
-# End.AN (SR-Aware Native Service) Example
+# SRv6 End.AN
 
-draft-ietf-spring-srv6-service-programming の End.AN を netns で検証する example です。SR-aware なサービスは SRH を自分で理解するため、proxy の往復や circuit は不要で、パケット処理は End と同一です。
+*(日本語: [README.ja.md](./README.ja.md))*
+
+netns example for End.AN from draft-ietf-spring-srv6-service-programming. An
+SR-aware service understands the SRH itself, so there is no proxy round trip
+and no circuit: packet processing is identical to End.
 
 ## Topology
 
@@ -12,12 +16,16 @@ graph LR
     router3 --- host2
 ```
 
-- forward 方向は router1 が H.Encaps で `fc00:2::200, fc00:3::3` を積みます。
-- `fc00:2::200` は router2 の Vinbero が End.AN として処理します。転送は End と同じで、専用 slot は per-SID の統計と将来の service liveness 連動のためにあります。
-- `--service-name` で NF catalog の metadata を登録し、`vbctl sid get` で引けることを確認します。NF discovery はこの SidFunctionList / Get を service の registration point として使います。
-- return 方向 (host2 から host1) は Linux native の経路です。
+- In the forward direction router1 pushes `fc00:2::200, fc00:3::3` with H.Encaps.
+- `fc00:2::200` is handled by Vinbero on router2 as End.AN. Forwarding is the
+  same as End; the dedicated slot exists for per-SID statistics and for
+  future service liveness integration.
+- `--service-name` registers NF catalog metadata, which `vbctl sid get` reads
+  back. NF discovery uses this SidFunctionList / Get pair as the service
+  registration point.
+- The return direction (host2 to host1) is plain Linux forwarding.
 
-## 実行方法
+## Usage
 
 ```bash
 sudo ./setup.sh
@@ -25,7 +33,8 @@ sudo ./test.sh
 sudo ./teardown.sh
 ```
 
-## テスト内容
+## What is verified
 
-- Phase 1 は Linux native の End を baseline に underlay の疎通を確認します。
-- Phase 2 は Vinbero の End.AN で同じ chain を検証し、`service_name` が API から round trip することを確認します。
+- Phase 1 establishes an underlay baseline with Linux native End.
+- Phase 2 runs the same chain through Vinbero's End.AN and confirms that
+  `service_name` round-trips through the API.

--- a/examples/end-an/README.md
+++ b/examples/end-an/README.md
@@ -20,9 +20,10 @@ graph LR
 - `fc00:2::200` is handled by Vinbero on router2 as End.AN. Forwarding is the
   same as End; the dedicated slot exists for per-SID statistics and for
   future service liveness integration.
-- `--service-name` registers NF catalog metadata, which `vbctl sid get` reads
-  back. NF discovery uses this SidFunctionList / Get pair as the service
-  registration point.
+- `--service-name` registers NF catalog metadata, which `vinbero sid get`
+  reads back (the netns examples use the `vinbero` binary; `vbctl` only
+  exists inside the interop-clab image). NF discovery uses this
+  SidFunctionList / Get pair as the service registration point.
 - The return direction (host2 to host1) is plain Linux forwarding.
 
 ## Usage

--- a/examples/end-as/README.ja.md
+++ b/examples/end-as/README.ja.md
@@ -1,0 +1,35 @@
+# End.AS (Static Proxy) Example
+
+*(English: [README.md](./README.md))*
+
+draft-ietf-spring-srv6-service-programming の End.AS を netns で検証する example です。SR-unaware なサービス (素の IPv4 forwarder) を SRv6 chain の途中に挟みます。
+
+## Topology
+
+```mermaid
+graph LR
+    host1 --- router1
+    router1 --- router2
+    router2 --- router3
+    router3 --- host2
+    router2 --- svc[svc<br/>SR-unaware IPv4 forwarder]
+```
+
+- forward 方向は router1 が H.Encaps で `fc00:2::100, fc00:3::3` を積みます。
+- `fc00:2::100` は router2 の Vinbero が End.AS として処理します。SR encapsulation を剥がして svc へ渡し、svc から戻ったパケットを静的 CACHE (`fc00:3::3`) で再 encapsulation して router3 へ送ります。
+- svc は SRv6 を一切知りません。受け取った IPv4 パケットを経路表に従って同じ wire に送り返すだけです。
+- return 方向 (host2 から host1) は proxy を通らない Linux native の経路です。
+
+## 実行方法
+
+```bash
+sudo ./setup.sh
+sudo ./test.sh
+sudo ./teardown.sh
+```
+
+## テスト内容
+
+- Phase 1 は Linux native の End を baseline にして underlay の疎通を確認します (Linux に End.AS は無いため proxy は bypass)。
+- Phase 2 は Vinbero の End.AS で svc 経由の chain を検証します。svc 側 veth の rx counter が増えることで、トラフィックが実際にサービスを通過したことを確認します。
+- 同じ IFACE-IN に 2 つ目の proxy SID を作ると reject されること (return circuit の 1:1 制約) も確認します。

--- a/examples/end-as/README.md
+++ b/examples/end-as/README.md
@@ -1,6 +1,10 @@
-# End.AS (Static Proxy) Example
+# SRv6 End.AS
 
-draft-ietf-spring-srv6-service-programming の End.AS を netns で検証する example です。SR-unaware なサービス (素の IPv4 forwarder) を SRv6 chain の途中に挟みます。
+*(日本語: [README.ja.md](./README.ja.md))*
+
+netns example for End.AS from draft-ietf-spring-srv6-service-programming. An
+SR-unaware service (a plain IPv4 forwarder) is inserted in the middle of an
+SRv6 chain.
 
 ## Topology
 
@@ -13,12 +17,16 @@ graph LR
     router2 --- svc[svc<br/>SR-unaware IPv4 forwarder]
 ```
 
-- forward 方向は router1 が H.Encaps で `fc00:2::100, fc00:3::3` を積みます。
-- `fc00:2::100` は router2 の Vinbero が End.AS として処理します。SR encapsulation を剥がして svc へ渡し、svc から戻ったパケットを静的 CACHE (`fc00:3::3`) で再 encapsulation して router3 へ送ります。
-- svc は SRv6 を一切知りません。受け取った IPv4 パケットを経路表に従って同じ wire に送り返すだけです。
-- return 方向 (host2 から host1) は proxy を通らない Linux native の経路です。
+- In the forward direction router1 pushes `fc00:2::100, fc00:3::3` with H.Encaps.
+- `fc00:2::100` is handled by Vinbero on router2 as End.AS. It strips the SR
+  encapsulation, hands the packet to svc, and re-encapsulates what comes back
+  using the static CACHE (`fc00:3::3`) before sending it to router3.
+- svc knows nothing about SRv6. It just routes the IPv4 packet it receives
+  back out the same wire.
+- The return direction (host2 to host1) is plain Linux forwarding and does
+  not traverse the proxy.
 
-## 実行方法
+## Usage
 
 ```bash
 sudo ./setup.sh
@@ -26,8 +34,12 @@ sudo ./test.sh
 sudo ./teardown.sh
 ```
 
-## テスト内容
+## What is verified
 
-- Phase 1 は Linux native の End を baseline にして underlay の疎通を確認します (Linux に End.AS は無いため proxy は bypass)。
-- Phase 2 は Vinbero の End.AS で svc 経由の chain を検証します。svc 側 veth の rx counter が増えることで、トラフィックが実際にサービスを通過したことを確認します。
-- 同じ IFACE-IN に 2 つ目の proxy SID を作ると reject されること (return circuit の 1:1 制約) も確認します。
+- Phase 1 establishes an underlay baseline with Linux native End (Linux has
+  no End.AS, so the proxy is bypassed).
+- Phase 2 exercises the chain through svc with Vinbero's End.AS. The rx
+  counter on the svc-side veth growing is what proves the traffic really
+  crossed the service.
+- Creating a second proxy SID on the same IFACE-IN is rejected (the return
+  circuit is 1:1).

--- a/examples/end-dt2-p2mp/README.ja.md
+++ b/examples/end-dt2-p2mp/README.ja.md
@@ -1,12 +1,11 @@
 # SRv6 End.DT2 P2MP Playground
 
-*(日本語: [README.ja.md](./README.ja.md))*
+*(English: [README.md](./README.md))*
 
-Demo environment for a point-to-multipoint L2VPN with SRv6 End.DT2 on Vinbero
-XDP. It exercises BUM flooding towards several remote PEs and flooding across
-several bridge ports.
+Vinbero XDPによるSRv6 End.DT2 P2MP（Point-to-Multipoint）L2VPNのデモ環境です。
+BUM flood による複数リモートPEへの転送と、bridgeの複数ポートへのfloodを検証します。
 
-## Topology
+## トポロジー
 
 ```mermaid
 graph LR
@@ -19,31 +18,29 @@ graph LR
     PE3 -->|VLAN 100| host4[host4<br/>VLAN100: .4]
 ```
 
-**Test scenarios:**
+**テストシナリオ:**
 
-1. BUM P2MP flood: when host1 broadcasts an ARP request, PE1's TC
-   clone-to-self sends one SRv6-encapsulated copy to PE2 and one to PE3
-2. Bridge multi-port flood: after PE2's End.DT2 decapsulates, bridge br100
-   floods to both host2 and host3
-3. Local L2: host2 and host3 sit on the same bridge and talk directly
+1. BUM P2MP flood: host1がARP broadcastを送ると、PE1のTC clone-to-selfが PE2 と PE3 の両方にSRv6 encapしたコピーを送出する
+2. Bridge multi-port flood: PE2のEnd.DT2がdecapした後、bridge br100がhost2とhost3の両方にfloodする
+3. ローカルL2: host2とhost3は同じbridge上なので直接通信できる
 
-## Quick start
+## クイックスタート
 
 ```bash
-sudo ./setup.sh    # build the environment
-sudo ./test.sh     # run the tests
-sudo ./teardown.sh # clean up
+sudo ./setup.sh    # 環境構築
+sudo ./test.sh     # テスト実行
+sudo ./teardown.sh # クリーンアップ
 ```
 
-## Running it by hand
+## 手動実行
 
-### 1. Build the environment
+### 1. 環境構築
 
 ```bash
 sudo ./setup.sh
 ```
 
-### 2. Start Vinbero on the three PEs
+### 2. Vinbero起動（3台のPE）
 
 ```bash
 # PE1
@@ -54,10 +51,10 @@ sudo ip netns exec p2m-router3 ../../out/bin/vinberod -c vinbero_pe2.yaml &
 sudo ip netns exec p2m-router4 ../../out/bin/vinberod -c vinbero_pe3.yaml &
 ```
 
-### 3. Configure the PEs
+### 3. PE設定
 
 ```bash
-# PE1: H.Encaps.L2 + two BdPeers (PE2 and PE3)
+# PE1: H.Encaps.L2 + BdPeer（PE2とPE3の2つ）
 sudo ip netns exec p2m-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
   hl2 create --interface p2m-rt1h1 --vlan-id 100 \
   --src-addr fc00:1::1 --segments fc00:2::1,fc00:3::3 --bd-id 100
@@ -77,20 +74,19 @@ sudo ip netns exec p2m-router4 ../../out/bin/vinbero -s http://127.0.0.1:8084 \
   sid create --trigger-prefix fc00:4::4/128 --action END_DT2 --bd-id 100 --bridge-name br100
 ```
 
-### 4. Test
+### 4. テスト
 
 ```bash
-# BUM P2MP: host1 to host2 (PE2), host3 (PE2 bridge), host4 (PE3)
+# BUM P2MP: host1 → host2 (PE2), host3 (PE2 bridge), host4 (PE3)
 sudo ip netns exec p2m-host1 ping -c 3 -I p2m-h1rt1.100 172.16.100.2
 sudo ip netns exec p2m-host1 ping -c 3 -I p2m-h1rt1.100 172.16.100.3
 sudo ip netns exec p2m-host1 ping -c 3 -I p2m-h1rt1.100 172.16.100.4
 
-# Bridge multi-port: host2 and host3 on the same bridge
+# Bridge multi-port: host2 ↔ host3 (same bridge)
 sudo ip netns exec p2m-host2 ping -c 3 -I p2m-h2rt3.100 172.16.100.3
 ```
 
-### 5. Clean up
-
+### 5. クリーンアップ
 ```bash
 sudo ./teardown.sh
 ```

--- a/examples/end-dt2-p2mp/README.ja.md
+++ b/examples/end-dt2-p2mp/README.ja.md
@@ -65,13 +65,30 @@ sudo ip netns exec p2m-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
 sudo ip netns exec p2m-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
   peer create --bd-id 100 --src-addr fc00:1::1 --segments fc00:2::1,fc00:4::4
 
-# PE2: End.DT2 + H.Encaps.L2 (return)
+# PE2: End.DT2 + H.Encaps.L2 (return、access port ごと) + BdPeer
 sudo ip netns exec p2m-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
   sid create --trigger-prefix fc00:3::3/128 --action END_DT2 --bd-id 100 --bridge-name br100
 
-# PE3: End.DT2 + H.Encaps.L2 (return)
+sudo ip netns exec p2m-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
+  hl2 create --interface p2m-rt3h2 --vlan-id 100 \
+  --src-addr fc00:3::3 --segments fc00:2::2,fc00:1::2 --bd-id 100
+sudo ip netns exec p2m-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
+  hl2 create --interface p2m-rt3h3 --vlan-id 100 \
+  --src-addr fc00:3::3 --segments fc00:2::2,fc00:1::2 --bd-id 100
+
+sudo ip netns exec p2m-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
+  peer create --bd-id 100 --src-addr fc00:3::3 --segments fc00:2::2,fc00:1::2
+
+# PE3: End.DT2 + H.Encaps.L2 (return) + BdPeer
 sudo ip netns exec p2m-router4 ../../out/bin/vinbero -s http://127.0.0.1:8084 \
   sid create --trigger-prefix fc00:4::4/128 --action END_DT2 --bd-id 100 --bridge-name br100
+
+sudo ip netns exec p2m-router4 ../../out/bin/vinbero -s http://127.0.0.1:8084 \
+  hl2 create --interface p2m-rt4h4 --vlan-id 100 \
+  --src-addr fc00:4::4 --segments fc00:2::2,fc00:1::2 --bd-id 100
+
+sudo ip netns exec p2m-router4 ../../out/bin/vinbero -s http://127.0.0.1:8084 \
+  peer create --bd-id 100 --src-addr fc00:4::4 --segments fc00:2::2,fc00:1::2
 ```
 
 ### 4. テスト

--- a/examples/end-dt2-p2mp/README.md
+++ b/examples/end-dt2-p2mp/README.md
@@ -68,13 +68,30 @@ sudo ip netns exec p2m-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
 sudo ip netns exec p2m-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
   peer create --bd-id 100 --src-addr fc00:1::1 --segments fc00:2::1,fc00:4::4
 
-# PE2: End.DT2 + H.Encaps.L2 (return)
+# PE2: End.DT2 + H.Encaps.L2 (return, one per access port) + BdPeer
 sudo ip netns exec p2m-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
   sid create --trigger-prefix fc00:3::3/128 --action END_DT2 --bd-id 100 --bridge-name br100
 
-# PE3: End.DT2 + H.Encaps.L2 (return)
+sudo ip netns exec p2m-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
+  hl2 create --interface p2m-rt3h2 --vlan-id 100 \
+  --src-addr fc00:3::3 --segments fc00:2::2,fc00:1::2 --bd-id 100
+sudo ip netns exec p2m-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
+  hl2 create --interface p2m-rt3h3 --vlan-id 100 \
+  --src-addr fc00:3::3 --segments fc00:2::2,fc00:1::2 --bd-id 100
+
+sudo ip netns exec p2m-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
+  peer create --bd-id 100 --src-addr fc00:3::3 --segments fc00:2::2,fc00:1::2
+
+# PE3: End.DT2 + H.Encaps.L2 (return) + BdPeer
 sudo ip netns exec p2m-router4 ../../out/bin/vinbero -s http://127.0.0.1:8084 \
   sid create --trigger-prefix fc00:4::4/128 --action END_DT2 --bd-id 100 --bridge-name br100
+
+sudo ip netns exec p2m-router4 ../../out/bin/vinbero -s http://127.0.0.1:8084 \
+  hl2 create --interface p2m-rt4h4 --vlan-id 100 \
+  --src-addr fc00:4::4 --segments fc00:2::2,fc00:1::2 --bd-id 100
+
+sudo ip netns exec p2m-router4 ../../out/bin/vinbero -s http://127.0.0.1:8084 \
+  peer create --bd-id 100 --src-addr fc00:4::4 --segments fc00:2::2,fc00:1::2
 ```
 
 ### 4. Test

--- a/examples/end-dt2/README.ja.md
+++ b/examples/end-dt2/README.ja.md
@@ -1,12 +1,11 @@
 # SRv6 End.DT2 Playground
 
-*(日本語: [README.ja.md](./README.ja.md))*
+*(English: [README.md](./README.md))*
 
-Demo environment for SRv6 End.DT2 (decapsulation with L2 table lookup) on
-Vinbero XDP. It exercises a full bidirectional L2VPN including bridge
-domains, MAC learning and BUM flooding.
+Vinbero XDPによるSRv6 End.DT2 (Decapsulation with L2 Table lookup) のデモ環境です。
+Bridge Domain、MAC学習、BUM flooding を含むL2VPNの完全な双方向動作を検証します。
 
-## Topology
+## トポロジー
 
 ```mermaid
 graph LR
@@ -16,60 +15,59 @@ graph LR
     router3 -->|VLAN 100| host2[host2<br/>VLAN100: 172.16.100.2]
 ```
 
-**Packet walk (host1 to host2, first ARP):**
-1. host1 broadcasts an ARP request on VLAN 100
-2. router1 (Vinbero XDP) recognises the BUM frame and hands it to TC with XDP_PASS
-3. router1 (TC) clones to self and sends one SRv6-encapsulated copy per remote PE
-   - VLAN materialization restores the VLAN tag on the inner frame
-4. router2 transits the SRH with End
-5. router3 (Vinbero XDP) runs End.DT2:
-   - decapsulates SRv6 and extracts the inner L2 frame (still tagged VLAN 100)
-   - learns the inner source MAC as a remote FDB entry
-   - FDB miss, so it redirects to bridge br100 and floods
-6. host2 receives the ARP request and replies
+**パケットの流れ（host1 → host2、初回ARP）:**
+1. host1がVLAN 100でARP broadcastを送信する
+2. router1（Vinbero XDP）がBUMフレームを検出し、XDP_PASSでTCに渡す
+3. router1（TC）がclone-to-selfで各リモートPEにSRv6 encapしたコピーを送出する
+   - VLAN materializationでinner frameにVLAN tagを復元する
+4. router2がEndでSRH transitする
+5. router3（Vinbero XDP）がEnd.DT2を実行する
+   - SRv6 decapしてinner L2 frame（VLAN 100付き）を取り出す
+   - inner src MACをリモートエントリとしてFDBに学習する
+   - FDB miss → bridge br100にredirectしてfloodする
+6. host2がARP requestを受信し、replyを返す
 
-Subsequent unicast frames are encapsulated straight to the peer PE, because
-the FDB has been learned.
+2回目以降のユニキャストは、FDB学習済みのため直接対向PEにSRv6 encapされます。
 
-## Quick start
+## クイックスタート
 
 ```bash
-sudo ./setup.sh    # build the environment
-sudo ./test.sh     # run the tests
-sudo ./teardown.sh # clean up
+sudo ./setup.sh    # 環境構築
+sudo ./test.sh     # テスト実行
+sudo ./teardown.sh # クリーンアップ
 ```
 
-## Running it by hand
+## 手動実行
 
-### 1. Build the environment and start Vinbero
+### 1. 環境構築とVinbero起動
 
 ```bash
 sudo ./setup.sh
 
-# router1: H.Encaps.L2 + TC BUM
+# router1でVinbero起動（H.Encaps.L2 + TC BUM）
 sudo ip netns exec dt2-router1 ../../out/bin/vinberod -c vinbero_router1.yaml &
 
-# router3: End.DT2 + the H.Encaps.L2 return path
+# router3でVinbero起動（End.DT2 + H.Encaps.L2 return path）
 sudo ip netns exec dt2-router3 ../../out/bin/vinberod -c vinbero_router3.yaml &
 ```
 
-### 2. Configure router1 (forward path)
+### 2. router1の設定（forward path）
 
 ```bash
-# H.Encaps.L2: VLAN 100 -> BD 100 -> SRv6 encap
+# H.Encaps.L2: VLAN 100 → BD 100 → SRv6 encap
 sudo ip netns exec dt2-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
   hl2 create --interface dt2-rt1h1 --vlan-id 100 \
   --src-addr fc00:1::1 --segments fc00:2::1,fc00:3::3 --bd-id 100
 
-# BdPeer: register the remote PE (router3) for BD 100
+# BdPeer: BD 100のリモートPE（router3）を登録
 sudo ip netns exec dt2-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
   peer create --bd-id 100 --src-addr fc00:1::1 --segments fc00:2::1,fc00:3::3
 ```
 
-### 3. Configure router3 (decap + return path)
+### 3. router3の設定（decap + return path）
 
 ```bash
-# End.DT2: SRv6 decap -> BD 100 -> bridge flood
+# End.DT2: SRv6 decap → BD 100 → bridge flood
 sudo ip netns exec dt2-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
   sid create --trigger-prefix fc00:3::3/128 --action END_DT2 --bd-id 100 --bridge-name br100
 
@@ -83,28 +81,27 @@ sudo ip netns exec dt2-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
   peer create --bd-id 100 --src-addr fc00:3::3 --segments fc00:2::2,fc00:1::2
 ```
 
-### 4. Test
+### 4. テスト
 
 ```bash
-# ping across the L2VPN (VLAN 100)
+# L2VPN経由のping（VLAN 100）
 sudo ip netns exec dt2-host1 ping -c 3 -I dt2-h1rt1.100 172.16.100.2
 
-# inspect the FDB entries
+# FDBエントリの確認
 sudo ip netns exec dt2-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 fdb list
 ```
 
-#### Packet capture
+#### パケットキャプチャ
 
 ```bash
-# SRv6-encapsulated packets between router1 and router2
+# router1-router2間でSRv6 encap済みパケットを確認
 sudo ip netns exec dt2-router1 tcpdump -i dt2-rt1rt2 -n ip6
 
-# decapsulated L2 frames (VLAN 100) between router3 and host2
+# router3-host2間でdecap後のL2フレーム（VLAN 100）を確認
 sudo ip netns exec dt2-router3 tcpdump -i dt2-rt3h2 -n -e
 ```
 
-### 5. Clean up
-
+### 5. クリーンアップ
 ```bash
 sudo ./teardown.sh
 ```

--- a/examples/end-dt2m-multihomed/README.ja.md
+++ b/examples/end-dt2m-multihomed/README.ja.md
@@ -60,8 +60,8 @@ sudo ./teardown.sh
 ## テストで検証する内容
 
 1. **Split-horizon (Phase C)**: `host1 → broadcast → PE1` が PE2 経由で
-   host1 に戻ってこないこと。PE1 側で `SPLIT_HORIZON_TX > 0`、PE2 側
-   (fail-safe 経路) で `SPLIT_HORIZON_RX` をアサート。
+   host1 に戻ってこないこと。両 PE で `SPLIT_HORIZON_TX > 0` をアサート
+   し、host1 側の pcap に自分発の ARP frame が 0 件であることを確認。
 2. **DF 選出 (Phase D)**: 以下のコマンド例の `vbctl` は `test.sh` /
    `smoke_api.sh` が `vinbero -s http://127.0.0.1:<PE port>` を包んだシェル関数
    です。netns 内に `vbctl` という実バイナリはありません。`--esi` には冒頭の実

--- a/examples/end-dt2m-multihomed/README.ja.md
+++ b/examples/end-dt2m-multihomed/README.ja.md
@@ -1,0 +1,109 @@
+# End.DT2M マルチホーム Playground
+
+*(English: [README.md](./README.md))*
+
+RFC 9252 の split-horizon フィルタリングと静的 DF 選出を、**host1 が共有 Linux
+ブリッジ経由で PE1 と PE2 にデュアルホームする** 5-namespace トポロジー上で
+検証します。
+
+- ESI: `01:00:00:00:00:00:00:00:00:01` (PE1/PE2 共に `local_attached`)
+- Bridge Domain: `bd_id = 100` / VLAN 100
+- host1 の MAC は MAC Pinning で `02:00:00:00:00:01` 固定
+- host1 側の veth は `ethtool -K <veth> txvlan off` で VLAN タグをパケット
+  データに残す (veth の VLAN offload は既知の罠)
+
+## トポロジー
+
+```mermaid
+flowchart LR
+    host1["host1<br/>172.16.100.1<br/>VLAN 100"]
+
+    subgraph ES1["ES-1 (共有 CE / mh-h1-br)"]
+      direction LR
+      leg1(( )):::leg
+      leg2(( )):::leg
+    end
+
+    pe1["mh-pe1<br/>fc00:1::1<br/>local_attached ES-1"]
+    pe2["mh-pe2<br/>fc00:2::2<br/>local_attached ES-1"]
+    p["mh-p<br/>fc00:99::1<br/>End (transit)"]
+    pe3["mh-pe3<br/>fc00:3::3"]
+    host2["host2<br/>172.16.100.2"]
+
+    host1 --- leg1
+    host1 --- leg2
+    leg1 --- pe1
+    leg2 --- pe2
+
+    pe1 <-. SRv6 .-> p
+    pe2 <-. SRv6 .-> p
+    p   <-. SRv6 .-> pe3
+    pe3 --- host2
+
+    classDef leg fill:#eef,stroke:#88a,stroke-dasharray:2 2;
+```
+
+PE1 と PE2 は `mh-host1` 内の `mh-h1-br` を介して host1 と接続され、2 本の
+veth レッグが生えます。split-horizon が無いと host1 からの BUM が他方の PE
+経由でループバックしてきますが、RFC 9252 の split-horizon + DF 選出を入れ
+ることで BUM が正しく一方向にファンアウトします。
+
+## クイックスタート (要 sudo)
+
+```bash
+sudo ./setup.sh
+# (各 PE で vinberod が ready になるのを待つ)
+sudo ./test.sh
+sudo ./teardown.sh
+```
+
+## テストで検証する内容
+
+1. **Split-horizon (Phase C)**: `host1 → broadcast → PE1` が PE2 経由で
+   host1 に戻ってこないこと。PE1 側で `SPLIT_HORIZON_TX > 0`、PE2 側
+   (fail-safe 経路) で `SPLIT_HORIZON_RX` をアサート。
+2. **DF 選出 (Phase D)**: 以下のコマンド例の `vbctl` は `test.sh` /
+   `smoke_api.sh` が `vinbero -s http://127.0.0.1:<PE port>` を包んだシェル関数
+   です。netns 内に `vbctl` という実バイナリはありません。`--esi` には冒頭の実
+   ESI を渡します。
+   - 初期状態は DF=PE1。両 PE で
+     `vbctl es df-set --esi 01:00:00:00:00:00:00:00:00:01 --pe fc00:1::1` を実行して DF を一致させる。
+   - リモートからの `PE3 → BUM → host1` は PE1 経由でのみ host1 に届く
+     (PE2 側は `NON_DF_DROP` で落ちる)。
+   - DF を PE2 に切り替え:
+     `vbctl es df-set --esi 01:00:00:00:00:00:00:00:00:01 --pe fc00:2::2`
+     → 以降は PE2 経由で届く。
+
+## ステータス
+
+**データプレーン** (eBPF ロジック): `pkg/bpf/split_horizon_test.go` の
+BPF_PROG_TEST_RUN ベースのアサーションで完全にカバー済み。
+- `TestXDPProgEndDT2MSplitHorizonRX` (Phase C: RX 側 drop)
+- `TestXDPProgEndDT2MNonDFDrop` (Phase D: DF ゲート)
+- `TestBdPeerReverseEsi` (`bd_peer_reverse_map` への ESI 伝播)
+
+**コントロールプレーン API** (Connect RPC): 同ディレクトリの
+`smoke_api.sh` で検証。vinberod を 1 台だけ立ち上げ (データプレーントラ
+フィック無し)、`es create / list / df-set / df-clear / delete` と
+`bd-peer create --esi` を一通り叩きます。
+
+**フル E2E トポロジー**: 同ディレクトリの `setup.sh` / `test.sh` で
+5-namespace の shared-CE トポロジーを立ち上げます。BPF コード自体は
+上記のユニットテストで検証済みですが、Linux bridge との相互作用
+(veth tx-vlan offload、ARP 重複、MAC Pinning 等) の確認には E2E が有用
+です。まず `smoke_api.sh` を green にしてから `setup.sh` + `test.sh`
+に進むのがおすすめです。
+
+## ファイル一覧
+
+| ファイル | 用途 |
+|---|---|
+| `README.md` | 本ドキュメント |
+| `smoke_api.sh` | API のみのスモーク (PE 1 台、データプレーン無し、10 秒以内に完走) |
+| `setup.sh` | 共有 CE ブリッジを含む 5-namespace トポロジー構築 |
+| `teardown.sh` | namespace / veth の撤去 |
+| `test.sh` | pcap + stats アサーション付きの E2E テスト |
+| `vinbero_pe1.yaml` | PE1 設定 (ES-1 local_attached) |
+| `vinbero_pe2.yaml` | PE2 設定 (ES-1 local_attached) |
+| `vinbero_p.yaml` | 中継ルータ設定 (End) |
+| `vinbero_pe3.yaml` | 出口 PE 設定 (シングルホーム) |

--- a/examples/end-dt2m-multihomed/README.ja.md
+++ b/examples/end-dt2m-multihomed/README.ja.md
@@ -98,7 +98,7 @@ BPF_PROG_TEST_RUN ベースのアサーションで完全にカバー済み。
 
 | ファイル | 用途 |
 |---|---|
-| `README.md` | 本ドキュメント |
+| `README.ja.md` | 本ドキュメント (英語版は `README.md`) |
 | `smoke_api.sh` | API のみのスモーク (PE 1 台、データプレーン無し、10 秒以内に完走) |
 | `setup.sh` | 共有 CE ブリッジを含む 5-namespace トポロジー構築 |
 | `teardown.sh` | namespace / veth の撤去 |

--- a/examples/end-dt2m-multihomed/README.md
+++ b/examples/end-dt2m-multihomed/README.md
@@ -1,22 +1,24 @@
-# End.DT2M マルチホーム Playground
+# SRv6 End.DT2M multi-homing
 
-RFC 9252 の split-horizon フィルタリングと静的 DF 選出を、**host1 が共有 Linux
-ブリッジ経由で PE1 と PE2 にデュアルホームする** 5-namespace トポロジー上で
-検証します。
+*(日本語: [README.ja.md](./README.ja.md))*
 
-- ESI: `01:00:00:00:00:00:00:00:00:01` (PE1/PE2 共に `local_attached`)
-- Bridge Domain: `bd_id = 100` / VLAN 100
-- host1 の MAC は MAC Pinning で `02:00:00:00:00:01` 固定
-- host1 側の veth は `ethtool -K <veth> txvlan off` で VLAN タグをパケット
-  データに残す (veth の VLAN offload は既知の罠)
+Verifies RFC 9252 split-horizon filtering and static DF election on a
+5-namespace topology where **host1 is dual-homed to PE1 and PE2 through a
+shared Linux bridge**.
 
-## トポロジー
+- ESI: `01:00:00:00:00:00:00:00:00:01` (`local_attached` on both PE1 and PE2)
+- Bridge domain: `bd_id = 100` / VLAN 100
+- host1's MAC is pinned to `02:00:00:00:00:01` with MAC pinning
+- The host1-side veths run `ethtool -K <veth> txvlan off` so the VLAN tag
+  stays in the packet data (veth VLAN offload is a known trap)
+
+## Topology
 
 ```mermaid
 flowchart LR
     host1["host1<br/>172.16.100.1<br/>VLAN 100"]
 
-    subgraph ES1["ES-1 (共有 CE / mh-h1-br)"]
+    subgraph ES1["ES-1 (shared CE / mh-h1-br)"]
       direction LR
       leg1(( )):::leg
       leg2(( )):::leg
@@ -41,67 +43,66 @@ flowchart LR
     classDef leg fill:#eef,stroke:#88a,stroke-dasharray:2 2;
 ```
 
-PE1 と PE2 は `mh-host1` 内の `mh-h1-br` を介して host1 と接続され、2 本の
-veth レッグが生えます。split-horizon が無いと host1 からの BUM が他方の PE
-経由でループバックしてきますが、RFC 9252 の split-horizon + DF 選出を入れ
-ることで BUM が正しく一方向にファンアウトします。
+PE1 and PE2 reach host1 through `mh-h1-br` inside `mh-host1`, so two veth
+legs come off it. Without split-horizon, BUM traffic from host1 loops back
+through the other PE; RFC 9252 split-horizon plus DF election makes it fan
+out in one direction only.
 
-## クイックスタート (要 sudo)
+## Quick start (needs sudo)
 
 ```bash
 sudo ./setup.sh
-# (各 PE で vinberod が ready になるのを待つ)
+# (wait for vinberod to become ready on each PE)
 sudo ./test.sh
 sudo ./teardown.sh
 ```
 
-## テストで検証する内容
+## What the test verifies
 
-1. **Split-horizon (Phase C)**: `host1 → broadcast → PE1` が PE2 経由で
-   host1 に戻ってこないこと。PE1 側で `SPLIT_HORIZON_TX > 0`、PE2 側
-   (fail-safe 経路) で `SPLIT_HORIZON_RX` をアサート。
-2. **DF 選出 (Phase D)**: 以下のコマンド例の `vbctl` は `test.sh` /
-   `smoke_api.sh` が `vinbero -s http://127.0.0.1:<PE port>` を包んだシェル関数
-   です。netns 内に `vbctl` という実バイナリはありません。`--esi` には冒頭の実
-   ESI を渡します。
-   - 初期状態は DF=PE1。両 PE で
-     `vbctl es df-set --esi 01:00:00:00:00:00:00:00:00:01 --pe fc00:1::1` を実行して DF を一致させる。
-   - リモートからの `PE3 → BUM → host1` は PE1 経由でのみ host1 に届く
-     (PE2 側は `NON_DF_DROP` で落ちる)。
-   - DF を PE2 に切り替え:
-     `vbctl es df-set --esi 01:00:00:00:00:00:00:00:00:01 --pe fc00:2::2`
-     → 以降は PE2 経由で届く。
+1. **Split-horizon (phase C)**: `host1 -> broadcast -> PE1` does not come back
+   to host1 via PE2. It asserts `SPLIT_HORIZON_TX > 0` on PE1 and
+   `SPLIT_HORIZON_RX` on PE2 (the fail-safe path).
+2. **DF election (phase D)**: `vbctl` in the commands below is a shell
+   function that `test.sh` and `smoke_api.sh` define around `vinbero -s
+   http://127.0.0.1:<PE port>`; there is no `vbctl` binary inside the
+   namespaces. Pass the real ESI from the top of this page to `--esi`.
+   - DF starts as PE1. Run
+     `vbctl es df-set --esi 01:00:00:00:00:00:00:00:00:01 --pe fc00:1::1`
+     on both PEs so they agree on the DF.
+   - `PE3 -> BUM -> host1` from the remote side reaches host1 only via PE1
+     (PE2 drops it as `NON_DF_DROP`).
+   - Switch the DF to PE2 with
+     `vbctl es df-set --esi 01:00:00:00:00:00:00:00:00:01 --pe fc00:2::2`,
+     after which the traffic arrives via PE2.
 
-## ステータス
+## Status
 
-**データプレーン** (eBPF ロジック): `pkg/bpf/split_horizon_test.go` の
-BPF_PROG_TEST_RUN ベースのアサーションで完全にカバー済み。
-- `TestXDPProgEndDT2MSplitHorizonRX` (Phase C: RX 側 drop)
-- `TestXDPProgEndDT2MNonDFDrop` (Phase D: DF ゲート)
-- `TestBdPeerReverseEsi` (`bd_peer_reverse_map` への ESI 伝播)
+**Data plane** (eBPF logic): fully covered by the BPF_PROG_TEST_RUN
+assertions in `pkg/bpf/split_horizon_test.go`.
+- `TestXDPProgEndDT2MSplitHorizonRX` (phase C: RX-side drop)
+- `TestXDPProgEndDT2MNonDFDrop` (phase D: DF gate)
+- `TestBdPeerReverseEsi` (ESI propagation into `bd_peer_reverse_map`)
 
-**コントロールプレーン API** (Connect RPC): 同ディレクトリの
-`smoke_api.sh` で検証。vinberod を 1 台だけ立ち上げ (データプレーントラ
-フィック無し)、`es create / list / df-set / df-clear / delete` と
-`bd-peer create --esi` を一通り叩きます。
+**Control plane API** (Connect RPC): covered by `smoke_api.sh` in this
+directory. It brings up a single vinberod (no data-plane traffic) and walks
+`es create / list / df-set / df-clear / delete` plus `bd-peer create --esi`.
 
-**フル E2E トポロジー**: 同ディレクトリの `setup.sh` / `test.sh` で
-5-namespace の shared-CE トポロジーを立ち上げます。BPF コード自体は
-上記のユニットテストで検証済みですが、Linux bridge との相互作用
-(veth tx-vlan offload、ARP 重複、MAC Pinning 等) の確認には E2E が有用
-です。まず `smoke_api.sh` を green にしてから `setup.sh` + `test.sh`
-に進むのがおすすめです。
+**Full E2E topology**: `setup.sh` and `test.sh` here build the 5-namespace
+shared-CE topology. The BPF code itself is covered by the unit tests above,
+but the E2E run is what exercises the interaction with the Linux bridge (veth
+tx-vlan offload, duplicate ARP, MAC pinning). Getting `smoke_api.sh` green
+first and then moving to `setup.sh` + `test.sh` is the smoother path.
 
-## ファイル一覧
+## Files
 
-| ファイル | 用途 |
+| File | Purpose |
 |---|---|
-| `README.md` | 本ドキュメント |
-| `smoke_api.sh` | API のみのスモーク (PE 1 台、データプレーン無し、10 秒以内に完走) |
-| `setup.sh` | 共有 CE ブリッジを含む 5-namespace トポロジー構築 |
-| `teardown.sh` | namespace / veth の撤去 |
-| `test.sh` | pcap + stats アサーション付きの E2E テスト |
-| `vinbero_pe1.yaml` | PE1 設定 (ES-1 local_attached) |
-| `vinbero_pe2.yaml` | PE2 設定 (ES-1 local_attached) |
-| `vinbero_p.yaml` | 中継ルータ設定 (End) |
-| `vinbero_pe3.yaml` | 出口 PE 設定 (シングルホーム) |
+| `README.md` | This document |
+| `smoke_api.sh` | API-only smoke test (one PE, no data plane, finishes within 10 seconds) |
+| `setup.sh` | Builds the 5-namespace topology including the shared CE bridge |
+| `teardown.sh` | Removes the namespaces and veths |
+| `test.sh` | E2E test with pcap and stats assertions |
+| `vinbero_pe1.yaml` | PE1 config (ES-1 local_attached) |
+| `vinbero_pe2.yaml` | PE2 config (ES-1 local_attached) |
+| `vinbero_p.yaml` | Transit router config (End) |
+| `vinbero_pe3.yaml` | Egress PE config (single-homed) |

--- a/examples/end-dt2m-multihomed/README.md
+++ b/examples/end-dt2m-multihomed/README.md
@@ -97,7 +97,7 @@ first and then moving to `setup.sh` + `test.sh` is the smoother path.
 
 | File | Purpose |
 |---|---|
-| `README.md` | This document |
+| `README.md` | This document (Japanese version: `README.ja.md`) |
 | `smoke_api.sh` | API-only smoke test (one PE, no data plane, finishes within 10 seconds) |
 | `setup.sh` | Builds the 5-namespace topology including the shared CE bridge |
 | `teardown.sh` | Removes the namespaces and veths |

--- a/examples/end-dt2m-multihomed/README.md
+++ b/examples/end-dt2m-multihomed/README.md
@@ -60,8 +60,8 @@ sudo ./teardown.sh
 ## What the test verifies
 
 1. **Split-horizon (phase C)**: `host1 -> broadcast -> PE1` does not come back
-   to host1 via PE2. It asserts `SPLIT_HORIZON_TX > 0` on PE1 and
-   `SPLIT_HORIZON_RX` on PE2 (the fail-safe path).
+   to host1 via PE2. It asserts `SPLIT_HORIZON_TX > 0` on both PEs and
+   checks a pcap on the host1 side for zero self-sourced ARP frames.
 2. **DF election (phase D)**: `vbctl` in the commands below is a shell
    function that `test.sh` and `smoke_api.sh` define around `vinbero -s
    http://127.0.0.1:<PE port>`; there is no `vbctl` binary inside the

--- a/examples/end-dt4/README.ja.md
+++ b/examples/end-dt4/README.ja.md
@@ -1,0 +1,76 @@
+# SRv6 End.DT4 Playground
+
+*(English: [README.md](./README.md))*
+
+Vinbero XDPによるSRv6 End.DT4 (Decapsulation with IPv4 Table lookup via VRF) のデモ環境です。
+
+## トポロジー
+
+```mermaid
+graph LR
+    host1[host1<br/>172.0.1.1] -->|IPv4| router1[router1<br/>172.0.1.2<br/>fc00:1::1<br/>H.Encaps]
+    router1 -->|SRv6| router2[router2<br/>fc00:12::2<br/>End]
+    router2 -->|SRv6| router3[router3 / Vinbero XDP<br/>172.0.2.2<br/>SID: fc00:3::3<br/>End.DT4<br/>VRF: vrf100 table 100]
+    router3 -->|IPv4| host2[host2<br/>172.0.2.1]
+```
+
+**パケットの流れ（host1 → host2の例）:**
+1. host1が172.0.2.1にpingを送信（IPv4）
+2. router1がLinux native H.Encapsを実行し、IPv4パケットをIPv6+SRHでカプセル化する
+3. router2がfc00:2::1でEnd操作を実行する（SL減少、次のセグメントへ）
+4. router3（Vinbero XDP）がfc00:3::3でEnd.DT4を実行する
+   - 外側IPv6+SRHヘッダを除去する
+   - VRF vrf100のルーティングテーブルでFIBルックアップし、host2へ転送する
+5. host2がpingを受信する
+
+End.DX4との違いは、End.DT4はVRF内のルーティングテーブルを参照するため、複数の顧客ネットワークをVRFで分離できる点です。
+
+## クイックスタート
+
+```bash
+sudo ./setup.sh    # 環境構築
+sudo ./test.sh     # テスト実行
+sudo ./teardown.sh # クリーンアップ
+```
+
+## 手動実行
+
+### 1. 環境構築とVinbero起動
+
+```bash
+sudo ./setup.sh
+
+# router3のLinux native End.DT4ルートを削除
+sudo ip netns exec dt4-router3 ip -6 route del local fc00:3::3/128 2>/dev/null
+
+# Vinbero起動
+sudo ip netns exec dt4-router3 ../../out/bin/vinberod -c vinbero_router3.yaml
+```
+
+### 2. SidFunction (End.DT4) エントリ登録
+
+```bash
+sudo ip netns exec dt4-router3 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
+  sid create --trigger-prefix fc00:3::3/128 --action END_DT4 --vrf-name vrf100
+```
+
+### 3. テスト
+
+```bash
+sudo ip netns exec dt4-host1 ping -c 3 172.0.2.1
+```
+
+#### パケットキャプチャ
+
+```bash
+# router2-router3間でSRv6パケットを確認
+sudo ip netns exec dt4-router3 tcpdump -i dt4-rt3rt2 -n ip6
+
+# router3-host2間でデカプセル化後のIPv4パケットを確認
+sudo ip netns exec dt4-router3 tcpdump -i dt4-rt3h2 -n ip
+```
+
+### 4. クリーンアップ
+```bash
+sudo ./teardown.sh
+```

--- a/examples/end-dt4/README.md
+++ b/examples/end-dt4/README.md
@@ -1,8 +1,11 @@
 # SRv6 End.DT4 Playground
 
-Vinbero XDPによるSRv6 End.DT4 (Decapsulation with IPv4 Table lookup via VRF) のデモ環境です。
+*(日本語: [README.ja.md](./README.ja.md))*
 
-## トポロジー
+Demo environment for SRv6 End.DT4 (decapsulation with IPv4 table lookup via
+VRF) on Vinbero XDP.
+
+## Topology
 
 ```mermaid
 graph LR
@@ -12,63 +15,66 @@ graph LR
     router3 -->|IPv4| host2[host2<br/>172.0.2.1]
 ```
 
-**パケットの流れ（host1 → host2の例）:**
-1. host1が172.0.2.1にpingを送信（IPv4）
-2. router1がLinux native H.Encapsを実行し、IPv4パケットをIPv6+SRHでカプセル化する
-3. router2がfc00:2::1でEnd操作を実行する（SL減少、次のセグメントへ）
-4. router3（Vinbero XDP）がfc00:3::3でEnd.DT4を実行する
-   - 外側IPv6+SRHヘッダを除去する
-   - VRF vrf100のルーティングテーブルでFIBルックアップし、host2へ転送する
-5. host2がpingを受信する
+**Packet walk (host1 to host2):**
+1. host1 pings 172.0.2.1 over IPv4
+2. router1 runs Linux native H.Encaps and wraps the IPv4 packet in IPv6 + SRH
+3. router2 runs End on fc00:2::1: decrement SL, move to the next segment
+4. router3 (Vinbero XDP) runs End.DT4 on fc00:3::3:
+   - strips the outer IPv6 + SRH headers
+   - resolves the inner packet in VRF vrf100's routing table and forwards it
+     to host2
+5. host2 receives the ping
 
-End.DX4との違いは、End.DT4はVRF内のルーティングテーブルを参照するため、複数の顧客ネットワークをVRFで分離できる点です。
+The difference from End.DX4 is the VRF routing table lookup, which lets
+several customer networks stay separated per VRF.
 
-## クイックスタート
+## Quick start
 
 ```bash
-sudo ./setup.sh    # 環境構築
-sudo ./test.sh     # テスト実行
-sudo ./teardown.sh # クリーンアップ
+sudo ./setup.sh    # build the environment
+sudo ./test.sh     # run the tests
+sudo ./teardown.sh # clean up
 ```
 
-## 手動実行
+## Running it by hand
 
-### 1. 環境構築とVinbero起動
+### 1. Build the environment and start Vinbero
 
 ```bash
 sudo ./setup.sh
 
-# router3のLinux native End.DT4ルートを削除
+# Remove the Linux native End.DT4 route on router3
 sudo ip netns exec dt4-router3 ip -6 route del local fc00:3::3/128 2>/dev/null
 
-# Vinbero起動
+# Start Vinbero
 sudo ip netns exec dt4-router3 ../../out/bin/vinberod -c vinbero_router3.yaml
 ```
 
-### 2. SidFunction (End.DT4) エントリ登録
+### 2. Register the SidFunction (End.DT4) entry
 
 ```bash
 sudo ip netns exec dt4-router3 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
   sid create --trigger-prefix fc00:3::3/128 --action END_DT4 --vrf-name vrf100
 ```
 
-### 3. テスト
+### 3. Test
 
 ```bash
 sudo ip netns exec dt4-host1 ping -c 3 172.0.2.1
 ```
 
-#### パケットキャプチャ
+#### Packet capture
 
 ```bash
-# router2-router3間でSRv6パケットを確認
+# SRv6 packets between router2 and router3
 sudo ip netns exec dt4-router3 tcpdump -i dt4-rt3rt2 -n ip6
 
-# router3-host2間でデカプセル化後のIPv4パケットを確認
+# Decapsulated IPv4 packets between router3 and host2
 sudo ip netns exec dt4-router3 tcpdump -i dt4-rt3h2 -n ip
 ```
 
-### 4. クリーンアップ
+### 4. Clean up
+
 ```bash
 sudo ./teardown.sh
 ```

--- a/examples/end-dt6/README.ja.md
+++ b/examples/end-dt6/README.ja.md
@@ -1,0 +1,76 @@
+# SRv6 End.DT6 Playground
+
+*(English: [README.md](./README.md))*
+
+Vinbero XDPによるSRv6 End.DT6 (Decapsulation with IPv6 Table lookup via VRF) のデモ環境です。
+
+## トポロジー
+
+```mermaid
+graph LR
+    host1[host1<br/>10.0.1.1<br/>2001:db8:1::1] -->|IPv6| router1[router1<br/>fc00:1::1<br/>H.Encaps]
+    router1 -->|SRv6| router2[router2<br/>fc00:12::2<br/>End]
+    router2 -->|SRv6| router3[router3 / Vinbero XDP<br/>SID: fc00:3::3<br/>End.DT6<br/>VRF: vrf100 table 100]
+    router3 -->|IPv6| host2[host2<br/>10.0.1.2<br/>2001:db8:2::1]
+```
+
+**パケットの流れ（host1 → host2の例）:**
+1. host1が2001:db8:2::1にpingを送信（IPv6）
+2. router1がLinux native H.Encapsを実行し、IPv6パケットを外側IPv6+SRHでカプセル化する
+3. router2がfc00:2::1でEnd操作を実行する（SL減少、次のセグメントへ）
+4. router3（Vinbero XDP）がfc00:3::3でEnd.DT6を実行する
+   - 外側IPv6+SRHヘッダを除去する
+   - VRF vrf100のルーティングテーブルでFIBルックアップし、host2へ転送する
+5. host2がpingを受信する
+
+End.DT4との違いは、内側パケットがIPv6である点です。End.DT46を使えばIPv4/IPv6の両方を1つのSIDで処理できます。
+
+## クイックスタート
+
+```bash
+sudo ./setup.sh    # 環境構築
+sudo ./test.sh     # テスト実行
+sudo ./teardown.sh # クリーンアップ
+```
+
+## 手動実行
+
+### 1. 環境構築とVinbero起動
+
+```bash
+sudo ./setup.sh
+
+# router3のLinux native End.DT6ルートを削除
+sudo ip netns exec dt6-router3 ip -6 route del local fc00:3::3/128 2>/dev/null
+
+# Vinbero起動
+sudo ip netns exec dt6-router3 ../../out/bin/vinberod -c vinbero_router3.yaml
+```
+
+### 2. SidFunction (End.DT6) エントリ登録
+
+```bash
+sudo ip netns exec dt6-router3 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
+  sid create --trigger-prefix fc00:3::3/128 --action END_DT6 --vrf-name vrf100
+```
+
+### 3. テスト
+
+```bash
+sudo ip netns exec dt6-host1 ping6 -c 3 2001:db8:2::1
+```
+
+#### パケットキャプチャ
+
+```bash
+# router2-router3間でSRv6パケットを確認
+sudo ip netns exec dt6-router3 tcpdump -i dt6-rt3rt2 -n ip6
+
+# router3-host2間でデカプセル化後のIPv6パケットを確認
+sudo ip netns exec dt6-router3 tcpdump -i dt6-rt3h2 -n ip6
+```
+
+### 4. クリーンアップ
+```bash
+sudo ./teardown.sh
+```

--- a/examples/end-dt6/README.md
+++ b/examples/end-dt6/README.md
@@ -1,8 +1,11 @@
 # SRv6 End.DT6 Playground
 
-Vinbero XDPによるSRv6 End.DT6 (Decapsulation with IPv6 Table lookup via VRF) のデモ環境です。
+*(日本語: [README.ja.md](./README.ja.md))*
 
-## トポロジー
+Demo environment for SRv6 End.DT6 (decapsulation with IPv6 table lookup via
+VRF) on Vinbero XDP.
+
+## Topology
 
 ```mermaid
 graph LR
@@ -12,63 +15,67 @@ graph LR
     router3 -->|IPv6| host2[host2<br/>10.0.1.2<br/>2001:db8:2::1]
 ```
 
-**パケットの流れ（host1 → host2の例）:**
-1. host1が2001:db8:2::1にpingを送信（IPv6）
-2. router1がLinux native H.Encapsを実行し、IPv6パケットを外側IPv6+SRHでカプセル化する
-3. router2がfc00:2::1でEnd操作を実行する（SL減少、次のセグメントへ）
-4. router3（Vinbero XDP）がfc00:3::3でEnd.DT6を実行する
-   - 外側IPv6+SRHヘッダを除去する
-   - VRF vrf100のルーティングテーブルでFIBルックアップし、host2へ転送する
-5. host2がpingを受信する
+**Packet walk (host1 to host2):**
+1. host1 pings 2001:db8:2::1 over IPv6
+2. router1 runs Linux native H.Encaps and wraps the IPv6 packet in an outer
+   IPv6 + SRH
+3. router2 runs End on fc00:2::1: decrement SL, move to the next segment
+4. router3 (Vinbero XDP) runs End.DT6 on fc00:3::3:
+   - strips the outer IPv6 + SRH headers
+   - resolves the inner packet in VRF vrf100's routing table and forwards it
+     to host2
+5. host2 receives the ping
 
-End.DT4との違いは、内側パケットがIPv6である点です。End.DT46を使えばIPv4/IPv6の両方を1つのSIDで処理できます。
+The difference from End.DT4 is that the inner packet is IPv6. End.DT46
+handles both IPv4 and IPv6 under a single SID.
 
-## クイックスタート
+## Quick start
 
 ```bash
-sudo ./setup.sh    # 環境構築
-sudo ./test.sh     # テスト実行
-sudo ./teardown.sh # クリーンアップ
+sudo ./setup.sh    # build the environment
+sudo ./test.sh     # run the tests
+sudo ./teardown.sh # clean up
 ```
 
-## 手動実行
+## Running it by hand
 
-### 1. 環境構築とVinbero起動
+### 1. Build the environment and start Vinbero
 
 ```bash
 sudo ./setup.sh
 
-# router3のLinux native End.DT6ルートを削除
+# Remove the Linux native End.DT6 route on router3
 sudo ip netns exec dt6-router3 ip -6 route del local fc00:3::3/128 2>/dev/null
 
-# Vinbero起動
+# Start Vinbero
 sudo ip netns exec dt6-router3 ../../out/bin/vinberod -c vinbero_router3.yaml
 ```
 
-### 2. SidFunction (End.DT6) エントリ登録
+### 2. Register the SidFunction (End.DT6) entry
 
 ```bash
 sudo ip netns exec dt6-router3 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
   sid create --trigger-prefix fc00:3::3/128 --action END_DT6 --vrf-name vrf100
 ```
 
-### 3. テスト
+### 3. Test
 
 ```bash
 sudo ip netns exec dt6-host1 ping6 -c 3 2001:db8:2::1
 ```
 
-#### パケットキャプチャ
+#### Packet capture
 
 ```bash
-# router2-router3間でSRv6パケットを確認
+# SRv6 packets between router2 and router3
 sudo ip netns exec dt6-router3 tcpdump -i dt6-rt3rt2 -n ip6
 
-# router3-host2間でデカプセル化後のIPv6パケットを確認
+# Decapsulated IPv6 packets between router3 and host2
 sudo ip netns exec dt6-router3 tcpdump -i dt6-rt3h2 -n ip6
 ```
 
-### 4. クリーンアップ
+### 4. Clean up
+
 ```bash
 sudo ./teardown.sh
 ```

--- a/examples/end-dx2v/README.ja.md
+++ b/examples/end-dx2v/README.ja.md
@@ -77,6 +77,14 @@ sudo ip netns exec dx2v-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
 # End.DX2V SID (table_id=1 を参照)
 sudo ip netns exec dx2v-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
   sid create --trigger-prefix fc00:3::3/128 --action END_DX2V --table-id 1
+
+# 復路: router3 が VLAN 100 / 200 を host1 方向へ encap する
+sudo ip netns exec dx2v-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
+  hl2 create --interface dx2v-rt3h2 --vlan-id 100 \
+  --src-addr fc00:3::3 --segments fc00:2::2,fc00:1::2
+sudo ip netns exec dx2v-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
+  hl2 create --interface dx2v-rt3h2 --vlan-id 200 \
+  --src-addr fc00:3::3 --segments fc00:2::2,fc00:1::2
 ```
 
 ### 4. テスト

--- a/examples/end-dx2v/README.ja.md
+++ b/examples/end-dx2v/README.ja.md
@@ -1,0 +1,96 @@
+# SRv6 End.DX2V Playground
+
+*(English: [README.md](./README.md))*
+
+Vinbero XDPによるSRv6 End.DX2V (Decapsulation and VLAN L2 cross-connect) のデモ環境です。
+
+End.DX2V は外側のIPv6+SRHを除去したあと、内側L2フレームのVLAN IDを見て出力ポートを選ぶVLAN単位のクロスコネクトです。この example はVLAN 100と200を同じ物理ポートへ振り分けます。
+
+L2VPNは双方向ともH.Encaps.L2が必要なため、Vinberoはrouter1とrouter3の両方で動きます。router1が往路をencap、router3がEnd.DX2Vでdecap兼VLANクロスコネクト、戻り方向はrouter3がencapしてrouter1がdecapします。
+
+## トポロジー
+
+```mermaid
+graph LR
+    host1[host1<br/>VLAN100 172.16.100.1<br/>VLAN200 172.16.200.1] -->|L2 + VLAN| router1[router1 / Vinbero XDP<br/>fc00:1::1<br/>H.Encaps.L2]
+    router1 -->|SRv6| router2[router2<br/>fc00:2::1, fc00:2::2<br/>End]
+    router2 -->|SRv6| router3[router3 / Vinbero XDP<br/>fc00:3::3<br/>End.DX2V]
+    router3 -->|L2 + VLAN| host2[host2<br/>VLAN100 172.16.100.2<br/>VLAN200 172.16.200.2]
+```
+
+**パケットの流れ（host1→host2, VLAN 100）:**
+1. host1がVLAN 100で172.16.100.2へpingを送信
+2. **router1 (Vinbero XDP)** がH.Encaps.L2を実行し、L2フレームをSegment List `[fc00:2::1, fc00:3::3]` でSRv6カプセル化
+3. router2がfc00:2::1でEndを実行 (SL減算、次セグメントへ)
+4. **router3 (Vinbero XDP)** がfc00:3::3でEnd.DX2Vを実行:
+   - 外側IPv6+SRHを除去
+   - 内側フレームのVLAN ID 100をVLAN tableで引き、対応する出力ポートへL2転送
+5. host2がVLAN 100でpingを受信
+6. VLAN 200も同じ仕組みで同じポートへクロスコネクト
+
+veth pairではtx-vlan-offloadが有効だとVLAN tagが `skb->vlan_tci` に退避してXDPから見えなくなるため、setup.shで送信側の `txvlan` / 受信側の `rxvlan` をoffにしています。
+
+## クイックスタート
+
+```bash
+sudo ./setup.sh    # 環境構築（VLAN 100/200 + VLAN offload無効化）
+sudo ./test.sh     # テスト実行（Linux native End.DX2 baseline → Vinbero End.DX2V）
+sudo ./teardown.sh # クリーンアップ
+```
+
+`test.sh` はrouter1/router3でVinberoを起動してH.Encaps.L2を登録し、Phase 1でLinux native End.DX2をbaseline確認、Phase 2でrouter3のEnd.DX2Vに置き換えてVLAN 100/200のクロスコネクトを検証、Phase 3でVLAN table APIを確認します。
+
+## 手動実行
+
+### 1. 環境構築とVinbero起動
+
+```bash
+sudo ./setup.sh
+
+# router1 (H.Encaps.L2, port 8082)
+sudo ip netns exec dx2v-router1 ../../out/bin/vinberod -c vinbero_router1.yaml &
+# router3 (End.DX2V + 戻り方向H.Encaps.L2, port 8083)
+sudo ip netns exec dx2v-router3 ../../out/bin/vinberod -c vinbero_router3.yaml &
+```
+
+### 2. router1: H.Encaps.L2 登録（VLAN 100 / 200）
+
+```bash
+sudo ip netns exec dx2v-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
+  hl2 create --interface dx2v-rt1h1 --vlan-id 100 --src-addr fc00:1::1 --segments fc00:2::1,fc00:3::3
+sudo ip netns exec dx2v-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
+  hl2 create --interface dx2v-rt1h1 --vlan-id 200 --src-addr fc00:1::1 --segments fc00:2::1,fc00:3::3
+```
+
+### 3. router3: VLAN table と End.DX2V SID 登録
+
+```bash
+# router3のLinux native End.DX2経路を削除
+sudo ip netns exec dx2v-router3 ip -6 route del local fc00:3::3/128 2>/dev/null
+
+# VLAN ID -> 出力ポートの対応をtable_id=1に登録
+sudo ip netns exec dx2v-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
+  vlan-table create --table-id 1 --vlan-id 100 --interface dx2v-rt3h2
+sudo ip netns exec dx2v-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
+  vlan-table create --table-id 1 --vlan-id 200 --interface dx2v-rt3h2
+
+# End.DX2V SID (table_id=1 を参照)
+sudo ip netns exec dx2v-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
+  sid create --trigger-prefix fc00:3::3/128 --action END_DX2V --table-id 1
+```
+
+### 4. テスト
+
+```bash
+sudo ip netns exec dx2v-host1 ping -c 3 -I dx2v-h1rt1.100 172.16.100.2  # VLAN 100
+sudo ip netns exec dx2v-host1 ping -c 3 -I dx2v-h1rt1.200 172.16.200.2  # VLAN 200
+
+# VLAN table の確認
+sudo ip netns exec dx2v-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 --json vlan-table list --table-id 1
+```
+
+### 5. 環境のクリーンアップ
+
+```bash
+sudo ./teardown.sh
+```

--- a/examples/end-dx2v/README.md
+++ b/examples/end-dx2v/README.md
@@ -1,12 +1,20 @@
 # SRv6 End.DX2V Playground
 
-Vinbero XDPによるSRv6 End.DX2V (Decapsulation and VLAN L2 cross-connect) のデモ環境です。
+*(日本語: [README.ja.md](./README.ja.md))*
 
-End.DX2V は外側のIPv6+SRHを除去したあと、内側L2フレームのVLAN IDを見て出力ポートを選ぶVLAN単位のクロスコネクトです。この example はVLAN 100と200を同じ物理ポートへ振り分けます。
+Demo environment for SRv6 End.DX2V (decapsulation and VLAN L2 cross-connect)
+on Vinbero XDP.
 
-L2VPNは双方向ともH.Encaps.L2が必要なため、Vinberoはrouter1とrouter3の両方で動きます。router1が往路をencap、router3がEnd.DX2Vでdecap兼VLANクロスコネクト、戻り方向はrouter3がencapしてrouter1がdecapします。
+End.DX2V strips the outer IPv6 + SRH and then picks the output port from the
+VLAN ID of the inner L2 frame, giving a per-VLAN cross-connect. This example
+maps VLAN 100 and VLAN 200 onto the same physical port.
 
-## トポロジー
+An L2VPN needs H.Encaps.L2 in both directions, so Vinbero runs on router1 and
+router3: router1 encapsulates the forward direction, router3 decapsulates and
+cross-connects with End.DX2V, and the return direction is encapsulated by
+router3 and decapsulated by router1.
+
+## Topology
 
 ```mermaid
 graph LR
@@ -16,42 +24,49 @@ graph LR
     router3 -->|L2 + VLAN| host2[host2<br/>VLAN100 172.16.100.2<br/>VLAN200 172.16.200.2]
 ```
 
-**パケットの流れ（host1→host2, VLAN 100）:**
-1. host1がVLAN 100で172.16.100.2へpingを送信
-2. **router1 (Vinbero XDP)** がH.Encaps.L2を実行し、L2フレームをSegment List `[fc00:2::1, fc00:3::3]` でSRv6カプセル化
-3. router2がfc00:2::1でEndを実行 (SL減算、次セグメントへ)
-4. **router3 (Vinbero XDP)** がfc00:3::3でEnd.DX2Vを実行:
-   - 外側IPv6+SRHを除去
-   - 内側フレームのVLAN ID 100をVLAN tableで引き、対応する出力ポートへL2転送
-5. host2がVLAN 100でpingを受信
-6. VLAN 200も同じ仕組みで同じポートへクロスコネクト
+**Packet walk (host1 to host2, VLAN 100):**
+1. host1 pings 172.16.100.2 on VLAN 100
+2. **router1 (Vinbero XDP)** runs H.Encaps.L2 and encapsulates the L2 frame
+   with the segment list `[fc00:2::1, fc00:3::3]`
+3. router2 runs End on fc00:2::1 (decrement SL, move to the next segment)
+4. **router3 (Vinbero XDP)** runs End.DX2V on fc00:3::3:
+   - strips the outer IPv6 + SRH
+   - looks the inner frame's VLAN ID 100 up in the VLAN table and forwards it
+     to the matching output port
+5. host2 receives the ping on VLAN 100
+6. VLAN 200 is cross-connected to the same port the same way
 
-veth pairではtx-vlan-offloadが有効だとVLAN tagが `skb->vlan_tci` に退避してXDPから見えなくなるため、setup.shで送信側の `txvlan` / 受信側の `rxvlan` をoffにしています。
+On veth pairs, tx-vlan-offload moves the VLAN tag into `skb->vlan_tci` where
+XDP cannot see it, so setup.sh turns `txvlan` off on the sending side and
+`rxvlan` off on the receiving side.
 
-## クイックスタート
+## Quick start
 
 ```bash
-sudo ./setup.sh    # 環境構築（VLAN 100/200 + VLAN offload無効化）
-sudo ./test.sh     # テスト実行（Linux native End.DX2 baseline → Vinbero End.DX2V）
-sudo ./teardown.sh # クリーンアップ
+sudo ./setup.sh    # build the environment (VLAN 100/200, VLAN offload off)
+sudo ./test.sh     # run the tests (Linux native End.DX2 baseline, then Vinbero End.DX2V)
+sudo ./teardown.sh # clean up
 ```
 
-`test.sh` はrouter1/router3でVinberoを起動してH.Encaps.L2を登録し、Phase 1でLinux native End.DX2をbaseline確認、Phase 2でrouter3のEnd.DX2Vに置き換えてVLAN 100/200のクロスコネクトを検証、Phase 3でVLAN table APIを確認します。
+`test.sh` starts Vinbero on router1 and router3 and registers H.Encaps.L2.
+Phase 1 establishes a baseline with Linux native End.DX2, phase 2 replaces it
+with End.DX2V on router3 and verifies the VLAN 100 and 200 cross-connects,
+and phase 3 checks the VLAN table API.
 
-## 手動実行
+## Running it by hand
 
-### 1. 環境構築とVinbero起動
+### 1. Build the environment and start Vinbero
 
 ```bash
 sudo ./setup.sh
 
 # router1 (H.Encaps.L2, port 8082)
 sudo ip netns exec dx2v-router1 ../../out/bin/vinberod -c vinbero_router1.yaml &
-# router3 (End.DX2V + 戻り方向H.Encaps.L2, port 8083)
+# router3 (End.DX2V + return-path H.Encaps.L2, port 8083)
 sudo ip netns exec dx2v-router3 ../../out/bin/vinberod -c vinbero_router3.yaml &
 ```
 
-### 2. router1: H.Encaps.L2 登録（VLAN 100 / 200）
+### 2. router1: register H.Encaps.L2 for VLAN 100 and 200
 
 ```bash
 sudo ip netns exec dx2v-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
@@ -60,34 +75,34 @@ sudo ip netns exec dx2v-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
   hl2 create --interface dx2v-rt1h1 --vlan-id 200 --src-addr fc00:1::1 --segments fc00:2::1,fc00:3::3
 ```
 
-### 3. router3: VLAN table と End.DX2V SID 登録
+### 3. router3: register the VLAN table and the End.DX2V SID
 
 ```bash
-# router3のLinux native End.DX2経路を削除
+# Remove the Linux native End.DX2 route on router3
 sudo ip netns exec dx2v-router3 ip -6 route del local fc00:3::3/128 2>/dev/null
 
-# VLAN ID -> 出力ポートの対応をtable_id=1に登録
+# Map VLAN ID to output port in table_id=1
 sudo ip netns exec dx2v-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
   vlan-table create --table-id 1 --vlan-id 100 --interface dx2v-rt3h2
 sudo ip netns exec dx2v-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
   vlan-table create --table-id 1 --vlan-id 200 --interface dx2v-rt3h2
 
-# End.DX2V SID (table_id=1 を参照)
+# End.DX2V SID referring to table_id=1
 sudo ip netns exec dx2v-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
   sid create --trigger-prefix fc00:3::3/128 --action END_DX2V --table-id 1
 ```
 
-### 4. テスト
+### 4. Test
 
 ```bash
 sudo ip netns exec dx2v-host1 ping -c 3 -I dx2v-h1rt1.100 172.16.100.2  # VLAN 100
 sudo ip netns exec dx2v-host1 ping -c 3 -I dx2v-h1rt1.200 172.16.200.2  # VLAN 200
 
-# VLAN table の確認
+# inspect the VLAN table
 sudo ip netns exec dx2v-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 --json vlan-table list --table-id 1
 ```
 
-### 5. 環境のクリーンアップ
+### 5. Clean up
 
 ```bash
 sudo ./teardown.sh

--- a/examples/end-dx2v/README.md
+++ b/examples/end-dx2v/README.md
@@ -90,6 +90,14 @@ sudo ip netns exec dx2v-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
 # End.DX2V SID referring to table_id=1
 sudo ip netns exec dx2v-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
   sid create --trigger-prefix fc00:3::3/128 --action END_DX2V --table-id 1
+
+# Return path: router3 encapsulates both VLANs back towards host1
+sudo ip netns exec dx2v-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
+  hl2 create --interface dx2v-rt3h2 --vlan-id 100 \
+  --src-addr fc00:3::3 --segments fc00:2::2,fc00:1::2
+sudo ip netns exec dx2v-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
+  hl2 create --interface dx2v-rt3h2 --vlan-id 200 \
+  --src-addr fc00:3::3 --segments fc00:2::2,fc00:1::2
 ```
 
 ### 4. Test

--- a/examples/end-dx4/README.ja.md
+++ b/examples/end-dx4/README.ja.md
@@ -70,7 +70,7 @@ sudo ip netns exec dx4-router3 tcpdump -i dx4-rt3rt2 -n ip6
 sudo ip netns exec dx4-router3 tcpdump -i dx4-rt3h2 -n ip
 ```
 
-### 4. 環境のクリーンナップ
+### 4. 環境のクリーンアップ
 ```bash
 sudo ./teardown.sh
 ```

--- a/examples/end-dx4/README.ja.md
+++ b/examples/end-dx4/README.ja.md
@@ -1,0 +1,76 @@
+# SRv6 End.DX4 Playground
+
+*(English: [README.md](./README.md))*
+
+Vinbero XDPによるSRv6 End.DX4 (Decapsulation with IPv4 Cross-connect) のデモ環境です。
+
+## トポロジー
+
+```mermaid
+graph LR
+    host1[host1<br/>172.0.1.1] -->|IPv4| router1[router1<br/>172.0.1.2<br/>fc00:1::1<br/>H.Encaps]
+    router1 -->|SRv6| router2[router2<br/>fc00:12::2<br/>End]
+    router2 -->|SRv6| router3[router3 / Vinbero XDP<br/>172.0.2.2<br/>SID: fc00:3::3<br/>End.DX4]
+    router3 -->|IPv4| host2[host2<br/>172.0.2.1]
+```
+
+**パケットの流れ（host1→host2の例）:**
+1. host1が172.0.2.1にpingを送信 (IPv4)
+2. router1がLinux native H.Encapsを実行:
+   - IPv4パケットをIPv6+SRHでカプセル化
+   - Outer DA: fc00:2::1 (最初のセグメント)
+   - Segment List: [fc00:2::1, fc00:3::3]
+3. router2がfc00:2::1でEnd操作を実行（SL減少、次のセグメントへ）
+4. **router3 (Vinbero XDP)** がfc00:3::3でEnd.DX4を実行:
+   - 外側IPv6+SRHヘッダを除去
+   - 内側IPv4パケットをFIBルックアップで転送
+5. host2がpingを受信
+
+## クイックスタート
+
+```bash
+sudo ./setup.sh    # 環境構築
+sudo ./test.sh     # テスト実行
+sudo ./teardown.sh # クリーンアップ（環境削除）
+```
+
+## 手動実行
+
+### 1. 環境構築とVinbero起動
+
+```bash
+sudo ./setup.sh
+
+# router3のLinux native End.DX4ルートを削除
+sudo ip netns exec dx4-router3 ip -6 route del local fc00:3::3/128 2>/dev/null
+
+# Vinbero起動
+sudo ip netns exec dx4-router3 ../../out/bin/vinberod -c vinbero_router3.yaml
+```
+
+### 2. SidFunction (End.DX4) エントリ登録
+
+```bash
+sudo ip netns exec dx4-router3 ../../out/bin/vinbero -s http://127.0.0.1:8082 sid create --trigger-prefix fc00:3::3/128 --action END_DX4
+```
+
+### 3. テスト
+
+```bash
+sudo ip netns exec dx4-host1 ping -c 3 172.0.2.1
+```
+
+#### パケットキャプチャ
+
+```bash
+# router2-router3間でSRv6パケットを確認
+sudo ip netns exec dx4-router3 tcpdump -i dx4-rt3rt2 -n ip6
+
+# router3-host2間でデカプセル化後のIPv4パケットを確認
+sudo ip netns exec dx4-router3 tcpdump -i dx4-rt3h2 -n ip
+```
+
+### 4. 環境のクリーンナップ
+```bash
+sudo ./teardown.sh
+```

--- a/examples/end-dx4/README.md
+++ b/examples/end-dx4/README.md
@@ -1,8 +1,11 @@
 # SRv6 End.DX4 Playground
 
-Vinbero XDPによるSRv6 End.DX4 (Decapsulation with IPv4 Cross-connect) のデモ環境です。
+*(日本語: [README.ja.md](./README.ja.md))*
 
-## トポロジー
+Demo environment for SRv6 End.DX4 (decapsulation with IPv4 cross-connect) on
+Vinbero XDP.
+
+## Topology
 
 ```mermaid
 graph LR
@@ -12,63 +15,64 @@ graph LR
     router3 -->|IPv4| host2[host2<br/>172.0.2.1]
 ```
 
-**パケットの流れ（host1→host2の例）:**
-1. host1が172.0.2.1にpingを送信 (IPv4)
-2. router1がLinux native H.Encapsを実行:
-   - IPv4パケットをIPv6+SRHでカプセル化
-   - Outer DA: fc00:2::1 (最初のセグメント)
-   - Segment List: [fc00:2::1, fc00:3::3]
-3. router2がfc00:2::1でEnd操作を実行（SL減少、次のセグメントへ）
-4. **router3 (Vinbero XDP)** がfc00:3::3でEnd.DX4を実行:
-   - 外側IPv6+SRHヘッダを除去
-   - 内側IPv4パケットをFIBルックアップで転送
-5. host2がpingを受信
+**Packet walk (host1 to host2):**
+1. host1 pings 172.0.2.1 over IPv4
+2. router1 runs Linux native H.Encaps:
+   - the IPv4 packet is encapsulated in IPv6 + SRH
+   - outer DA: fc00:2::1 (the first segment)
+   - segment list: [fc00:2::1, fc00:3::3]
+3. router2 runs End on fc00:2::1: decrement SL, move to the next segment
+4. **router3 (Vinbero XDP)** runs End.DX4 on fc00:3::3:
+   - strips the outer IPv6 + SRH headers
+   - forwards the inner IPv4 packet via a FIB lookup
+5. host2 receives the ping
 
-## クイックスタート
+## Quick start
 
 ```bash
-sudo ./setup.sh    # 環境構築
-sudo ./test.sh     # テスト実行
-sudo ./teardown.sh # クリーンアップ（環境削除）
+sudo ./setup.sh    # build the environment
+sudo ./test.sh     # run the tests
+sudo ./teardown.sh # clean up
 ```
 
-## 手動実行
+## Running it by hand
 
-### 1. 環境構築とVinbero起動
+### 1. Build the environment and start Vinbero
 
 ```bash
 sudo ./setup.sh
 
-# router3のLinux native End.DX4ルートを削除
+# Remove the Linux native End.DX4 route on router3
 sudo ip netns exec dx4-router3 ip -6 route del local fc00:3::3/128 2>/dev/null
 
-# Vinbero起動
+# Start Vinbero
 sudo ip netns exec dx4-router3 ../../out/bin/vinberod -c vinbero_router3.yaml
 ```
 
-### 2. SidFunction (End.DX4) エントリ登録
+### 2. Register the SidFunction (End.DX4) entry
 
 ```bash
 sudo ip netns exec dx4-router3 ../../out/bin/vinbero -s http://127.0.0.1:8082 sid create --trigger-prefix fc00:3::3/128 --action END_DX4
 ```
 
-### 3. テスト
+### 3. Test
 
 ```bash
 sudo ip netns exec dx4-host1 ping -c 3 172.0.2.1
 ```
 
-#### パケットキャプチャ
+#### Packet capture
 
 ```bash
-# router2-router3間でSRv6パケットを確認
+# SRv6 packets between router2 and router3
 sudo ip netns exec dx4-router3 tcpdump -i dx4-rt3rt2 -n ip6
 
-# router3-host2間でデカプセル化後のIPv4パケットを確認
+# Decapsulated IPv4 packets between router3 and host2
 sudo ip netns exec dx4-router3 tcpdump -i dx4-rt3h2 -n ip
 ```
 
-### 4. 環境のクリーンナップ
+### 4. Clean up
+
 ```bash
 sudo ./teardown.sh
 ```

--- a/examples/end-dx6/README.ja.md
+++ b/examples/end-dx6/README.ja.md
@@ -70,7 +70,7 @@ sudo ip netns exec dx6-router3 tcpdump -i dx6-rt3rt2 -n ip6
 sudo ip netns exec dx6-router3 tcpdump -i dx6-rt3h2 -n ip6
 ```
 
-### 4. 環境のクリーンナップ
+### 4. 環境のクリーンアップ
 ```bash
 sudo ./teardown.sh
 ```

--- a/examples/end-dx6/README.ja.md
+++ b/examples/end-dx6/README.ja.md
@@ -1,0 +1,76 @@
+# SRv6 End.DX6 Playground
+
+*(English: [README.md](./README.md))*
+
+Vinbero XDPによるSRv6 End.DX6 (Decapsulation with IPv6 Cross-connect) のデモ環境です。
+
+## トポロジー
+
+```mermaid
+graph LR
+    host1[host1<br/>2001:1::1] -->|IPv6| router1[router1<br/>2001:1::2<br/>fc00:1::1<br/>H.Encaps]
+    router1 -->|SRv6| router2[router2<br/>fc00:12::2<br/>End]
+    router2 -->|SRv6| router3[router3 / Vinbero XDP<br/>2001:2::2<br/>SID: fc00:3::3<br/>End.DX6]
+    router3 -->|IPv6| host2[host2<br/>2001:2::1]
+```
+
+**パケットの流れ（host1→host2の例）:**
+1. host1が2001:2::1にping6を送信 (IPv6)
+2. router1がLinux native H.Encapsを実行:
+   - IPv6パケットをIPv6+SRHでカプセル化 (IPv6-in-IPv6)
+   - Outer DA: fc00:2::1 (最初のセグメント)
+   - Segment List: [fc00:2::1, fc00:3::3]
+3. router2がfc00:2::1でEnd操作を実行（SL減少、次のセグメントへ）
+4. **router3 (Vinbero XDP)** がfc00:3::3でEnd.DX6を実行:
+   - 外側IPv6+SRHヘッダを除去
+   - 内側IPv6パケットをFIBルックアップで転送
+5. host2がping6を受信
+
+## クイックスタート
+
+```bash
+sudo ./setup.sh    # 環境構築
+sudo ./test.sh     # テスト実行
+sudo ./teardown.sh # クリーンアップ（環境削除）
+```
+
+## 手動実行
+
+### 1. 環境構築とVinbero起動
+
+```bash
+sudo ./setup.sh
+
+# router3のLinux native End.DX6ルートを削除
+sudo ip netns exec dx6-router3 ip -6 route del local fc00:3::3/128 2>/dev/null
+
+# Vinbero起動
+sudo ip netns exec dx6-router3 ../../out/bin/vinberod -c vinbero_router3.yaml
+```
+
+### 2. SidFunction (End.DX6) エントリ登録
+
+```bash
+sudo ip netns exec dx6-router3 ../../out/bin/vinbero -s http://127.0.0.1:8082 sid create --trigger-prefix fc00:3::3/128 --action END_DX6
+```
+
+### 3. テスト
+
+```bash
+sudo ip netns exec dx6-host1 ping6 -c 3 2001:2::1
+```
+
+#### パケットキャプチャ
+
+```bash
+# router2-router3間でSRv6パケットを確認
+sudo ip netns exec dx6-router3 tcpdump -i dx6-rt3rt2 -n ip6
+
+# router3-host2間でデカプセル化後のIPv6パケットを確認
+sudo ip netns exec dx6-router3 tcpdump -i dx6-rt3h2 -n ip6
+```
+
+### 4. 環境のクリーンナップ
+```bash
+sudo ./teardown.sh
+```

--- a/examples/end-dx6/README.md
+++ b/examples/end-dx6/README.md
@@ -1,8 +1,11 @@
 # SRv6 End.DX6 Playground
 
-Vinbero XDPによるSRv6 End.DX6 (Decapsulation with IPv6 Cross-connect) のデモ環境です。
+*(日本語: [README.ja.md](./README.ja.md))*
 
-## トポロジー
+Demo environment for SRv6 End.DX6 (decapsulation with IPv6 cross-connect) on
+Vinbero XDP.
+
+## Topology
 
 ```mermaid
 graph LR
@@ -12,63 +15,64 @@ graph LR
     router3 -->|IPv6| host2[host2<br/>2001:2::1]
 ```
 
-**パケットの流れ（host1→host2の例）:**
-1. host1が2001:2::1にping6を送信 (IPv6)
-2. router1がLinux native H.Encapsを実行:
-   - IPv6パケットをIPv6+SRHでカプセル化 (IPv6-in-IPv6)
-   - Outer DA: fc00:2::1 (最初のセグメント)
-   - Segment List: [fc00:2::1, fc00:3::3]
-3. router2がfc00:2::1でEnd操作を実行（SL減少、次のセグメントへ）
-4. **router3 (Vinbero XDP)** がfc00:3::3でEnd.DX6を実行:
-   - 外側IPv6+SRHヘッダを除去
-   - 内側IPv6パケットをFIBルックアップで転送
-5. host2がping6を受信
+**Packet walk (host1 to host2):**
+1. host1 pings 2001:2::1 over IPv6
+2. router1 runs Linux native H.Encaps:
+   - the IPv6 packet is encapsulated in IPv6 + SRH (IPv6-in-IPv6)
+   - outer DA: fc00:2::1 (the first segment)
+   - segment list: [fc00:2::1, fc00:3::3]
+3. router2 runs End on fc00:2::1: decrement SL, move to the next segment
+4. **router3 (Vinbero XDP)** runs End.DX6 on fc00:3::3:
+   - strips the outer IPv6 + SRH headers
+   - forwards the inner IPv6 packet via a FIB lookup
+5. host2 receives the ping
 
-## クイックスタート
+## Quick start
 
 ```bash
-sudo ./setup.sh    # 環境構築
-sudo ./test.sh     # テスト実行
-sudo ./teardown.sh # クリーンアップ（環境削除）
+sudo ./setup.sh    # build the environment
+sudo ./test.sh     # run the tests
+sudo ./teardown.sh # clean up
 ```
 
-## 手動実行
+## Running it by hand
 
-### 1. 環境構築とVinbero起動
+### 1. Build the environment and start Vinbero
 
 ```bash
 sudo ./setup.sh
 
-# router3のLinux native End.DX6ルートを削除
+# Remove the Linux native End.DX6 route on router3
 sudo ip netns exec dx6-router3 ip -6 route del local fc00:3::3/128 2>/dev/null
 
-# Vinbero起動
+# Start Vinbero
 sudo ip netns exec dx6-router3 ../../out/bin/vinberod -c vinbero_router3.yaml
 ```
 
-### 2. SidFunction (End.DX6) エントリ登録
+### 2. Register the SidFunction (End.DX6) entry
 
 ```bash
 sudo ip netns exec dx6-router3 ../../out/bin/vinbero -s http://127.0.0.1:8082 sid create --trigger-prefix fc00:3::3/128 --action END_DX6
 ```
 
-### 3. テスト
+### 3. Test
 
 ```bash
 sudo ip netns exec dx6-host1 ping6 -c 3 2001:2::1
 ```
 
-#### パケットキャプチャ
+#### Packet capture
 
 ```bash
-# router2-router3間でSRv6パケットを確認
+# SRv6 packets between router2 and router3
 sudo ip netns exec dx6-router3 tcpdump -i dx6-rt3rt2 -n ip6
 
-# router3-host2間でデカプセル化後のIPv6パケットを確認
+# Decapsulated IPv6 packets between router3 and host2
 sudo ip netns exec dx6-router3 tcpdump -i dx6-rt3h2 -n ip6
 ```
 
-### 4. 環境のクリーンナップ
+### 4. Clean up
+
 ```bash
 sudo ./teardown.sh
 ```

--- a/examples/end-t/README.ja.md
+++ b/examples/end-t/README.ja.md
@@ -1,0 +1,78 @@
+# SRv6 End.T Playground
+
+*(English: [README.md](./README.md))*
+
+Vinbero XDPによるSRv6 End.T (Endpoint with specific IPv6 table lookup) のデモ環境です。
+
+End.T はEndと同じくSRH処理 (DA更新とSL減算) を行いますが、転送先のFIBルックアップをdefault tableではなく指定VRFのrouting tableで行います。decapはしません。
+
+## トポロジー
+
+```mermaid
+graph LR
+    host1[host1<br/>172.0.1.1] -->|IPv4| router1[router1<br/>fc00:1::1<br/>H.Encaps / End.DX4]
+    router1 -->|SRv6| router2[router2 / Vinbero XDP<br/>fc00:2::1, fc00:2::2<br/>End.T table 100]
+    router2 -->|SRv6| router3[router3<br/>fc00:3::3<br/>End.DX4]
+    router3 -->|IPv4| host2[host2<br/>172.0.2.1]
+```
+
+router2 の `eth` 2本 (`rt2rt1` / `rt2rt3`) は VRF `vrf100` (table 100) に enslave され、router 間経路は table 100 に置かれます。End.T が更新後のDAをこのVRF tableで引きます。
+
+**パケットの流れ（host1→host2）:**
+1. host1が172.0.2.1にpingを送信 (IPv4)
+2. router1がLinux native H.Encapsを実行し、Segment List `[fc00:2::1, fc00:3::3]` でSRv6カプセル化
+3. **router2 (Vinbero XDP)** がfc00:2::1でEnd.Tを実行:
+   - SRH処理でDAをfc00:3::3に更新、SLを減算
+   - 更新後のDAをVRF table 100でFIBルックアップして転送
+4. router3がfc00:3::3でEnd.DX4を実行し、内側IPv4パケットをhost2へ転送
+5. 戻り方向は対称で、fc00:2::2のEnd.Tがhost2→host1を処理
+
+## クイックスタート
+
+```bash
+sudo ./setup.sh    # 環境構築
+sudo ./test.sh     # テスト実行（Linux native → Vinbero XDP の2フェーズ）
+sudo ./teardown.sh # クリーンアップ
+```
+
+`test.sh` はまずLinux native End.Tで疎通を確認し、native経路を削除してからVinbero XDPで再検証します。
+
+## 手動実行
+
+### 1. 環境構築とVinbero起動
+
+```bash
+sudo ./setup.sh
+
+# router2のLinux native End.T経路を削除
+sudo ip netns exec end-t-router2 ip -6 route del local fc00:2::1/128 2>/dev/null
+sudo ip netns exec end-t-router2 ip -6 route del local fc00:2::2/128 2>/dev/null
+
+# Vinbero起動（フォアグラウンドで動き続けるので & でバックグラウンド起動するか別ターミナルで）
+sudo ip netns exec end-t-router2 ../../out/bin/vinberod -c vinbero_router2.yaml &
+```
+
+### 2. SidFunction (End.T) エントリ登録
+
+VRFを指定して両方向のSIDを登録します。
+
+```bash
+sudo ip netns exec end-t-router2 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
+  sid create --trigger-prefix fc00:2::1/128 --action END_T --vrf-name vrf100
+sudo ip netns exec end-t-router2 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
+  sid create --trigger-prefix fc00:2::2/128 --action END_T --vrf-name vrf100
+```
+
+### 3. テスト
+
+```bash
+sudo ip netns exec end-t-host1 ping -c 3 172.0.2.1
+```
+
+bpf_fib_lookupはNDP解決済みのnext-hopを要求するため、setup.shで事前にrouter間のNDPを解決しています。
+
+### 4. 環境のクリーンアップ
+
+```bash
+sudo ./teardown.sh
+```

--- a/examples/end-t/README.md
+++ b/examples/end-t/README.md
@@ -1,10 +1,15 @@
 # SRv6 End.T Playground
 
-Vinbero XDPによるSRv6 End.T (Endpoint with specific IPv6 table lookup) のデモ環境です。
+*(日本語: [README.ja.md](./README.ja.md))*
 
-End.T はEndと同じくSRH処理 (DA更新とSL減算) を行いますが、転送先のFIBルックアップをdefault tableではなく指定VRFのrouting tableで行います。decapはしません。
+Demo environment for SRv6 End.T (endpoint with specific IPv6 table lookup)
+on Vinbero XDP.
 
-## トポロジー
+End.T does the same SRH processing as End (update the DA, decrement SL), but
+resolves the forwarding decision in a specific VRF routing table instead of
+the default table. It does not decapsulate.
+
+## Topology
 
 ```mermaid
 graph LR
@@ -14,45 +19,48 @@ graph LR
     router3 -->|IPv4| host2[host2<br/>172.0.2.1]
 ```
 
-router2 の `eth` 2本 (`rt2rt1` / `rt2rt3`) は VRF `vrf100` (table 100) に enslave され、router 間経路は table 100 に置かれます。End.T が更新後のDAをこのVRF tableで引きます。
+Both of router2's interfaces (`rt2rt1` and `rt2rt3`) are enslaved to VRF
+`vrf100` (table 100), so the inter-router routes live in table 100 and End.T
+resolves the updated DA there.
 
-**パケットの流れ（host1→host2）:**
-1. host1が172.0.2.1にpingを送信 (IPv4)
-2. router1がLinux native H.Encapsを実行し、Segment List `[fc00:2::1, fc00:3::3]` でSRv6カプセル化
-3. **router2 (Vinbero XDP)** がfc00:2::1でEnd.Tを実行:
-   - SRH処理でDAをfc00:3::3に更新、SLを減算
-   - 更新後のDAをVRF table 100でFIBルックアップして転送
-4. router3がfc00:3::3でEnd.DX4を実行し、内側IPv4パケットをhost2へ転送
-5. 戻り方向は対称で、fc00:2::2のEnd.Tがhost2→host1を処理
+**Packet walk (host1 to host2):**
+1. host1 pings 172.0.2.1 over IPv4
+2. router1 runs Linux native H.Encaps with the segment list `[fc00:2::1, fc00:3::3]`
+3. **router2 (Vinbero XDP)** runs End.T on fc00:2::1:
+   - SRH processing updates the DA to fc00:3::3 and decrements SL
+   - the updated DA is resolved in VRF table 100 and forwarded
+4. router3 runs End.DX4 on fc00:3::3 and forwards the inner IPv4 packet to host2
+5. The return direction is symmetric: End.T on fc00:2::2 handles host2 to host1
 
-## クイックスタート
+## Quick start
 
 ```bash
-sudo ./setup.sh    # 環境構築
-sudo ./test.sh     # テスト実行（Linux native → Vinbero XDP の2フェーズ）
-sudo ./teardown.sh # クリーンアップ
+sudo ./setup.sh    # build the environment
+sudo ./test.sh     # run the tests (Linux native, then Vinbero XDP)
+sudo ./teardown.sh # clean up
 ```
 
-`test.sh` はまずLinux native End.Tで疎通を確認し、native経路を削除してからVinbero XDPで再検証します。
+`test.sh` first checks connectivity through Linux native End.T, then removes
+the native routes and repeats the check against Vinbero XDP.
 
-## 手動実行
+## Running it by hand
 
-### 1. 環境構築とVinbero起動
+### 1. Build the environment and start Vinbero
 
 ```bash
 sudo ./setup.sh
 
-# router2のLinux native End.T経路を削除
+# Remove the Linux native End.T routes on router2
 sudo ip netns exec end-t-router2 ip -6 route del local fc00:2::1/128 2>/dev/null
 sudo ip netns exec end-t-router2 ip -6 route del local fc00:2::2/128 2>/dev/null
 
-# Vinbero起動（フォアグラウンドで動き続けるので & でバックグラウンド起動するか別ターミナルで）
+# vinberod stays in the foreground, so background it or use another terminal
 sudo ip netns exec end-t-router2 ../../out/bin/vinberod -c vinbero_router2.yaml &
 ```
 
-### 2. SidFunction (End.T) エントリ登録
+### 2. Register the SidFunction (End.T) entries
 
-VRFを指定して両方向のSIDを登録します。
+Both directions are registered against the VRF.
 
 ```bash
 sudo ip netns exec end-t-router2 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
@@ -61,15 +69,16 @@ sudo ip netns exec end-t-router2 ../../out/bin/vinbero -s http://127.0.0.1:8082 
   sid create --trigger-prefix fc00:2::2/128 --action END_T --vrf-name vrf100
 ```
 
-### 3. テスト
+### 3. Test
 
 ```bash
 sudo ip netns exec end-t-host1 ping -c 3 172.0.2.1
 ```
 
-bpf_fib_lookupはNDP解決済みのnext-hopを要求するため、setup.shで事前にrouter間のNDPを解決しています。
+bpf_fib_lookup needs a next hop whose neighbour is already resolved, so
+setup.sh resolves NDP between the routers up front.
 
-### 4. 環境のクリーンアップ
+### 4. Clean up
 
 ```bash
 sudo ./teardown.sh

--- a/examples/end-x/README.ja.md
+++ b/examples/end-x/README.ja.md
@@ -1,0 +1,76 @@
+# SRv6 End.X Playground
+
+*(English: [README.md](./README.md))*
+
+Vinbero XDPによるSRv6 End.X (Endpoint with L3 cross-connect) のデモ環境です。
+
+End.X はSRH処理 (DA更新とSL減算) のあと、通常のFIBルックアップではなく設定済みの明示的なnext-hopへ転送します。経路に依存しない固定next-hopのクロスコネクトを実現します。
+
+## トポロジー
+
+```mermaid
+graph LR
+    host1[host1<br/>172.0.1.1] -->|IPv4| router1[router1<br/>fc00:1::1<br/>End.DX4 / H.Encaps]
+    router1 -->|SRv6| router2[router2 / Vinbero XDP<br/>fc00:2::1, fc00:2::2<br/>End.X]
+    router2 -->|SRv6| router3[router3<br/>fc00:3::3<br/>End.DX4]
+    router3 -->|IPv4| host2[host2<br/>172.0.2.1]
+```
+
+**パケットの流れ（host1→host2）:**
+1. host1が172.0.2.1にpingを送信 (IPv4)
+2. router1がLinux native H.Encapsを実行し、Segment List `[fc00:2::1, fc00:3::3]` でSRv6カプセル化
+3. **router2 (Vinbero XDP)** がfc00:2::1でEnd.Xを実行:
+   - SRH処理でDAをfc00:3::3に更新、SLを減算
+   - FIBルックアップせず、設定済みnext-hop `fc00:23::1` (rt2-rt3リンク上のrouter3) へ転送
+4. router3がfc00:3::3でEnd.DX4を実行し、内側IPv4パケットをhost2へ転送
+5. 戻り方向は対称で、fc00:2::2のEnd.Xがnext-hop `fc00:12::1` (router1) へ転送
+
+## クイックスタート
+
+```bash
+sudo ./setup.sh    # 環境構築
+sudo ./test.sh     # テスト実行（Linux native → Vinbero XDP の2フェーズ）
+sudo ./teardown.sh # クリーンアップ
+```
+
+`test.sh` はまずLinux native End.Xで疎通を確認し、native経路を削除してからVinbero XDPで再検証します。
+
+## 手動実行
+
+### 1. 環境構築とVinbero起動
+
+```bash
+sudo ./setup.sh
+
+# router2のLinux native End.X経路を削除
+sudo ip netns exec end-x-router2 ip -6 route del local fc00:2::1/128 2>/dev/null
+sudo ip netns exec end-x-router2 ip -6 route del local fc00:2::2/128 2>/dev/null
+
+# Vinbero起動（フォアグラウンドで動き続けるので & でバックグラウンド起動するか別ターミナルで）
+sudo ip netns exec end-x-router2 ../../out/bin/vinberod -c vinbero_router2.yaml &
+```
+
+### 2. SidFunction (End.X) エントリ登録
+
+`--nexthop` で転送先を明示します。
+
+```bash
+# Forward: fc00:2::1 -> nexthop fc00:23::1 (router3)
+sudo ip netns exec end-x-router2 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
+  sid create --trigger-prefix fc00:2::1/128 --action END_X --nexthop fc00:23::1
+# Return: fc00:2::2 -> nexthop fc00:12::1 (router1)
+sudo ip netns exec end-x-router2 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
+  sid create --trigger-prefix fc00:2::2/128 --action END_X --nexthop fc00:12::1
+```
+
+### 3. テスト
+
+```bash
+sudo ip netns exec end-x-host1 ping -c 3 172.0.2.1
+```
+
+### 4. 環境のクリーンアップ
+
+```bash
+sudo ./teardown.sh
+```

--- a/examples/end-x/README.md
+++ b/examples/end-x/README.md
@@ -1,10 +1,15 @@
 # SRv6 End.X Playground
 
-Vinbero XDPによるSRv6 End.X (Endpoint with L3 cross-connect) のデモ環境です。
+*(日本語: [README.ja.md](./README.ja.md))*
 
-End.X はSRH処理 (DA更新とSL減算) のあと、通常のFIBルックアップではなく設定済みの明示的なnext-hopへ転送します。経路に依存しない固定next-hopのクロスコネクトを実現します。
+Demo environment for SRv6 End.X (endpoint with L3 cross-connect) on Vinbero
+XDP.
 
-## トポロジー
+End.X does the usual SRH processing (update the DA, decrement SL) and then
+forwards to a configured next hop instead of consulting the FIB, which gives
+a fixed cross-connect that does not depend on routing.
+
+## Topology
 
 ```mermaid
 graph LR
@@ -14,43 +19,46 @@ graph LR
     router3 -->|IPv4| host2[host2<br/>172.0.2.1]
 ```
 
-**パケットの流れ（host1→host2）:**
-1. host1が172.0.2.1にpingを送信 (IPv4)
-2. router1がLinux native H.Encapsを実行し、Segment List `[fc00:2::1, fc00:3::3]` でSRv6カプセル化
-3. **router2 (Vinbero XDP)** がfc00:2::1でEnd.Xを実行:
-   - SRH処理でDAをfc00:3::3に更新、SLを減算
-   - FIBルックアップせず、設定済みnext-hop `fc00:23::1` (rt2-rt3リンク上のrouter3) へ転送
-4. router3がfc00:3::3でEnd.DX4を実行し、内側IPv4パケットをhost2へ転送
-5. 戻り方向は対称で、fc00:2::2のEnd.Xがnext-hop `fc00:12::1` (router1) へ転送
+**Packet walk (host1 to host2):**
+1. host1 pings 172.0.2.1 over IPv4
+2. router1 runs Linux native H.Encaps with the segment list `[fc00:2::1, fc00:3::3]`
+3. **router2 (Vinbero XDP)** runs End.X on fc00:2::1:
+   - SRH processing updates the DA to fc00:3::3 and decrements SL
+   - no FIB lookup: the packet goes to the configured next hop `fc00:23::1`
+     (router3 on the rt2-rt3 link)
+4. router3 runs End.DX4 on fc00:3::3 and forwards the inner IPv4 packet to host2
+5. The return direction is symmetric: End.X on fc00:2::2 forwards to next hop
+   `fc00:12::1` (router1)
 
-## クイックスタート
+## Quick start
 
 ```bash
-sudo ./setup.sh    # 環境構築
-sudo ./test.sh     # テスト実行（Linux native → Vinbero XDP の2フェーズ）
-sudo ./teardown.sh # クリーンアップ
+sudo ./setup.sh    # build the environment
+sudo ./test.sh     # run the tests (Linux native, then Vinbero XDP)
+sudo ./teardown.sh # clean up
 ```
 
-`test.sh` はまずLinux native End.Xで疎通を確認し、native経路を削除してからVinbero XDPで再検証します。
+`test.sh` first checks connectivity through Linux native End.X, then removes
+the native routes and repeats the check against Vinbero XDP.
 
-## 手動実行
+## Running it by hand
 
-### 1. 環境構築とVinbero起動
+### 1. Build the environment and start Vinbero
 
 ```bash
 sudo ./setup.sh
 
-# router2のLinux native End.X経路を削除
+# Remove the Linux native End.X routes on router2
 sudo ip netns exec end-x-router2 ip -6 route del local fc00:2::1/128 2>/dev/null
 sudo ip netns exec end-x-router2 ip -6 route del local fc00:2::2/128 2>/dev/null
 
-# Vinbero起動（フォアグラウンドで動き続けるので & でバックグラウンド起動するか別ターミナルで）
+# vinberod stays in the foreground, so background it or use another terminal
 sudo ip netns exec end-x-router2 ../../out/bin/vinberod -c vinbero_router2.yaml &
 ```
 
-### 2. SidFunction (End.X) エントリ登録
+### 2. Register the SidFunction (End.X) entries
 
-`--nexthop` で転送先を明示します。
+`--nexthop` names the forwarding target.
 
 ```bash
 # Forward: fc00:2::1 -> nexthop fc00:23::1 (router3)
@@ -61,13 +69,13 @@ sudo ip netns exec end-x-router2 ../../out/bin/vinbero -s http://127.0.0.1:8082 
   sid create --trigger-prefix fc00:2::2/128 --action END_X --nexthop fc00:12::1
 ```
 
-### 3. テスト
+### 3. Test
 
 ```bash
 sudo ip netns exec end-x-host1 ping -c 3 172.0.2.1
 ```
 
-### 4. 環境のクリーンアップ
+### 4. Clean up
 
 ```bash
 sudo ./teardown.sh

--- a/examples/end/README.ja.md
+++ b/examples/end/README.ja.md
@@ -1,0 +1,74 @@
+# SRv6 End Playground
+
+*(English: [README.md](./README.md))*
+
+Vinbero XDPによるSRv6 End操作のデモ環境です。
+
+## トポロジー
+
+```mermaid
+graph LR
+    host1[host1<br/>172.0.1.1] -->|IPv4| router1[router1<br/>172.0.1.2<br/>fc00:1::1<br/>End.DX4]
+    router1 -->|SRv6| router2[router2 / Vinbero XDP<br/>fc00:12::2, fc00:23::2<br/>SID: fc00:2::1 host1→host2用<br/>SID: fc00:2::2 host2→host1用<br/>End]
+    router2 -->|SRv6| router3[router3<br/>172.0.2.2<br/>fc00:3::3<br/>End.DX4]
+    router3 -->|IPv4| host2[host2<br/>172.0.2.1]
+```
+
+**パケットの流れ（host1→host2の例）:**
+1. host1が172.0.2.1にpingを送信
+2. router1がSRv6カプセル化（T.Encaps）してSegment List: [fc00:2::1, fc00:3::3]を付与
+3. **router2 (Vinbero XDP)** がfc00:2::1でEnd操作を実行（SL減少、次のセグメントへ）
+4. router3がfc00:3::3でEnd.DX4を実行（IPv4に戻す）
+5. host2がpingを受信
+
+## クイックスタート
+
+```bash
+sudo ./setup.sh    # 環境構築
+sudo ./test.sh     # テスト実行
+sudo ./teardown.sh # クリーンアップ（環境削除）
+```
+
+## 手動実行
+
+namespace と veth は setup.sh が `end-` を前置します (例: namespace `end-router2`、veth `end-rt3rt2`)。TOPO_NS_PREFIX を変えた場合はこの prefix も読み替えてください。
+
+### 1. 環境構築とVinbero起動
+
+```bash
+sudo ./setup.sh
+
+# router2のLinux native SRv6を削除
+sudo ip netns exec end-router2 ip -6 route del local fc00:2::1/128 2>/dev/null
+sudo ip netns exec end-router2 ip -6 route del local fc00:2::2/128 2>/dev/null
+
+# Vinbero起動 (バックグラウンド)
+sudo ip netns exec end-router2 ../../out/bin/vinberod -c vinbero_router2.yaml &
+```
+
+### 2. SID登録
+
+```bash
+sudo ip netns exec end-router2 ../../out/bin/vinbero -s http://127.0.0.1:8082 sid create --trigger-prefix fc00:2::1/128 --action END
+sudo ip netns exec end-router2 ../../out/bin/vinbero -s http://127.0.0.1:8082 sid create --trigger-prefix fc00:2::2/128 --action END
+```
+
+### 3. テスト
+
+```bash
+sudo ip netns exec end-host1 ping -c 3 172.0.2.1
+sudo ip netns exec end-host2 ping -c 3 172.0.1.1
+```
+
+#### パケットキャプチャ
+
+```bash
+sudo ip netns exec end-router3 tcpdump -i end-rt3rt2 -n ip6
+```
+
+SRv6 Routing Header (RT6) でsegleft: 1→0、DA: fc00:2::1→fc00:3::3の変化が確認できます。
+
+### 4. 環境のクリーンアップ
+```bash
+sudo ./teardown.sh
+```

--- a/examples/end/README.md
+++ b/examples/end/README.md
@@ -1,72 +1,78 @@
 # SRv6 End Playground
 
-Vinbero XDPによるSRv6 End操作のデモ環境です。
+*(日本語: [README.ja.md](./README.ja.md))*
 
-## トポロジー
+Demo environment for the SRv6 End behavior on Vinbero XDP.
+
+## Topology
 
 ```mermaid
 graph LR
     host1[host1<br/>172.0.1.1] -->|IPv4| router1[router1<br/>172.0.1.2<br/>fc00:1::1<br/>End.DX4]
-    router1 -->|SRv6| router2[router2 / Vinbero XDP<br/>fc00:12::2, fc00:23::2<br/>SID: fc00:2::1 host1→host2用<br/>SID: fc00:2::2 host2→host1用<br/>End]
+    router1 -->|SRv6| router2[router2 / Vinbero XDP<br/>fc00:12::2, fc00:23::2<br/>SID: fc00:2::1 for host1 to host2<br/>SID: fc00:2::2 for host2 to host1<br/>End]
     router2 -->|SRv6| router3[router3<br/>172.0.2.2<br/>fc00:3::3<br/>End.DX4]
     router3 -->|IPv4| host2[host2<br/>172.0.2.1]
 ```
 
-**パケットの流れ（host1→host2の例）:**
-1. host1が172.0.2.1にpingを送信
-2. router1がSRv6カプセル化（T.Encaps）してSegment List: [fc00:2::1, fc00:3::3]を付与
-3. **router2 (Vinbero XDP)** がfc00:2::1でEnd操作を実行（SL減少、次のセグメントへ）
-4. router3がfc00:3::3でEnd.DX4を実行（IPv4に戻す）
-5. host2がpingを受信
+**Packet walk (host1 to host2):**
+1. host1 pings 172.0.2.1
+2. router1 encapsulates with SRv6 (T.Encaps) and a segment list of [fc00:2::1, fc00:3::3]
+3. **router2 (Vinbero XDP)** runs End on fc00:2::1: decrement SL, move to the next segment
+4. router3 runs End.DX4 on fc00:3::3 and restores the IPv4 packet
+5. host2 receives the ping
 
-## クイックスタート
+## Quick start
 
 ```bash
-sudo ./setup.sh    # 環境構築
-sudo ./test.sh     # テスト実行
-sudo ./teardown.sh # クリーンアップ（環境削除）
+sudo ./setup.sh    # build the environment
+sudo ./test.sh     # run the tests
+sudo ./teardown.sh # clean up
 ```
 
-## 手動実行
+## Running it by hand
 
-namespace と veth は setup.sh が `end-` を前置します (例: namespace `end-router2`、veth `end-rt3rt2`)。TOPO_NS_PREFIX を変えた場合はこの prefix も読み替えてください。
+setup.sh prefixes namespaces and veths with `end-` (namespace `end-router2`,
+veth `end-rt3rt2`, and so on). Adjust the prefix if you override
+TOPO_NS_PREFIX.
 
-### 1. 環境構築とVinbero起動
+### 1. Build the environment and start Vinbero
 
 ```bash
 sudo ./setup.sh
 
-# router2のLinux native SRv6を削除
+# Remove the Linux native SRv6 routes on router2
 sudo ip netns exec end-router2 ip -6 route del local fc00:2::1/128 2>/dev/null
 sudo ip netns exec end-router2 ip -6 route del local fc00:2::2/128 2>/dev/null
 
-# Vinbero起動 (バックグラウンド)
+# Start Vinbero in the background
 sudo ip netns exec end-router2 ../../out/bin/vinberod -c vinbero_router2.yaml &
 ```
 
-### 2. SID登録
+### 2. Register the SIDs
 
 ```bash
 sudo ip netns exec end-router2 ../../out/bin/vinbero -s http://127.0.0.1:8082 sid create --trigger-prefix fc00:2::1/128 --action END
 sudo ip netns exec end-router2 ../../out/bin/vinbero -s http://127.0.0.1:8082 sid create --trigger-prefix fc00:2::2/128 --action END
 ```
 
-### 3. テスト
+### 3. Test
 
 ```bash
 sudo ip netns exec end-host1 ping -c 3 172.0.2.1
 sudo ip netns exec end-host2 ping -c 3 172.0.1.1
 ```
 
-#### パケットキャプチャ
+#### Packet capture
 
 ```bash
 sudo ip netns exec end-router3 tcpdump -i end-rt3rt2 -n ip6
 ```
 
-SRv6 Routing Header (RT6) でsegleft: 1→0、DA: fc00:2::1→fc00:3::3の変化が確認できます。
+The SRv6 Routing Header (RT6) shows segleft going 1 to 0 and the DA going
+fc00:2::1 to fc00:3::3.
 
-### 4. 環境のクリーンアップ
+### 4. Clean up
+
 ```bash
 sudo ./teardown.sh
 ```

--- a/examples/gtp4-encap/README.ja.md
+++ b/examples/gtp4-encap/README.ja.md
@@ -1,0 +1,95 @@
+# SRv6 GTP-U/IPv4 (H.M.GTP4.D + End.M.GTP4.E)
+
+*(English: [README.md](./README.md))*
+
+RFC 9433に基づくGTP-U/IPv4とSRv6の双方向変換のデモ環境です。
+
+## トポロジー
+
+```mermaid
+graph LR
+    gNB[gNB/host1<br/>172.0.1.1<br/>GTP-U/IPv4] -->|GTP-U| router1[router1 / Vinbero XDP<br/>fc00:1::1<br/>H.M.GTP4.D → SRv6<br/>End.M.GTP4.E ← SRv6]
+    router1 -->|SRv6| router2[router2<br/>IPv6 transit]
+    router2 -->|SRv6| router3[router3 / Vinbero XDP<br/>fc00:3::/56<br/>End.M.GTP4.E → GTP-U<br/>H.M.GTP4.D ← GTP-U]
+    router3 -->|GTP-U| UPF[UPF/host2<br/>172.0.2.1<br/>GTP-U/IPv4]
+```
+
+**パケットの流れ（gNB→UPF）:**
+1. gNBがGTP-U/IPv4パケットを送信 (TEID, QFI付き)
+2. **router1 (H.M.GTP4.D)**: GTP-Uを剥離、SRv6でカプセル化。Args.Mob.Session (IPv4Dst, TEID, QFI) を End.M.GTP4.E SID へ single segment で encode
+3. router2: 素の IPv6 として transit (localsid なし、single segment なので End hop は無い)
+4. **router3 (End.M.GTP4.E)**: SRv6を剥離、SIDからTEID/QFIを decode、GTP-U/IPv4で再カプセル化
+5. UPFがGTP-U/IPv4パケットを受信
+
+## クイックスタート
+
+```bash
+pip3 install scapy  # GTP-Uパケット生成に必要
+sudo ./setup.sh     # 環境構築
+sudo ./test.sh      # テスト実行 (scapyでGTP-Uパケットを送信)
+sudo ./teardown.sh  # クリーンアップ
+```
+
+### 手動でGTP-Uパケットを送信
+
+```bash
+# QFI=9 (5G) のGTP-Uパケットを送信
+sudo ip netns exec gtp4-host1 python3 send_gtpu.py --teid 0x12345678 --qfi 9
+
+# QFI=0 (4G/LTE, 拡張ヘッダなし) のGTP-Uパケットを送信
+sudo ip netns exec gtp4-host1 python3 send_gtpu.py --teid 0xCAFEBABE --qfi 0
+
+# router2でSRv6パケットをキャプチャ
+sudo ip netns exec gtp4-router2 tcpdump -i gtp4-rt2rt1 -n ip6
+```
+
+## 手動実行
+
+### 1. 環境構築とVinbero起動
+
+```bash
+sudo ./setup.sh
+
+# router1でVinbero起動
+sudo ip netns exec gtp4-router1 ../../out/bin/vinberod -c vinbero_router1.yaml &
+
+# router3でVinbero起動
+sudo ip netns exec gtp4-router3 ../../out/bin/vinberod -c vinbero_router3.yaml &
+```
+
+### 2. エントリ登録
+
+router2 は素の IPv6 transit なので、headend は single segment で End.M.GTP4.E SID へ直接 encap します。End.M.GTP4.E は args-offset 7 で Args.Mob.Session が SID の byte 7-15 に入るため、`/128` ではマッチせず `/56` locator で登録します。
+
+```bash
+# Forward: gNB -> SRv6 (router1: H.M.GTP4.D)
+sudo ip netns exec gtp4-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
+  hv4 create --trigger-prefix 172.0.2.0/24 --src-addr fc00:1::1 \
+  --segments fc00:3::3 --mode H_M_GTP4_D --args-offset 7
+
+# Forward: SRv6 -> UPF (router3: End.M.GTP4.E)
+sudo ip netns exec gtp4-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
+  sid create --trigger-prefix fc00:3::/56 --action END_M_GTP4_E \
+  --gtp-v4-src-addr 172.0.2.2 --args-offset 7
+
+# Return: UPF -> SRv6 (router3: H.M.GTP4.D)
+sudo ip netns exec gtp4-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
+  hv4 create --trigger-prefix 172.0.1.0/24 --src-addr fc00:3::3 \
+  --segments fc00:1::1 --mode H_M_GTP4_D --args-offset 7
+
+# Return: SRv6 -> gNB (router1: End.M.GTP4.E)
+sudo ip netns exec gtp4-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
+  sid create --trigger-prefix fc00:1::/56 --action END_M_GTP4_E \
+  --gtp-v4-src-addr 172.0.1.2 --args-offset 7
+```
+
+### 3. Args.Mob.Session
+
+SID内のオフセット7からArgs.Mob.Sessionが encode されます:
+
+```
+SID (128 bit): [LOC:FUNCT (56 bit)][IPv4DstAddr (32 bit)][TEID (32 bit)][QFI(6)|R(1)|U(1)]
+                byte 0-6              byte 7-10             byte 11-14     byte 15
+```
+
+各エントリの `--args-offset` でオフセットを指定します。

--- a/examples/gtp4-encap/README.md
+++ b/examples/gtp4-encap/README.md
@@ -1,63 +1,73 @@
-# SRv6 GTP-U/IPv4 (H.M.GTP4.D + End.M.GTP4.E)
+# GTP-U/IPv4 and SRv6 conversion
 
-RFC 9433に基づくGTP-U/IPv4とSRv6の双方向変換のデモ環境です。
+*(日本語: [README.ja.md](./README.ja.md))*
 
-## トポロジー
+Demo environment for the bidirectional conversion between GTP-U/IPv4 and
+SRv6 per RFC 9433.
+
+## Topology
 
 ```mermaid
 graph LR
-    gNB[gNB/host1<br/>172.0.1.1<br/>GTP-U/IPv4] -->|GTP-U| router1[router1 / Vinbero XDP<br/>fc00:1::1<br/>H.M.GTP4.D → SRv6<br/>End.M.GTP4.E ← SRv6]
+    gNB[gNB/host1<br/>172.0.1.1<br/>GTP-U/IPv4] -->|GTP-U| router1[router1 / Vinbero XDP<br/>fc00:1::1<br/>H.M.GTP4.D to SRv6<br/>End.M.GTP4.E from SRv6]
     router1 -->|SRv6| router2[router2<br/>IPv6 transit]
-    router2 -->|SRv6| router3[router3 / Vinbero XDP<br/>fc00:3::/56<br/>End.M.GTP4.E → GTP-U<br/>H.M.GTP4.D ← GTP-U]
+    router2 -->|SRv6| router3[router3 / Vinbero XDP<br/>fc00:3::/56<br/>End.M.GTP4.E to GTP-U<br/>H.M.GTP4.D from GTP-U]
     router3 -->|GTP-U| UPF[UPF/host2<br/>172.0.2.1<br/>GTP-U/IPv4]
 ```
 
-**パケットの流れ（gNB→UPF）:**
-1. gNBがGTP-U/IPv4パケットを送信 (TEID, QFI付き)
-2. **router1 (H.M.GTP4.D)**: GTP-Uを剥離、SRv6でカプセル化。Args.Mob.Session (IPv4Dst, TEID, QFI) を End.M.GTP4.E SID へ single segment で encode
-3. router2: 素の IPv6 として transit (localsid なし、single segment なので End hop は無い)
-4. **router3 (End.M.GTP4.E)**: SRv6を剥離、SIDからTEID/QFIを decode、GTP-U/IPv4で再カプセル化
-5. UPFがGTP-U/IPv4パケットを受信
+**Packet walk (gNB to UPF):**
+1. gNB sends a GTP-U/IPv4 packet carrying a TEID and QFI
+2. **router1 (H.M.GTP4.D)** strips GTP-U and encapsulates in SRv6, encoding
+   Args.Mob.Session (IPv4Dst, TEID, QFI) into the End.M.GTP4.E SID as a single
+   segment
+3. router2 transits it as plain IPv6 (no localsid, and no End hop because
+   there is only one segment)
+4. **router3 (End.M.GTP4.E)** strips SRv6, decodes TEID and QFI from the SID,
+   and re-encapsulates as GTP-U/IPv4
+5. UPF receives the GTP-U/IPv4 packet
 
-## クイックスタート
+## Quick start
 
 ```bash
-pip3 install scapy  # GTP-Uパケット生成に必要
-sudo ./setup.sh     # 環境構築
-sudo ./test.sh      # テスト実行 (scapyでGTP-Uパケットを送信)
-sudo ./teardown.sh  # クリーンアップ
+pip3 install scapy  # needed to build the GTP-U packets
+sudo ./setup.sh     # build the environment
+sudo ./test.sh      # run the tests (sends GTP-U packets with scapy)
+sudo ./teardown.sh  # clean up
 ```
 
-### 手動でGTP-Uパケットを送信
+### Sending GTP-U packets by hand
 
 ```bash
-# QFI=9 (5G) のGTP-Uパケットを送信
+# GTP-U packet with QFI=9 (5G)
 sudo ip netns exec gtp4-host1 python3 send_gtpu.py --teid 0x12345678 --qfi 9
 
-# QFI=0 (4G/LTE, 拡張ヘッダなし) のGTP-Uパケットを送信
+# GTP-U packet with QFI=0 (4G/LTE, no extension header)
 sudo ip netns exec gtp4-host1 python3 send_gtpu.py --teid 0xCAFEBABE --qfi 0
 
-# router2でSRv6パケットをキャプチャ
+# Capture the SRv6 packets on router2
 sudo ip netns exec gtp4-router2 tcpdump -i gtp4-rt2rt1 -n ip6
 ```
 
-## 手動実行
+## Running it by hand
 
-### 1. 環境構築とVinbero起動
+### 1. Build the environment and start Vinbero
 
 ```bash
 sudo ./setup.sh
 
-# router1でVinbero起動
+# Start Vinbero on router1
 sudo ip netns exec gtp4-router1 ../../out/bin/vinberod -c vinbero_router1.yaml &
 
-# router3でVinbero起動
+# Start Vinbero on router3
 sudo ip netns exec gtp4-router3 ../../out/bin/vinberod -c vinbero_router3.yaml &
 ```
 
-### 2. エントリ登録
+### 2. Register the entries
 
-router2 は素の IPv6 transit なので、headend は single segment で End.M.GTP4.E SID へ直接 encap します。End.M.GTP4.E は args-offset 7 で Args.Mob.Session が SID の byte 7-15 に入るため、`/128` ではマッチせず `/56` locator で登録します。
+router2 is a plain IPv6 transit, so the headend encapsulates directly to the
+End.M.GTP4.E SID with a single segment. End.M.GTP4.E uses args-offset 7, which
+puts Args.Mob.Session in bytes 7-15 of the SID, so it is registered as a `/56`
+locator rather than a `/128`.
 
 ```bash
 # Forward: gNB -> SRv6 (router1: H.M.GTP4.D)
@@ -83,11 +93,11 @@ sudo ip netns exec gtp4-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
 
 ### 3. Args.Mob.Session
 
-SID内のオフセット7からArgs.Mob.Sessionが encode されます:
+Args.Mob.Session is encoded from offset 7 of the SID:
 
 ```
 SID (128 bit): [LOC:FUNCT (56 bit)][IPv4DstAddr (32 bit)][TEID (32 bit)][QFI(6)|R(1)|U(1)]
                 byte 0-6              byte 7-10             byte 11-14     byte 15
 ```
 
-各エントリの `--args-offset` でオフセットを指定します。
+Each entry sets the offset with `--args-offset`.

--- a/examples/gtp6-drop-in/README.ja.md
+++ b/examples/gtp6-drop-in/README.ja.md
@@ -1,0 +1,38 @@
+# SRv6 GTP-U/IPv6 Drop-In (End.M.GTP6.D.Di)
+
+*(English: [README.md](./README.md))*
+
+RFC 9433のDrop-Inモード: 既存のGTP-Uインフラに最小限の変更でSRv6を導入するデモ環境です。
+
+## 概要
+
+Vinbero の End.M.GTP6.D.Di は SRv6 パケットの中に載った GTP-U を認識する SID-triggered endpoint です。Drop-In モードでは:
+- SL の減算も DA の更新も**行わない**
+- パケットを**一切書き換えず** `XDP_PASS` でカーネルの SRv6 スタックに委譲する
+
+GTP-U のバイトが残ったまま nexthdr だけ書き換えると不整合なパケットになるため、Vinbero は意図的に無改変で渡します。これにより既存の GTP-U 転送インフラをほぼそのまま維持しつつ SRv6 ドメインと統合できます。
+
+## トポロジー
+
+```mermaid
+graph LR
+    gNB[gNB<br/>GTP-U/IPv6] -->|SRv6+GTP-U| router1[router1 / Vinbero XDP<br/>fc00:1::1<br/>End.M.GTP6.D.Di]
+    router1 -->|SRv6 via kernel| router2[router2<br/>fc00:2::1<br/>End]
+```
+
+## クイックスタート
+
+```bash
+sudo ./setup.sh
+sudo ./test.sh
+sudo ./teardown.sh
+```
+
+## 動作
+
+1. パケット受信: `[IPv6][SRH(nexthdr=UDP)][UDP:2152][GTP-U][Inner IP]`
+2. Vinbero XDP: SRH nexthdr が UDP かつ GTP-U が妥当であることを検証
+3. パケットを書き換えずに `XDP_PASS` でカーネルに委譲 (SL/DA/nexthdr は不変)
+4. カーネル SRv6 スタックがそのまま処理
+
+変換が無いため、`test.sh` は per-slot 呼び出しカウンタ (`vinbero stats slot show`) で Di プログラムが当該パケットに対して実行されたことを確認します。netns example のクライアントバイナリは `vinbero` です (`out/bin/vbctl` はありません。`vbctl` は interop-clab の Docker image 内の symlink です)。

--- a/examples/gtp6-drop-in/README.md
+++ b/examples/gtp6-drop-in/README.md
@@ -1,16 +1,25 @@
-# SRv6 GTP-U/IPv6 Drop-In (End.M.GTP6.D.Di)
+# GTP-U Drop-In mode
 
-RFC 9433のDrop-Inモード: 既存のGTP-Uインフラに最小限の変更でSRv6を導入するデモ環境です。
+*(日本語: [README.ja.md](./README.ja.md))*
 
-## 概要
+Demo environment for the RFC 9433 Drop-In mode, which introduces SRv6 into an
+existing GTP-U deployment with minimal change.
 
-Vinbero の End.M.GTP6.D.Di は SRv6 パケットの中に載った GTP-U を認識する SID-triggered endpoint です。Drop-In モードでは:
-- SL の減算も DA の更新も**行わない**
-- パケットを**一切書き換えず** `XDP_PASS` でカーネルの SRv6 スタックに委譲する
+## Overview
 
-GTP-U のバイトが残ったまま nexthdr だけ書き換えると不整合なパケットになるため、Vinbero は意図的に無改変で渡します。これにより既存の GTP-U 転送インフラをほぼそのまま維持しつつ SRv6 ドメインと統合できます。
+Vinbero's End.M.GTP6.D.Di is a SID-triggered endpoint that recognises GTP-U
+carried inside an SRv6 packet. In Drop-In mode it:
 
-## トポロジー
+- does **not** decrement SL or update the DA
+- passes the packet to the kernel's SRv6 stack with `XDP_PASS`, **without
+  rewriting a single byte**
+
+Rewriting only the nexthdr while the GTP-U bytes stay in place would produce
+an inconsistent packet, so Vinbero deliberately hands it over untouched. That
+keeps the existing GTP-U forwarding infrastructure essentially as-is while
+integrating it with an SRv6 domain.
+
+## Topology
 
 ```mermaid
 graph LR
@@ -18,7 +27,7 @@ graph LR
     router1 -->|SRv6 via kernel| router2[router2<br/>fc00:2::1<br/>End]
 ```
 
-## クイックスタート
+## Quick start
 
 ```bash
 sudo ./setup.sh
@@ -26,11 +35,17 @@ sudo ./test.sh
 sudo ./teardown.sh
 ```
 
-## 動作
+## How it behaves
 
-1. パケット受信: `[IPv6][SRH(nexthdr=UDP)][UDP:2152][GTP-U][Inner IP]`
-2. Vinbero XDP: SRH nexthdr が UDP かつ GTP-U が妥当であることを検証
-3. パケットを書き換えずに `XDP_PASS` でカーネルに委譲 (SL/DA/nexthdr は不変)
-4. カーネル SRv6 スタックがそのまま処理
+1. The packet arrives as `[IPv6][SRH(nexthdr=UDP)][UDP:2152][GTP-U][Inner IP]`
+2. Vinbero XDP verifies that the SRH nexthdr is UDP and that the GTP-U header
+   is well formed
+3. The packet is handed to the kernel with `XDP_PASS`, unmodified (SL, DA and
+   nexthdr are all unchanged)
+4. The kernel SRv6 stack takes it from there
 
-変換が無いため、`test.sh` は per-slot 呼び出しカウンタ (`vinbero stats slot show`) で Di プログラムが当該パケットに対して実行されたことを確認します。netns example のクライアントバイナリは `vinbero` です (`out/bin/vbctl` はありません。`vbctl` は interop-clab の Docker image 内の symlink です)。
+Since nothing is converted, `test.sh` uses the per-slot invocation counter
+(`vinbero stats slot show`) to confirm that the Di program actually ran for
+those packets. The client binary in the netns examples is `vinbero`; there is
+no `out/bin/vbctl` (that name is a symlink inside the interop-clab Docker
+image).

--- a/examples/gtp6-encap/README.ja.md
+++ b/examples/gtp6-encap/README.ja.md
@@ -1,0 +1,33 @@
+# SRv6 GTP-U/IPv6 (H.M.GTP6.D + End.M.GTP6.E)
+
+*(English: [README.md](./README.md))*
+
+RFC 9433 に基づく GTP-U/IPv6 と SRv6 の変換デモ環境です。gtp4-encap の IPv6 対称版で、router1 は素の GTP-U/IPv6 tunnel を outer IPv6 dst で intercept して SRv6 化する headend (H.M.GTP6.D) として動きます。
+
+## トポロジー
+
+```mermaid
+graph LR
+    gNB[gNB/host1<br/>GTP-U/IPv6] -->|GTP-U/IPv6 to 2001:db8:caf::/64| router1[router1 / Vinbero XDP<br/>H.M.GTP6.D]
+    router1 -->|SRv6| router2[router2<br/>IPv6 transit]
+    router2 -->|SRv6| router3[router3 / Vinbero XDP<br/>fc00:3::/56<br/>End.M.GTP6.E]
+    router3 -->|GTP-U/IPv6| UPF[UPF/host2<br/>GTP-U/IPv6]
+```
+
+**パケットの流れ:**
+1. gNB が素の GTP-U/IPv6 パケットを N3/UPF アドレス (2001:db8:caf::/64) 宛に送信。router1 経由でルーティングされる
+2. **router1 (H.M.GTP6.D)**: outer IPv6 dst で GTP-U tunnel を intercept し、外側 IPv6+UDP+GTP-U を剥離して End.M.GTP6.E SID 向けに SRv6 encap。TEID/QFI を SID の Args.Mob.Session (args_offset 8) に encode
+3. router2: SRv6 を素の IPv6 として transit (localsid なし)
+4. **router3 (End.M.GTP6.E)**: SRv6 を剥離、SID から TEID/QFI を decode して GTP-U/IPv6 で再カプセル化
+
+args_offset を 8 にすることで Args.Mob.Session の 5 バイトが /64 locator の外 (byte 8-12) に入り、SID が経路可能なまま保たれます。
+
+## クイックスタート
+
+```bash
+sudo ./setup.sh
+sudo ./test.sh
+sudo ./teardown.sh
+```
+
+`test.sh` は router1 で H.M.GTP6.D を登録 (`hv6 create --mode H_M_GTP6_D --args-offset 8`)、host1 から素の GTP-U/IPv6 を送り、router1→router2 リンクで変換後の SRv6 パケットを捕捉して変換を検証します。

--- a/examples/gtp6-encap/README.md
+++ b/examples/gtp6-encap/README.md
@@ -1,8 +1,13 @@
-# SRv6 GTP-U/IPv6 (H.M.GTP6.D + End.M.GTP6.E)
+# GTP-U/IPv6 and SRv6 conversion
 
-RFC 9433 に基づく GTP-U/IPv6 と SRv6 の変換デモ環境です。gtp4-encap の IPv6 対称版で、router1 は素の GTP-U/IPv6 tunnel を outer IPv6 dst で intercept して SRv6 化する headend (H.M.GTP6.D) として動きます。
+*(日本語: [README.ja.md](./README.ja.md))*
 
-## トポロジー
+Demo environment for converting between GTP-U/IPv6 and SRv6 per RFC 9433.
+This is the IPv6 counterpart of gtp4-encap: router1 acts as the headend
+(H.M.GTP6.D) that intercepts a plain GTP-U/IPv6 tunnel by its outer IPv6
+destination and turns it into SRv6.
+
+## Topology
 
 ```mermaid
 graph LR
@@ -12,15 +17,21 @@ graph LR
     router3 -->|GTP-U/IPv6| UPF[UPF/host2<br/>GTP-U/IPv6]
 ```
 
-**パケットの流れ:**
-1. gNB が素の GTP-U/IPv6 パケットを N3/UPF アドレス (2001:db8:caf::/64) 宛に送信。router1 経由でルーティングされる
-2. **router1 (H.M.GTP6.D)**: outer IPv6 dst で GTP-U tunnel を intercept し、外側 IPv6+UDP+GTP-U を剥離して End.M.GTP6.E SID 向けに SRv6 encap。TEID/QFI を SID の Args.Mob.Session (args_offset 8) に encode
-3. router2: SRv6 を素の IPv6 として transit (localsid なし)
-4. **router3 (End.M.GTP6.E)**: SRv6 を剥離、SID から TEID/QFI を decode して GTP-U/IPv6 で再カプセル化
+**Packet walk:**
+1. gNB sends a plain GTP-U/IPv6 packet towards the N3/UPF address
+   (2001:db8:caf::/64), which routes through router1
+2. **router1 (H.M.GTP6.D)** intercepts the GTP-U tunnel by its outer IPv6
+   destination, strips the outer IPv6 + UDP + GTP-U, and encapsulates towards
+   the End.M.GTP6.E SID. TEID and QFI are encoded into the SID's
+   Args.Mob.Session (args_offset 8)
+3. router2 transits the SRv6 packet as plain IPv6 (no localsid)
+4. **router3 (End.M.GTP6.E)** strips SRv6, decodes TEID and QFI from the SID,
+   and re-encapsulates as GTP-U/IPv6
 
-args_offset を 8 にすることで Args.Mob.Session の 5 バイトが /64 locator の外 (byte 8-12) に入り、SID が経路可能なまま保たれます。
+With args_offset 8 the five Args.Mob.Session bytes land outside the /64
+locator (bytes 8-12), so the SID stays routable.
 
-## クイックスタート
+## Quick start
 
 ```bash
 sudo ./setup.sh
@@ -28,4 +39,7 @@ sudo ./test.sh
 sudo ./teardown.sh
 ```
 
-`test.sh` は router1 で H.M.GTP6.D を登録 (`hv6 create --mode H_M_GTP6_D --args-offset 8`)、host1 から素の GTP-U/IPv6 を送り、router1→router2 リンクで変換後の SRv6 パケットを捕捉して変換を検証します。
+`test.sh` registers H.M.GTP6.D on router1 (`hv6 create --mode H_M_GTP6_D
+--args-offset 8`), sends a plain GTP-U/IPv6 packet from host1, and captures
+the converted SRv6 packet on the router1-router2 link to verify the
+conversion.

--- a/examples/headend-l2/README.ja.md
+++ b/examples/headend-l2/README.ja.md
@@ -44,17 +44,30 @@ sudo ./teardown.sh # クリーンアップ（環境削除）
 
 ### 1. 環境構築とVinbero起動
 
+L2VPN は両端に headend が要るので、Vinbero は router1 と router3 の両方で動かします。
+
 ```bash
 sudo ./setup.sh
 
-# Vinbero起動
-sudo ip netns exec hl2-router1 ../../out/bin/vinberod -c vinbero_router1.yaml
+# 両 router で Vinbero を起動
+sudo ip netns exec hl2-router1 ../../out/bin/vinberod -c vinbero_router1.yaml &
+sudo ip netns exec hl2-router3 ../../out/bin/vinberod -c vinbero_router3.yaml &
 ```
 
 ### 2. HeadendL2エントリ登録
 
+`--interface` は必須です。VLAN が入ってくる access port を指定します。
+
 ```bash
-sudo ip netns exec hl2-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 hl2 create --vlan-id 100 --src-addr fc00:1::1 --segments fc00:2::1,fc00:3::3
+# 往路 (router1)
+sudo ip netns exec hl2-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
+  hl2 create --interface hl2-rt1h1 --vlan-id 100 \
+  --src-addr fc00:1::1 --segments fc00:2::1,fc00:3::3
+
+# 復路 (router3)
+sudo ip netns exec hl2-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
+  hl2 create --interface hl2-rt3h2 --vlan-id 100 \
+  --src-addr fc00:3::3 --segments fc00:2::2,fc00:1::2
 ```
 
 ### 3. テスト
@@ -73,7 +86,7 @@ sudo ip netns exec hl2-router2 tcpdump -i hl2-rt2rt1 -n -v ip6
 
 SRv6 Routing Header (RT6) と Next Header 143 (Ethernet) が確認できます。
 
-### 5. 環境のクリーンナップ
+### 5. 環境のクリーンアップ
 ```bash
 sudo ./teardown.sh
 ```

--- a/examples/headend-l2/README.ja.md
+++ b/examples/headend-l2/README.ja.md
@@ -1,0 +1,120 @@
+# SRv6 Headend (H.Encaps.L2) L2VPN Playground
+
+*(English: [README.md](./README.md))*
+
+Vinbero XDPによるSRv6 H.Encaps.L2 (Headend L2 Encapsulation) for L2VPNのデモ環境です。
+
+## 概要
+
+H.Encaps.L2は、L2フレーム全体（Ethernetヘッダーを含む）をSRv6パケットにカプセル化します。
+これにより、L2ドメインをSRv6ネットワーク経由で拡張するL2VPNを実現できます。
+
+**トリガー**: VLAN ID（VLANタグ付きパケット、またはVLAN ID 0でタグなしパケット）
+
+## トポロジー
+
+```mermaid
+graph LR
+    host1[host1<br/>VLAN 100<br/>172.16.100.1] -->|VLAN 100| router1[router1 / Vinbero XDP<br/>fc00:1::1<br/>H.Encaps.L2<br/>Trigger: VLAN ID 100<br/>Segments: fc00:2::1, fc00:3::3]
+    router1 -->|SRv6| router2[router2<br/>fc00:12::2<br/>End]
+    router2 -->|SRv6| router3[router3<br/>fc00:3::3<br/>End.DX2]
+    router3 -->|VLAN 100| host2[host2<br/>VLAN 100<br/>172.16.100.2]
+```
+
+**パケットの流れ（host1→host2の例）:**
+1. host1がVLAN 100タグ付きフレームを送信 (172.16.100.1 → 172.16.100.2)
+2. **router1 (Vinbero XDP)** がH.Encaps.L2を実行:
+   - L2フレーム全体をIPv6+SRHでカプセル化
+   - Next Header: IPPROTO_ETHERNET (143)
+   - Outer DA: fc00:2::1 (最初のセグメント)
+   - Segment List: [fc00:2::1, fc00:3::3]
+3. router2がfc00:2::1でEnd操作を実行（SL減少、次のセグメントへ）
+4. router3がfc00:3::3でEnd.DX2を実行（L2フレームに戻す）
+5. host2がL2フレームを受信
+
+## クイックスタート
+
+```bash
+sudo ./setup.sh    # 環境構築
+sudo ./test.sh     # テスト実行
+sudo ./teardown.sh # クリーンアップ（環境削除）
+```
+
+## 手動実行
+
+### 1. 環境構築とVinbero起動
+
+```bash
+sudo ./setup.sh
+
+# Vinbero起動
+sudo ip netns exec hl2-router1 ../../out/bin/vinberod -c vinbero_router1.yaml
+```
+
+### 2. HeadendL2エントリ登録
+
+```bash
+sudo ip netns exec hl2-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 hl2 create --vlan-id 100 --src-addr fc00:1::1 --segments fc00:2::1,fc00:3::3
+```
+
+### 3. テスト
+
+```bash
+# VLAN 100経由でpingテスト
+sudo ip netns exec hl2-host1 ping -c 3 -I hl2-h1rt1.100 172.16.100.2
+```
+
+### 4. パケットキャプチャで確認
+
+```bash
+# router1-router2間でSRv6パケットを確認
+sudo ip netns exec hl2-router2 tcpdump -i hl2-rt2rt1 -n -v ip6
+```
+
+SRv6 Routing Header (RT6) と Next Header 143 (Ethernet) が確認できます。
+
+### 5. 環境のクリーンナップ
+```bash
+sudo ./teardown.sh
+```
+
+## L2VPNユースケース
+
+H.Encaps.L2は以下のようなL2VPNシナリオに適しています：
+
+- **VLAN拡張**: 異なるサイト間でVLANを透過的に接続
+- **L2ブリッジング**: リモートサイト間でEthernetセグメントを拡張
+- **レガシー対応**: L3サービスに対応していないアプリケーションの接続
+
+## 技術詳細
+
+### SRv6ヘッダー構造
+
+```
++------------------+
+| Outer IPv6 Header|
+| (SA: fc00:1::1)  |
+| (DA: fc00:2::1)  |
++------------------+
+| Segment Routing  |
+| Header (SRH)     |
+| Segments Left: 1 |
+| [fc00:2::1,      |
+|  fc00:3::3]      |
+| Next Header: 143 |
++------------------+
+| Original L2 Frame|
+| (Ethernet Header)|
+| (VLAN 100 Tag)   |
+| (IP Payload)     |
++------------------+
+```
+
+### End.DX2動作
+
+End.DX2はSRv6パケットからL2フレームを取り出し、指定されたインターフェースに転送します：
+
+```bash
+# LinuxでのEnd.DX2設定例
+ip -6 route add local fc00:3::3/128 encap seg6local action End.DX2 oif eth1
+```

--- a/examples/headend-l2/README.md
+++ b/examples/headend-l2/README.md
@@ -46,17 +46,31 @@ sudo ./teardown.sh # clean up
 
 ### 1. Build the environment and start Vinbero
 
+An L2VPN needs a headend at both ends, so Vinbero runs on router1 and
+router3.
+
 ```bash
 sudo ./setup.sh
 
-# Start Vinbero
-sudo ip netns exec hl2-router1 ../../out/bin/vinberod -c vinbero_router1.yaml
+# Start Vinbero on both routers
+sudo ip netns exec hl2-router1 ../../out/bin/vinberod -c vinbero_router1.yaml &
+sudo ip netns exec hl2-router3 ../../out/bin/vinberod -c vinbero_router3.yaml &
 ```
 
-### 2. Register the HeadendL2 entry
+### 2. Register the HeadendL2 entries
+
+`--interface` is required: it names the access port the VLAN arrives on.
 
 ```bash
-sudo ip netns exec hl2-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 hl2 create --vlan-id 100 --src-addr fc00:1::1 --segments fc00:2::1,fc00:3::3
+# Forward path on router1
+sudo ip netns exec hl2-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 \
+  hl2 create --interface hl2-rt1h1 --vlan-id 100 \
+  --src-addr fc00:1::1 --segments fc00:2::1,fc00:3::3
+
+# Return path on router3
+sudo ip netns exec hl2-router3 ../../out/bin/vinbero -s http://127.0.0.1:8083 \
+  hl2 create --interface hl2-rt3h2 --vlan-id 100 \
+  --src-addr fc00:3::3 --segments fc00:2::2,fc00:1::2
 ```
 
 ### 3. Test

--- a/examples/headend-l2/README.md
+++ b/examples/headend-l2/README.md
@@ -1,15 +1,19 @@
-# SRv6 Headend (H.Encaps.L2) L2VPN Playground
+# SRv6 H.Encaps.L2 Playground
 
-Vinbero XDPによるSRv6 H.Encaps.L2 (Headend L2 Encapsulation) for L2VPNのデモ環境です。
+*(日本語: [README.ja.md](./README.ja.md))*
 
-## 概要
+Demo environment for SRv6 H.Encaps.L2 (headend L2 encapsulation) for L2VPN on
+Vinbero XDP.
 
-H.Encaps.L2は、L2フレーム全体（Ethernetヘッダーを含む）をSRv6パケットにカプセル化します。
-これにより、L2ドメインをSRv6ネットワーク経由で拡張するL2VPNを実現できます。
+## Overview
 
-**トリガー**: VLAN ID（VLANタグ付きパケット、またはVLAN ID 0でタグなしパケット）
+H.Encaps.L2 encapsulates a whole L2 frame, Ethernet header included, into an
+SRv6 packet. That gives an L2VPN which extends an L2 domain across an SRv6
+network.
 
-## トポロジー
+**Trigger**: VLAN ID (a VLAN-tagged packet, or VLAN ID 0 for untagged)
+
+## Topology
 
 ```mermaid
 graph LR
@@ -19,74 +23,76 @@ graph LR
     router3 -->|VLAN 100| host2[host2<br/>VLAN 100<br/>172.16.100.2]
 ```
 
-**パケットの流れ（host1→host2の例）:**
-1. host1がVLAN 100タグ付きフレームを送信 (172.16.100.1 → 172.16.100.2)
-2. **router1 (Vinbero XDP)** がH.Encaps.L2を実行:
-   - L2フレーム全体をIPv6+SRHでカプセル化
-   - Next Header: IPPROTO_ETHERNET (143)
-   - Outer DA: fc00:2::1 (最初のセグメント)
-   - Segment List: [fc00:2::1, fc00:3::3]
-3. router2がfc00:2::1でEnd操作を実行（SL減少、次のセグメントへ）
-4. router3がfc00:3::3でEnd.DX2を実行（L2フレームに戻す）
-5. host2がL2フレームを受信
+**Packet walk (host1 to host2):**
+1. host1 sends a VLAN 100 tagged frame (172.16.100.1 to 172.16.100.2)
+2. **router1 (Vinbero XDP)** runs H.Encaps.L2:
+   - encapsulates the whole L2 frame in IPv6 + SRH
+   - next header: IPPROTO_ETHERNET (143)
+   - outer DA: fc00:2::1 (the first segment)
+   - segment list: [fc00:2::1, fc00:3::3]
+3. router2 runs End on fc00:2::1: decrement SL, move to the next segment
+4. router3 runs End.DX2 on fc00:3::3 and restores the L2 frame
+5. host2 receives the frame
 
-## クイックスタート
+## Quick start
 
 ```bash
-sudo ./setup.sh    # 環境構築
-sudo ./test.sh     # テスト実行
-sudo ./teardown.sh # クリーンアップ（環境削除）
+sudo ./setup.sh    # build the environment
+sudo ./test.sh     # run the tests
+sudo ./teardown.sh # clean up
 ```
 
-## 手動実行
+## Running it by hand
 
-### 1. 環境構築とVinbero起動
+### 1. Build the environment and start Vinbero
 
 ```bash
 sudo ./setup.sh
 
-# Vinbero起動
+# Start Vinbero
 sudo ip netns exec hl2-router1 ../../out/bin/vinberod -c vinbero_router1.yaml
 ```
 
-### 2. HeadendL2エントリ登録
+### 2. Register the HeadendL2 entry
 
 ```bash
 sudo ip netns exec hl2-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 hl2 create --vlan-id 100 --src-addr fc00:1::1 --segments fc00:2::1,fc00:3::3
 ```
 
-### 3. テスト
+### 3. Test
 
 ```bash
-# VLAN 100経由でpingテスト
+# ping over VLAN 100
 sudo ip netns exec hl2-host1 ping -c 3 -I hl2-h1rt1.100 172.16.100.2
 ```
 
-### 4. パケットキャプチャで確認
+### 4. Confirm with a packet capture
 
 ```bash
-# router1-router2間でSRv6パケットを確認
+# SRv6 packets between router1 and router2
 sudo ip netns exec hl2-router2 tcpdump -i hl2-rt2rt1 -n -v ip6
 ```
 
-SRv6 Routing Header (RT6) と Next Header 143 (Ethernet) が確認できます。
+The capture shows the SRv6 Routing Header (RT6) and next header 143
+(Ethernet).
 
-### 5. 環境のクリーンナップ
+### 5. Clean up
+
 ```bash
 sudo ./teardown.sh
 ```
 
-## L2VPNユースケース
+## L2VPN use cases
 
-H.Encaps.L2は以下のようなL2VPNシナリオに適しています：
+H.Encaps.L2 fits L2VPN scenarios such as:
 
-- **VLAN拡張**: 異なるサイト間でVLANを透過的に接続
-- **L2ブリッジング**: リモートサイト間でEthernetセグメントを拡張
-- **レガシー対応**: L3サービスに対応していないアプリケーションの接続
+- **VLAN extension**: connect a VLAN transparently across sites
+- **L2 bridging**: extend an Ethernet segment between remote sites
+- **Legacy support**: connect applications that cannot use an L3 service
 
-## 技術詳細
+## Details
 
-### SRv6ヘッダー構造
+### SRv6 header layout
 
 ```
 +------------------+
@@ -108,11 +114,12 @@ H.Encaps.L2は以下のようなL2VPNシナリオに適しています：
 +------------------+
 ```
 
-### End.DX2動作
+### End.DX2 behavior
 
-End.DX2はSRv6パケットからL2フレームを取り出し、指定されたインターフェースに転送します：
+End.DX2 extracts the L2 frame from the SRv6 packet and forwards it out the
+configured interface:
 
 ```bash
-# LinuxでのEnd.DX2設定例
+# End.DX2 on Linux
 ip -6 route add local fc00:3::3/128 encap seg6local action End.DX2 oif eth1
 ```

--- a/examples/headend-v4/README.ja.md
+++ b/examples/headend-v4/README.ja.md
@@ -1,0 +1,73 @@
+# SRv6 Headend (H.Encaps) IPv4 Playground
+
+*(English: [README.md](./README.md))*
+
+Vinbero XDPによるSRv6 H.Encaps (Headend Encapsulation) for IPv4のデモ環境です。
+
+## トポロジー
+
+```mermaid
+graph LR
+    host1[host1<br/>172.0.1.1] -->|IPv4| router1[router1 / Vinbero XDP<br/>172.0.1.2<br/>fc00:1::1<br/>H.Encaps<br/>Trigger: 172.0.2.0/24<br/>Segments: fc00:2::1, fc00:3::3]
+    router1 -->|SRv6| router2[router2<br/>fc00:12::2<br/>End]
+    router2 -->|SRv6| router3[router3<br/>172.0.2.2<br/>fc00:3::3<br/>End.DX4]
+    router3 -->|IPv4| host2[host2<br/>172.0.2.1]
+```
+
+**パケットの流れ（host1→host2の例）:**
+1. host1が172.0.2.1にpingを送信 (IPv4)
+2. **router1 (Vinbero XDP)** がH.Encapsを実行:
+   - IPv4パケットをIPv6+SRHでカプセル化
+   - Outer DA: fc00:2::1 (最初のセグメント)
+   - Segment List: [fc00:2::1, fc00:3::3]
+3. router2がfc00:2::1でEnd操作を実行（SL減少、次のセグメントへ）
+4. router3がfc00:3::3でEnd.DX4を実行（IPv4に戻す）
+5. host2がpingを受信
+
+## クイックスタート
+
+```bash
+sudo ./setup.sh    # 環境構築
+sudo ./test.sh     # テスト実行
+sudo ./teardown.sh # クリーンアップ（環境削除）
+```
+
+## 手動実行
+
+### 1. 環境構築とVinbero起動
+
+```bash
+sudo ./setup.sh
+
+# router1のLinux native SRv6ルートを削除
+sudo ip netns exec hv4-router1 ip route del 172.0.2.0/24 2>/dev/null
+
+# Vinbero起動
+sudo ip netns exec hv4-router1 ../../out/bin/vinberod -c vinbero_router1.yaml
+```
+
+### 2. HeadendV4エントリ登録
+
+```bash
+sudo ip netns exec hv4-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 hv4 create --trigger-prefix 172.0.2.0/24 --src-addr fc00:1::1 --segments fc00:2::1,fc00:3::3
+```
+
+### 3. テスト
+
+```bash
+sudo ip netns exec hv4-host1 ping -c 3 172.0.2.1
+```
+
+#### パケットキャプチャ
+
+```bash
+# router1-router2間でSRv6パケットを確認
+sudo ip netns exec hv4-router2 tcpdump -i hv4-rt2rt1 -n ip6
+```
+
+SRv6 Routing Header (RT6) でsegment list: [fc00:2::1, fc00:3::3] が確認できます。
+
+### 4. 環境のクリーンナップ
+```bash
+sudo ./teardown.sh
+```

--- a/examples/headend-v4/README.ja.md
+++ b/examples/headend-v4/README.ja.md
@@ -67,7 +67,7 @@ sudo ip netns exec hv4-router2 tcpdump -i hv4-rt2rt1 -n ip6
 
 SRv6 Routing Header (RT6) でsegment list: [fc00:2::1, fc00:3::3] が確認できます。
 
-### 4. 環境のクリーンナップ
+### 4. 環境のクリーンアップ
 ```bash
 sudo ./teardown.sh
 ```

--- a/examples/headend-v4/README.md
+++ b/examples/headend-v4/README.md
@@ -1,8 +1,11 @@
-# SRv6 Headend (H.Encaps) IPv4 Playground
+# SRv6 H.Encaps for IPv4 Playground
 
-Vinbero XDPによるSRv6 H.Encaps (Headend Encapsulation) for IPv4のデモ環境です。
+*(日本語: [README.ja.md](./README.ja.md))*
 
-## トポロジー
+Demo environment for SRv6 H.Encaps (headend encapsulation) of IPv4 traffic on
+Vinbero XDP.
+
+## Topology
 
 ```mermaid
 graph LR
@@ -12,60 +15,62 @@ graph LR
     router3 -->|IPv4| host2[host2<br/>172.0.2.1]
 ```
 
-**パケットの流れ（host1→host2の例）:**
-1. host1が172.0.2.1にpingを送信 (IPv4)
-2. **router1 (Vinbero XDP)** がH.Encapsを実行:
-   - IPv4パケットをIPv6+SRHでカプセル化
-   - Outer DA: fc00:2::1 (最初のセグメント)
-   - Segment List: [fc00:2::1, fc00:3::3]
-3. router2がfc00:2::1でEnd操作を実行（SL減少、次のセグメントへ）
-4. router3がfc00:3::3でEnd.DX4を実行（IPv4に戻す）
-5. host2がpingを受信
+**Packet walk (host1 to host2):**
+1. host1 pings 172.0.2.1 over IPv4
+2. **router1 (Vinbero XDP)** runs H.Encaps:
+   - encapsulates the IPv4 packet in IPv6 + SRH
+   - outer DA: fc00:2::1 (the first segment)
+   - segment list: [fc00:2::1, fc00:3::3]
+3. router2 runs End on fc00:2::1: decrement SL, move to the next segment
+4. router3 runs End.DX4 on fc00:3::3 and restores the IPv4 packet
+5. host2 receives the ping
 
-## クイックスタート
+## Quick start
 
 ```bash
-sudo ./setup.sh    # 環境構築
-sudo ./test.sh     # テスト実行
-sudo ./teardown.sh # クリーンアップ（環境削除）
+sudo ./setup.sh    # build the environment
+sudo ./test.sh     # run the tests
+sudo ./teardown.sh # clean up
 ```
 
-## 手動実行
+## Running it by hand
 
-### 1. 環境構築とVinbero起動
+### 1. Build the environment and start Vinbero
 
 ```bash
 sudo ./setup.sh
 
-# router1のLinux native SRv6ルートを削除
+# Remove the Linux native SRv6 route on router1
 sudo ip netns exec hv4-router1 ip route del 172.0.2.0/24 2>/dev/null
 
-# Vinbero起動
+# Start Vinbero
 sudo ip netns exec hv4-router1 ../../out/bin/vinberod -c vinbero_router1.yaml
 ```
 
-### 2. HeadendV4エントリ登録
+### 2. Register the HeadendV4 entry
 
 ```bash
 sudo ip netns exec hv4-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 hv4 create --trigger-prefix 172.0.2.0/24 --src-addr fc00:1::1 --segments fc00:2::1,fc00:3::3
 ```
 
-### 3. テスト
+### 3. Test
 
 ```bash
 sudo ip netns exec hv4-host1 ping -c 3 172.0.2.1
 ```
 
-#### パケットキャプチャ
+#### Packet capture
 
 ```bash
-# router1-router2間でSRv6パケットを確認
+# SRv6 packets between router1 and router2
 sudo ip netns exec hv4-router2 tcpdump -i hv4-rt2rt1 -n ip6
 ```
 
-SRv6 Routing Header (RT6) でsegment list: [fc00:2::1, fc00:3::3] が確認できます。
+The SRv6 Routing Header (RT6) carries the segment list
+[fc00:2::1, fc00:3::3].
 
-### 4. 環境のクリーンナップ
+### 4. Clean up
+
 ```bash
 sudo ./teardown.sh
 ```

--- a/examples/headend-v6/README.ja.md
+++ b/examples/headend-v6/README.ja.md
@@ -1,0 +1,75 @@
+# SRv6 Headend (H.Encaps) IPv6 Playground
+
+*(English: [README.md](./README.md))*
+
+Vinbero XDPによるSRv6 H.Encaps (Headend Encapsulation) for IPv6のデモ環境です。
+IPv6パケットをIPv6+SRHでカプセル化します（IPv6-in-IPv6）。
+
+## トポロジー
+
+```mermaid
+graph LR
+    host1[host1<br/>2001:1::1] -->|IPv6| router1[router1 / Vinbero XDP<br/>2001:1::2<br/>fc00:1::1<br/>H.Encaps<br/>Trigger: 2001:2::/64<br/>Segments: fc00:2::1, fc00:3::3]
+    router1 -->|SRv6| router2[router2<br/>fc00:12::2<br/>End]
+    router2 -->|SRv6| router3[router3<br/>2001:2::2<br/>fc00:3::3<br/>End.DX6]
+    router3 -->|IPv6| host2[host2<br/>2001:2::1]
+```
+
+**パケットの流れ（host1→host2の例）:**
+1. host1が2001:2::1にping6を送信 (IPv6)
+2. **router1 (Vinbero XDP)** がH.Encapsを実行:
+   - IPv6パケットを外側IPv6+SRHでカプセル化
+   - Outer DA: fc00:2::1 (最初のセグメント)
+   - Segment List: [fc00:2::1, fc00:3::3]
+3. router2がfc00:2::1でEnd操作を実行（SL減少、次のセグメントへ）
+4. router3がfc00:3::3でEnd.DX6を実行（内側IPv6を取り出す）
+5. host2がping6を受信
+
+## クイックスタート
+
+```bash
+sudo ./setup.sh    # 環境構築
+sudo ./test.sh     # テスト実行
+sudo ./teardown.sh # クリーンアップ
+```
+
+## 手動実行
+
+### 1. 環境構築とVinbero起動
+
+```bash
+sudo ./setup.sh
+
+# router1のLinux native SRv6ルートを削除
+sudo ip netns exec hv6-router1 ip -6 route del 2001:2::/64 2>/dev/null
+
+# Vinbero起動
+sudo ip netns exec hv6-router1 ../../out/bin/vinberod -c vinbero_router1.yaml
+```
+
+### 2. HeadendV6エントリ登録
+
+```bash
+sudo ip netns exec hv6-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 hv6 create --trigger-prefix 2001:2::/64 --src-addr fc00:1::1 --segments fc00:2::1,fc00:3::3
+```
+
+### 3. テスト
+
+```bash
+sudo ip netns exec hv6-host1 ping6 -c 3 2001:2::1
+```
+
+#### パケットキャプチャ
+
+```bash
+# router1-router2間でSRv6パケットを確認
+sudo ip netns exec hv6-router2 tcpdump -i hv6-rt2rt1 -n ip6
+```
+
+外側IPv6+SRH内に内側IPv6パケットがカプセル化されていることが確認できます。
+
+### 4. 環境のクリーンナップ
+
+```bash
+sudo ./teardown.sh
+```

--- a/examples/headend-v6/README.ja.md
+++ b/examples/headend-v6/README.ja.md
@@ -68,7 +68,7 @@ sudo ip netns exec hv6-router2 tcpdump -i hv6-rt2rt1 -n ip6
 
 外側IPv6+SRH内に内側IPv6パケットがカプセル化されていることが確認できます。
 
-### 4. 環境のクリーンナップ
+### 4. 環境のクリーンアップ
 
 ```bash
 sudo ./teardown.sh

--- a/examples/headend-v6/README.md
+++ b/examples/headend-v6/README.md
@@ -1,9 +1,11 @@
-# SRv6 Headend (H.Encaps) IPv6 Playground
+# SRv6 H.Encaps for IPv6 Playground
 
-Vinbero XDPによるSRv6 H.Encaps (Headend Encapsulation) for IPv6のデモ環境です。
-IPv6パケットをIPv6+SRHでカプセル化します（IPv6-in-IPv6）。
+*(日本語: [README.ja.md](./README.ja.md))*
 
-## トポロジー
+Demo environment for SRv6 H.Encaps (headend encapsulation) of IPv6 traffic on
+Vinbero XDP. The IPv6 packet is encapsulated in IPv6 + SRH (IPv6-in-IPv6).
+
+## Topology
 
 ```mermaid
 graph LR
@@ -13,60 +15,61 @@ graph LR
     router3 -->|IPv6| host2[host2<br/>2001:2::1]
 ```
 
-**パケットの流れ（host1→host2の例）:**
-1. host1が2001:2::1にping6を送信 (IPv6)
-2. **router1 (Vinbero XDP)** がH.Encapsを実行:
-   - IPv6パケットを外側IPv6+SRHでカプセル化
-   - Outer DA: fc00:2::1 (最初のセグメント)
-   - Segment List: [fc00:2::1, fc00:3::3]
-3. router2がfc00:2::1でEnd操作を実行（SL減少、次のセグメントへ）
-4. router3がfc00:3::3でEnd.DX6を実行（内側IPv6を取り出す）
-5. host2がping6を受信
+**Packet walk (host1 to host2):**
+1. host1 pings 2001:2::1 over IPv6
+2. **router1 (Vinbero XDP)** runs H.Encaps:
+   - encapsulates the IPv6 packet in an outer IPv6 + SRH
+   - outer DA: fc00:2::1 (the first segment)
+   - segment list: [fc00:2::1, fc00:3::3]
+3. router2 runs End on fc00:2::1: decrement SL, move to the next segment
+4. router3 runs End.DX6 on fc00:3::3 and extracts the inner IPv6 packet
+5. host2 receives the ping
 
-## クイックスタート
+## Quick start
 
 ```bash
-sudo ./setup.sh    # 環境構築
-sudo ./test.sh     # テスト実行
-sudo ./teardown.sh # クリーンアップ
+sudo ./setup.sh    # build the environment
+sudo ./test.sh     # run the tests
+sudo ./teardown.sh # clean up
 ```
 
-## 手動実行
+## Running it by hand
 
-### 1. 環境構築とVinbero起動
+### 1. Build the environment and start Vinbero
 
 ```bash
 sudo ./setup.sh
 
-# router1のLinux native SRv6ルートを削除
+# Remove the Linux native SRv6 route on router1
 sudo ip netns exec hv6-router1 ip -6 route del 2001:2::/64 2>/dev/null
 
-# Vinbero起動
+# Start Vinbero
 sudo ip netns exec hv6-router1 ../../out/bin/vinberod -c vinbero_router1.yaml
 ```
 
-### 2. HeadendV6エントリ登録
+### 2. Register the HeadendV6 entry
 
 ```bash
 sudo ip netns exec hv6-router1 ../../out/bin/vinbero -s http://127.0.0.1:8082 hv6 create --trigger-prefix 2001:2::/64 --src-addr fc00:1::1 --segments fc00:2::1,fc00:3::3
 ```
 
-### 3. テスト
+### 3. Test
 
 ```bash
 sudo ip netns exec hv6-host1 ping6 -c 3 2001:2::1
 ```
 
-#### パケットキャプチャ
+#### Packet capture
 
 ```bash
-# router1-router2間でSRv6パケットを確認
+# SRv6 packets between router1 and router2
 sudo ip netns exec hv6-router2 tcpdump -i hv6-rt2rt1 -n ip6
 ```
 
-外側IPv6+SRH内に内側IPv6パケットがカプセル化されていることが確認できます。
+The capture shows the inner IPv6 packet encapsulated inside the outer
+IPv6 + SRH.
 
-### 4. 環境のクリーンナップ
+### 4. Clean up
 
 ```bash
 sudo ./teardown.sh


### PR DESCRIPTION
## What

`headend-ecmp` と `interop-clab` の各 scenario は既に英語主体で、日本語は `README.ja.md` に置く形になっています。netns example 21 本だけが日本語のみだったので、同じ形に揃えます。

- 各 example の `README.md` を `README.ja.md` に移し、英語の `README.md` を新規に書きます
- 双方向にリンクします (`*(日本語: [README.ja.md](./README.ja.md))*` / `*(English: [README.md](./README.md))*`)

## 翻訳以外の変更

レビューで見つかった記述の誤りも直しています。いずれも両言語版に同じ内容で入れています。

- `end-dt2m-multihomed`: ファイル一覧の自己参照が移設前の `README.md` を指していたので、各言語版が自分のファイルを指すようにしました
- `end-an`: `vbctl sid get` を `vinbero sid get` に直しました。netns example が使うのは `out/bin/vinbero` で、`vbctl` は interop-clab の image 内の symlink です (`test.sh` の実装どおり)
- `end-dt2-p2mp`: 手動手順の PE2 / PE3 に「End.DT2 + H.Encaps.L2 (return)」と書きながら `sid create` しか載っていなかったので、`test.sh` が実行している `hl2 create` (PE2 は access port 2 本) と `peer create` を追記しました
- `headend-l2`: 手動手順の `hl2 create` に必須の `--interface` が無く、router3 の起動と復路エントリも無かったので、`test.sh` と同じ両端構成に直しました
- `end-dx2v`: 手動手順に router3 の復路 H.Encaps.L2 (VLAN 100 / 200) が無く、記載どおりでは双方向 ping が返らないので追記しました
- `end-dt2m-multihomed`: Phase C の説明が「PE1 の TX と PE2 の RX を assert」となっていましたが、実際は両 PE の TX と host1 側 pcap なので実装に合わせました
- 日本語版 5 ページの「クリーンナップ」を「クリーンアップ」に直しました

## Scope

`examples/README.md` (一覧ページ) はこの PR では触っていません。uSID の PR #146 が同じファイルを編集しているため、ここで変換すると merge が確実に conflict します。あちらが merge されたあとに追随します。

## Verification

- 追加した cross-link 22 本の解決を確認しました
- repo 内から `examples/<name>/README.md` を指す参照が無いことを確認しました (リンク切れなし)
- 上記 3 件の記述修正は、対応する `test.sh` の実装と突き合わせて確認しました
