### PR TITLE
fix(bpf): keep the builtin aux lifecycle tied to the exact SID entry

### DIFF
--- a/pkg/bpf/aux_lifecycle_test.go
+++ b/pkg/bpf/aux_lifecycle_test.go
@@ -2,6 +2,7 @@ package bpf
 
 import (
 	"net"
+	"sync"
 	"testing"
 )
 
@@ -136,5 +137,55 @@ func TestCreateSidFunction_UpsertFreesTheAuxOfAnUnownedEntry(t *testing.T) {
 
 	if owner := m.auxAlloc.OwnerOf(legacyAux); owner != "" {
 		t.Errorf("legacy aux index %d owner = %q, want it freed", legacyAux, owner)
+	}
+}
+
+// Drives concurrent upserts and checks the aux bookkeeping still adds up:
+// one live index per prefix, each owned by the entry pointing at it. The
+// ABA window the lifecycle lock closes is too narrow to hit on demand, so
+// this is a load-shaped invariant check rather than proof of the lock --
+// it catches gross double-free or double-alloc, not the specific
+// interleaving.
+func TestSidFunctionAuxLifecycle_ConcurrentUpserts(t *testing.T) {
+	m := auxTestOps(t)
+	prefixes := []string{
+		"fd00:1:a11:3::1/128",
+		"fd00:1:a11:3::2/128",
+		"fd00:1:a11:3::3/128",
+	}
+	t.Cleanup(func() {
+		for _, p := range prefixes {
+			_ = m.DeleteSidFunction(p, OwnerRPC)
+		}
+	})
+
+	before := m.auxAlloc.countByOwner(AuxOwnerBuiltin)
+	var wg sync.WaitGroup
+	for _, p := range prefixes {
+		wg.Add(1)
+		go func(prefix string) {
+			defer wg.Done()
+			for i := range 20 {
+				entry := &SidFunctionEntry{Action: actionEndX}
+				nh := nexthopBytes(t, "fe80::1")
+				nh[15] = byte(i + 1)
+				if err := m.CreateSidFunction(prefix, entry, NewSidAuxNexthop(nh), OwnerRPC); err != nil {
+					t.Errorf("create %s: %v", prefix, err)
+					return
+				}
+			}
+		}(p)
+	}
+	wg.Wait()
+
+	// One live aux per prefix, whatever order the updates landed in.
+	if got, want := m.auxAlloc.countByOwner(AuxOwnerBuiltin), before+len(prefixes); got != want {
+		t.Errorf("builtin aux slots in use = %d, want %d", got, want)
+	}
+	for _, p := range prefixes {
+		idx := auxIndexOf(t, m, p)
+		if owner := m.auxAlloc.OwnerOf(uint32(idx)); owner != AuxOwnerBuiltin {
+			t.Errorf("%s points at aux %d whose owner is %q", p, idx, owner)
+		}
 	}
 }

--- a/pkg/bpf/aux_lifecycle_test.go
+++ b/pkg/bpf/aux_lifecycle_test.go
@@ -140,12 +140,12 @@ func TestCreateSidFunction_UpsertFreesTheAuxOfAnUnownedEntry(t *testing.T) {
 	}
 }
 
-// Drives concurrent upserts and checks the aux bookkeeping still adds up:
-// one live index per prefix, each owned by the entry pointing at it. The
-// ABA window the lifecycle lock closes is too narrow to hit on demand, so
-// this is a load-shaped invariant check rather than proof of the lock --
-// it catches gross double-free or double-alloc, not the specific
-// interleaving.
+// Drives concurrent upserts of the SAME prefixes from several workers, so
+// the read-modify-write sequences the lifecycle lock protects actually
+// overlap, and checks the aux bookkeeping still adds up: one live index per
+// prefix, each owned by the entry pointing at it. The ABA interleaving is
+// too narrow to hit on demand, so this catches gross double-free or
+// double-alloc rather than proving the lock.
 func TestSidFunctionAuxLifecycle_ConcurrentUpserts(t *testing.T) {
 	m := auxTestOps(t)
 	prefixes := []string{
@@ -160,25 +160,28 @@ func TestSidFunctionAuxLifecycle_ConcurrentUpserts(t *testing.T) {
 	})
 
 	before := m.auxAlloc.countByOwner(AuxOwnerBuiltin)
+	const workers = 4
 	var wg sync.WaitGroup
-	for _, p := range prefixes {
+	for w := range workers {
 		wg.Add(1)
-		go func(prefix string) {
+		go func(w int) {
 			defer wg.Done()
-			for i := range 20 {
-				entry := &SidFunctionEntry{Action: actionEndX}
-				nh := nexthopBytes(t, "fe80::1")
-				nh[15] = byte(i + 1)
-				if err := m.CreateSidFunction(prefix, entry, NewSidAuxNexthop(nh), OwnerRPC); err != nil {
-					t.Errorf("create %s: %v", prefix, err)
-					return
+			for i := range 15 {
+				for _, prefix := range prefixes {
+					entry := &SidFunctionEntry{Action: actionEndX}
+					nh := nexthopBytes(t, "fe80::1")
+					nh[14] = byte(w + 1)
+					nh[15] = byte(i + 1)
+					if err := m.CreateSidFunction(prefix, entry, NewSidAuxNexthop(nh), OwnerRPC); err != nil {
+						t.Errorf("worker %d create %s: %v", w, prefix, err)
+						return
+					}
 				}
 			}
-		}(p)
+		}(w)
 	}
 	wg.Wait()
 
-	// One live aux per prefix, whatever order the updates landed in.
 	if got, want := m.auxAlloc.countByOwner(AuxOwnerBuiltin), before+len(prefixes); got != want {
 		t.Errorf("builtin aux slots in use = %d, want %d", got, want)
 	}

--- a/pkg/bpf/aux_lifecycle_test.go
+++ b/pkg/bpf/aux_lifecycle_test.go
@@ -1,0 +1,102 @@
+package bpf
+
+import (
+	"net"
+	"testing"
+)
+
+// auxTestOps loads a collection and returns MapOperations for the aux
+// lifecycle tests. Requires sudo, like the rest of pkg/bpf.
+func auxTestOps(t *testing.T) *MapOperations {
+	t.Helper()
+	objs, err := ReadCollection(nil, nil)
+	if err != nil {
+		t.Skipf("BPF collection load failed (needs sudo): %v", err)
+	}
+	t.Cleanup(func() { _ = objs.Close() })
+	return NewMapOperations(objs)
+}
+
+func nexthopBytes(t *testing.T, addr string) [16]byte {
+	t.Helper()
+	var out [16]byte
+	ip := net.ParseIP(addr).To16()
+	if ip == nil {
+		t.Fatalf("bad address %q", addr)
+	}
+	copy(out[:], ip)
+	return out
+}
+
+func auxIndexOf(t *testing.T, m *MapOperations, prefix string) uint16 {
+	t.Helper()
+	entry, err := m.GetSidFunction(prefix)
+	if err != nil {
+		t.Fatalf("GetSidFunction(%s): %v", prefix, err)
+	}
+	return entry.AuxIndex
+}
+
+// CreateSidFunction is an upsert. Re-creating an entry that carries a
+// builtin aux allocates a fresh index, so the superseded one has to go back
+// to the pool -- otherwise every re-create burns a slot and the aux map
+// eventually refuses new SIDs.
+func TestCreateSidFunction_UpsertFreesTheSupersededAux(t *testing.T) {
+	m := auxTestOps(t)
+	const prefix = "fd00:1:a11:1::1/128"
+	nh := nexthopBytes(t, "fe80::1")
+
+	entry := &SidFunctionEntry{Action: actionEndX}
+	if err := m.CreateSidFunction(prefix, entry, NewSidAuxNexthop(nh), OwnerRPC); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	t.Cleanup(func() { _ = m.DeleteSidFunction(prefix, OwnerRPC) })
+	first := auxIndexOf(t, m, prefix)
+	before := m.auxAlloc.countByOwner(AuxOwnerBuiltin)
+
+	entry2 := &SidFunctionEntry{Action: actionEndX}
+	if err := m.CreateSidFunction(prefix, entry2, NewSidAuxNexthop(nexthopBytes(t, "fe80::2")), OwnerRPC); err != nil {
+		t.Fatalf("re-create: %v", err)
+	}
+	second := auxIndexOf(t, m, prefix)
+
+	if got := m.auxAlloc.countByOwner(AuxOwnerBuiltin); got != before {
+		t.Errorf("builtin aux slots in use = %d, want %d (the re-create leaked one)", got, before)
+	}
+	if first != second && m.auxAlloc.OwnerOf(uint32(first)) != "" {
+		t.Errorf("aux index %d is still owned after being superseded", first)
+	}
+}
+
+// Deleting a prefix that has no entry of its own must not touch the broader
+// entry covering it. sid_function_map is an LPM trie, so the pre-delete
+// lookup answers with that covering entry; acting on it would free the aux
+// of a SID that is still installed.
+func TestDeleteSidFunction_MissingPrefixKeepsTheCoveringAux(t *testing.T) {
+	m := auxTestOps(t)
+	const covering = "fd00:1:a11:c0de::/64"
+	nh := nexthopBytes(t, "fe80::1")
+
+	entry := &SidFunctionEntry{Action: actionEndX}
+	if err := m.CreateSidFunction(covering, entry, NewSidAuxNexthop(nh), OwnerRPC); err != nil {
+		t.Fatalf("create covering entry: %v", err)
+	}
+	t.Cleanup(func() { _ = m.DeleteSidFunction(covering, OwnerRPC) })
+	idx := auxIndexOf(t, m, covering)
+
+	// Nothing is installed at this /128; it only falls under the /64.
+	if err := m.DeleteSidFunction("fd00:1:a11:c0de::5/128", OwnerRPC); err != nil {
+		t.Fatalf("delete of an absent prefix: %v", err)
+	}
+
+	if owner := m.auxAlloc.OwnerOf(uint32(idx)); owner != AuxOwnerBuiltin {
+		t.Errorf("aux index %d owner = %q, want %q (freed by an unrelated delete)", idx, owner, AuxOwnerBuiltin)
+	}
+	aux, err := m.GetSidAux(uint32(idx))
+	if err != nil {
+		t.Fatalf("GetSidAux: %v", err)
+	}
+	if aux.Nexthop.Nexthop != nh {
+		t.Errorf("aux nexthop = %v, want %v (zeroed by an unrelated delete)", aux.Nexthop.Nexthop, nh)
+	}
+}

--- a/pkg/bpf/aux_lifecycle_test.go
+++ b/pkg/bpf/aux_lifecycle_test.go
@@ -6,12 +6,14 @@ import (
 )
 
 // auxTestOps loads a collection and returns MapOperations for the aux
-// lifecycle tests. Requires sudo, like the rest of pkg/bpf.
+// lifecycle tests. Loading needs privileges, like the rest of pkg/bpf: the
+// suite is run with `go test -exec "sudo -E"`, and a load failure is a real
+// failure rather than a reason to skip.
 func auxTestOps(t *testing.T) *MapOperations {
 	t.Helper()
 	objs, err := ReadCollection(nil, nil)
 	if err != nil {
-		t.Skipf("BPF collection load failed (needs sudo): %v", err)
+		t.Fatalf("Failed to load BPF objects: %v", err)
 	}
 	t.Cleanup(func() { _ = objs.Close() })
 	return NewMapOperations(objs)
@@ -98,5 +100,41 @@ func TestDeleteSidFunction_MissingPrefixKeepsTheCoveringAux(t *testing.T) {
 	}
 	if aux.Nexthop.Nexthop != nh {
 		t.Errorf("aux nexthop = %v, want %v (zeroed by an unrelated delete)", aux.Nexthop.Nexthop, nh)
+	}
+}
+
+// Entries pinned before owner tracking existed carry no owner record, so
+// ownership cannot stand in for "this prefix already has an entry". Such an
+// entry must still hand its aux back when it is upserted.
+func TestCreateSidFunction_UpsertFreesTheAuxOfAnUnownedEntry(t *testing.T) {
+	m := auxTestOps(t)
+	const prefix = "fd00:1:a11:2::1/128"
+
+	// Build the legacy shape by hand: a main-map entry with a builtin aux
+	// and no owner record.
+	key, err := buildLpmKeyV6(prefix)
+	if err != nil {
+		t.Fatalf("buildLpmKeyV6: %v", err)
+	}
+	legacyAux, err := m.auxAlloc.AllocOwner(AuxOwnerBuiltin)
+	if err != nil {
+		t.Fatalf("AllocOwner: %v", err)
+	}
+	if err := m.objs.SidAuxMap.Put(legacyAux, NewSidAuxNexthop(nexthopBytes(t, "fe80::9"))); err != nil {
+		t.Fatalf("put aux: %v", err)
+	}
+	legacy := &SidFunctionEntry{Action: actionEndX, AuxIndex: uint16(legacyAux)}
+	if err := m.objs.SidFunctionMap.Put(key, legacy); err != nil {
+		t.Fatalf("put legacy entry: %v", err)
+	}
+	t.Cleanup(func() { _ = m.ForceDeleteSidFunction(prefix) })
+
+	entry := &SidFunctionEntry{Action: actionEndX}
+	if err := m.CreateSidFunction(prefix, entry, NewSidAuxNexthop(nexthopBytes(t, "fe80::1")), OwnerRPC); err != nil {
+		t.Fatalf("upsert over the legacy entry: %v", err)
+	}
+
+	if owner := m.auxAlloc.OwnerOf(legacyAux); owner != "" {
+		t.Errorf("legacy aux index %d owner = %q, want it freed", legacyAux, owner)
 	}
 }

--- a/pkg/bpf/maps.go
+++ b/pkg/bpf/maps.go
@@ -1064,7 +1064,10 @@ func (m *MapOperations) CreateSidFunction(triggerPrefix string, entry *SidFuncti
 	}
 	// This is an upsert. Whatever aux the superseded entry pointed at goes
 	// unreferenced the moment the new entry lands, so remember it now.
-	supersededAux := m.exactSidFunctionAuxIndex(key, alreadyOwned)
+	supersededAux, err := m.exactSidFunctionAuxIndex(key)
+	if err != nil {
+		return err
+	}
 	if aux != nil {
 		if err := m.allocAndPutBuiltinAux(entry, aux); err != nil {
 			return err
@@ -1083,23 +1086,35 @@ func (m *MapOperations) CreateSidFunction(triggerPrefix string, entry *SidFuncti
 }
 
 // exactSidFunctionAuxIndex returns the aux index of the entry stored under
-// exactly key, or 0. It is only consulted on an upsert (the owner map, a
-// hash keyed by the exact prefix, already told us an entry is there), which
-// keeps the scan off the common path: sid_function_map is an LPM trie, so
-// Lookup would answer with a covering entry rather than this one.
-func (m *MapOperations) exactSidFunctionAuxIndex(key *LpmKeyV6, alreadyOwned bool) uint16 {
-	if !alreadyOwned {
-		return 0
+// exactly key, or 0 when this prefix has no entry of its own.
+//
+// sid_function_map is an LPM trie, so Lookup answers with a covering entry
+// rather than this one and cannot be used for the question. A miss there
+// does settle it though -- nothing covers the key, so nothing sits on it
+// either -- which keeps the scan off the path a fresh create takes.
+// Ownership is deliberately not used as the shortcut: entries pinned before
+// owner tracking existed carry no owner record, and skipping them would
+// leak their aux on the first upsert.
+func (m *MapOperations) exactSidFunctionAuxIndex(key *LpmKeyV6) (uint16, error) {
+	var covering SidFunctionEntry
+	if err := m.objs.SidFunctionMap.Lookup(key, &covering); err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("lookup SID function entry: %w", err)
 	}
 	var k LpmKeyV6
 	var e SidFunctionEntry
 	iter := m.objs.SidFunctionMap.Iterate()
 	for iter.Next(&k, &e) {
 		if k == *key {
-			return e.AuxIndex
+			return e.AuxIndex, nil
 		}
 	}
-	return 0
+	if err := iter.Err(); err != nil {
+		return 0, fmt.Errorf("scan SID function map: %w", err)
+	}
+	return 0, nil
 }
 
 // releaseSupersededBuiltinAux frees the aux index an upsert left behind.
@@ -1146,7 +1161,10 @@ func (m *MapOperations) CreateSidFunctionWithAuxIndex(triggerPrefix string, entr
 	}
 	// Binding a plugin aux over an entry that carried a builtin one leaves
 	// that builtin index unreferenced, same as any other upsert.
-	supersededAux := m.exactSidFunctionAuxIndex(key, alreadyOwned)
+	supersededAux, err := m.exactSidFunctionAuxIndex(key)
+	if err != nil {
+		return err
+	}
 	if err := m.auxAlloc.WithOwnerLocked(uint32(entry.AuxIndex), expectedAuxOwner, func() error {
 		return putMainAndOwner(m.objs.SidFunctionMap, m.sidFunctionOwners, key, entry, entryOwner, alreadyOwned, "SID function", nil)
 	}); err != nil {

--- a/pkg/bpf/maps.go
+++ b/pkg/bpf/maps.go
@@ -112,6 +112,16 @@ type MapOperations struct {
 	headendV4Owners   *entryOwnerMap
 	headendV6Owners   *entryOwnerMap
 	ecmpGroupOwners   *entryOwnerMap
+
+	// sidLifecycle serializes the read-modify-write sequences that bind a
+	// SID entry to its aux index: the owner check, the exact-entry read,
+	// the map write or delete, and the release of the aux the previous
+	// entry held. Those steps are not atomic on their own, and the writers
+	// do not share a lock above this layer (the RPC handler has its own
+	// mutex, the BGP applier does not take it), so without this two
+	// concurrent updates can free an index the other has just reused, or
+	// read one entry and then act on another. Zero value is usable.
+	sidLifecycle sync.Mutex
 }
 
 // NewMapOperations creates a new MapOperations instance.
@@ -1058,6 +1068,8 @@ func (m *MapOperations) CreateSidFunction(triggerPrefix string, entry *SidFuncti
 	if err != nil {
 		return fmt.Errorf("failed to build LPM key: %w", err)
 	}
+	m.sidLifecycle.Lock()
+	defer m.sidLifecycle.Unlock()
 	alreadyOwned, err := checkEntryOwner(m.sidFunctionOwners, key, owner)
 	if err != nil {
 		return err
@@ -1155,6 +1167,9 @@ func (m *MapOperations) CreateSidFunctionWithAuxIndex(triggerPrefix string, entr
 	if err != nil {
 		return fmt.Errorf("failed to build LPM key: %w", err)
 	}
+	m.sidLifecycle.Lock()
+	defer m.sidLifecycle.Unlock()
+
 	alreadyOwned, err := checkEntryOwner(m.sidFunctionOwners, key, entryOwner)
 	if err != nil {
 		return err
@@ -1264,6 +1279,8 @@ func (m *MapOperations) deleteSidFunctionInternal(triggerPrefix string, requeste
 	if err != nil {
 		return fmt.Errorf("failed to build LPM key: %w", err)
 	}
+	m.sidLifecycle.Lock()
+	defer m.sidLifecycle.Unlock()
 	if !force {
 		if _, err := checkEntryOwner(m.sidFunctionOwners, key, requester); err != nil {
 			return err

--- a/pkg/bpf/maps.go
+++ b/pkg/bpf/maps.go
@@ -1076,7 +1076,7 @@ func (m *MapOperations) CreateSidFunction(triggerPrefix string, entry *SidFuncti
 	}
 	// This is an upsert. Whatever aux the superseded entry pointed at goes
 	// unreferenced the moment the new entry lands, so remember it now.
-	supersededAux, err := m.exactSidFunctionAuxIndex(key)
+	supersededAux, err := m.exactSidFunctionAuxIndex(key, alreadyOwned)
 	if err != nil {
 		return err
 	}
@@ -1101,19 +1101,22 @@ func (m *MapOperations) CreateSidFunction(triggerPrefix string, entry *SidFuncti
 // exactly key, or 0 when this prefix has no entry of its own.
 //
 // sid_function_map is an LPM trie, so Lookup answers with a covering entry
-// rather than this one and cannot be used for the question. A miss there
-// does settle it though -- nothing covers the key, so nothing sits on it
-// either -- which keeps the scan off the path a fresh create takes.
-// Ownership is deliberately not used as the shortcut: entries pinned before
-// owner tracking existed carry no owner record, and skipping them would
-// leak their aux on the first upsert.
-func (m *MapOperations) exactSidFunctionAuxIndex(key *LpmKeyV6) (uint16, error) {
+// rather than this one. Two cheap facts settle almost every call: a miss
+// means nothing covers the key, so nothing sits on it either; and when the
+// owner map (a hash on the exact prefix) says this prefix is owned, the
+// entry exists, which makes the longest-prefix answer the exact one. Only
+// an entry with no owner record -- pinned before owner tracking existed --
+// needs the scan.
+func (m *MapOperations) exactSidFunctionAuxIndex(key *LpmKeyV6, alreadyOwned bool) (uint16, error) {
 	var covering SidFunctionEntry
 	if err := m.objs.SidFunctionMap.Lookup(key, &covering); err != nil {
 		if errors.Is(err, ebpf.ErrKeyNotExist) {
 			return 0, nil
 		}
 		return 0, fmt.Errorf("lookup SID function entry: %w", err)
+	}
+	if alreadyOwned {
+		return covering.AuxIndex, nil
 	}
 	var k LpmKeyV6
 	var e SidFunctionEntry
@@ -1176,7 +1179,7 @@ func (m *MapOperations) CreateSidFunctionWithAuxIndex(triggerPrefix string, entr
 	}
 	// Binding a plugin aux over an entry that carried a builtin one leaves
 	// that builtin index unreferenced, same as any other upsert.
-	supersededAux, err := m.exactSidFunctionAuxIndex(key)
+	supersededAux, err := m.exactSidFunctionAuxIndex(key, alreadyOwned)
 	if err != nil {
 		return err
 	}

--- a/pkg/bpf/maps.go
+++ b/pkg/bpf/maps.go
@@ -168,10 +168,23 @@ func checkEntryOwner(owners *entryOwnerMap, key any, caller OwnerTag) (alreadyOw
 // callers can delete idempotently. A double withdraw or a delete
 // replayed after a restart must not surface as an error.
 func deleteMapKey(m *ebpf.Map, key any) error {
-	if err := m.Delete(key); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
-		return err
+	_, err := deleteMapKeyExisted(m, key)
+	return err
+}
+
+// deleteMapKeyExisted is deleteMapKey plus the verdict on whether the key
+// was there. Map.Delete is an exact-key operation even on an LPM trie, so
+// this is the reliable way to tell "this prefix had its own entry" from
+// "some broader prefix covers it" -- Lookup cannot, it answers with the
+// covering entry.
+func deleteMapKeyExisted(m *ebpf.Map, key any) (bool, error) {
+	if err := m.Delete(key); err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return false, nil
+		}
+		return false, err
 	}
-	return nil
+	return true, nil
 }
 
 // putMainAndOwner writes value to the main map and, when not already
@@ -1049,6 +1062,9 @@ func (m *MapOperations) CreateSidFunction(triggerPrefix string, entry *SidFuncti
 	if err != nil {
 		return err
 	}
+	// This is an upsert. Whatever aux the superseded entry pointed at goes
+	// unreferenced the moment the new entry lands, so remember it now.
+	supersededAux := m.exactSidFunctionAuxIndex(key, alreadyOwned)
 	if aux != nil {
 		if err := m.allocAndPutBuiltinAux(entry, aux); err != nil {
 			return err
@@ -1059,7 +1075,48 @@ func (m *MapOperations) CreateSidFunction(triggerPrefix string, entry *SidFuncti
 			_ = m.auxAlloc.FreeOwner(uint32(entry.AuxIndex), AuxOwnerBuiltin)
 		}
 	}
-	return putMainAndOwner(m.objs.SidFunctionMap, m.sidFunctionOwners, key, entry, owner, alreadyOwned, "SID function", auxCleanup)
+	if err := putMainAndOwner(m.objs.SidFunctionMap, m.sidFunctionOwners, key, entry, owner, alreadyOwned, "SID function", auxCleanup); err != nil {
+		return err
+	}
+	m.releaseSupersededBuiltinAux(supersededAux, entry.AuxIndex)
+	return nil
+}
+
+// exactSidFunctionAuxIndex returns the aux index of the entry stored under
+// exactly key, or 0. It is only consulted on an upsert (the owner map, a
+// hash keyed by the exact prefix, already told us an entry is there), which
+// keeps the scan off the common path: sid_function_map is an LPM trie, so
+// Lookup would answer with a covering entry rather than this one.
+func (m *MapOperations) exactSidFunctionAuxIndex(key *LpmKeyV6, alreadyOwned bool) uint16 {
+	if !alreadyOwned {
+		return 0
+	}
+	var k LpmKeyV6
+	var e SidFunctionEntry
+	iter := m.objs.SidFunctionMap.Iterate()
+	for iter.Next(&k, &e) {
+		if k == *key {
+			return e.AuxIndex
+		}
+	}
+	return 0
+}
+
+// releaseSupersededBuiltinAux frees the aux index an upsert left behind.
+// Plugin-owned indices are left alone: the owner check inside
+// WithOwnerLocked fails for them, and their lifecycle belongs to the
+// PluginAux RPCs. newIdx guards the case where nothing actually changed.
+func (m *MapOperations) releaseSupersededBuiltinAux(oldIdx, newIdx uint16) {
+	if oldIdx == 0 || oldIdx == newIdx {
+		return
+	}
+	idx := uint32(oldIdx)
+	_ = m.auxAlloc.WithOwnerLocked(idx, AuxOwnerBuiltin, func() error {
+		var zero SidAuxEntry
+		_ = m.objs.SidAuxMap.Put(idx, &zero)
+		m.auxAlloc.freeOwnerLocked(idx)
+		return nil
+	})
 }
 
 // CreateSidFunctionWithAuxIndex binds a SID function entry to an aux index
@@ -1087,9 +1144,16 @@ func (m *MapOperations) CreateSidFunctionWithAuxIndex(triggerPrefix string, entr
 	if err != nil {
 		return err
 	}
-	return m.auxAlloc.WithOwnerLocked(uint32(entry.AuxIndex), expectedAuxOwner, func() error {
+	// Binding a plugin aux over an entry that carried a builtin one leaves
+	// that builtin index unreferenced, same as any other upsert.
+	supersededAux := m.exactSidFunctionAuxIndex(key, alreadyOwned)
+	if err := m.auxAlloc.WithOwnerLocked(uint32(entry.AuxIndex), expectedAuxOwner, func() error {
 		return putMainAndOwner(m.objs.SidFunctionMap, m.sidFunctionOwners, key, entry, entryOwner, alreadyOwned, "SID function", nil)
-	})
+	}); err != nil {
+		return err
+	}
+	m.releaseSupersededBuiltinAux(supersededAux, entry.AuxIndex)
+	return nil
 }
 
 // AllocPluginAux reserves an index in the plugin_raw variant of sid_aux_map
@@ -1189,12 +1253,17 @@ func (m *MapOperations) deleteSidFunctionInternal(triggerPrefix string, requeste
 	}
 
 	// Read entry first so aux can be cleaned up after successful delete.
+	// The lookup is a longest-prefix match, so it can answer with a broader
+	// entry that merely covers this prefix; the delete below decides whether
+	// what we read was really this prefix's own entry.
 	var entry SidFunctionEntry
 	hasEntry := m.objs.SidFunctionMap.Lookup(key, &entry) == nil
 
-	if err := deleteMapKey(m.objs.SidFunctionMap, key); err != nil {
+	existed, err := deleteMapKeyExisted(m.objs.SidFunctionMap, key)
+	if err != nil {
 		return fmt.Errorf("failed to delete SID function entry: %w", err)
 	}
+	hasEntry = hasEntry && existed
 	if err := m.sidFunctionOwners.Delete(key); err != nil {
 		return fmt.Errorf("failed to delete SID function owner: %w", err)
 	}


### PR DESCRIPTION
## 概要

`sid_function_map` は LPM trie で、`Lookup` は最長一致です。その結果を「今操作している entry」として扱っている箇所が 2 つあり、どちらも aux index の lifecycle を壊します。uSID の PR #145 のレビューで見つかったものですが、原因は uSID とは無関係で main に既存です。built-in aux を持つ全 action (End.X / End.T / End.DT2 / End.B6 など) が該当します。

### 1. upsert で aux index が漏れる

`CreateSidFunction` は upsert です。同じ trigger_prefix に再作成すると `allocAndPutBuiltinAux` が新しい index を確保しますが、置換前の entry が指していた index は解放されません。再作成のたびに 1 slot 消費し、`sid_aux_map` を使い切ると以後の SID 登録が失敗します。

置換前の index を覚えておき、新しい entry が live になった後に解放します。plugin 所有の index は `WithOwnerLocked` の owner 検証で弾かれるので触りません (lifecycle は PluginAux RPC 側)。

### 2. delete が「覆っている entry」の aux を解放する

`deleteSidFunctionInternal` は削除前に `Lookup` で entry を読みます。entry を持たない prefix を削除すると、これが**それを覆っている広い entry** を返します。`deleteMapKey` は ENOENT を握り潰すので delete は成功扱いになり、そのまま覆っている entry の aux をゼロ化して index を pool に戻します。**その SID はまだ installed で、その index を指したままです。**

`Map.Delete` は trie でも exact なので、その戻り値で「この prefix 自身の entry があったか」を判定します。

## テスト

`pkg/bpf/aux_lifecycle_test.go` を追加しました。どちらも修正前の実装で落ちることを確認済みです。

- `TestCreateSidFunction_UpsertFreesTheSupersededAux`: 修正前は `builtin aux slots in use = 2, want 1`
- `TestDeleteSidFunction_MissingPrefixKeepsTheCoveringAux`: 修正前は覆っている entry の aux owner が空になり、nexthop がゼロ化される

`go test -exec "sudo -E" ./pkg/bpf ./pkg/server` full suite pass (pkg/bpf 851s)。