### PR TITLE
perf(bpf): make the BPF test suite finish in seconds instead of minutes

### DIFF
--- a/benchmark/configs/vinbero-bench-stats.yml
+++ b/benchmark/configs/vinbero-bench-stats.yml
@@ -4,8 +4,6 @@ internal:
     - enp138s0f1np1
   bpf:
     device_mode: "driver"
-    verifier_log_level: 0
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/benchmark/configs/vinbero-bench.yml
+++ b/benchmark/configs/vinbero-bench.yml
@@ -4,8 +4,6 @@ internal:
     - enp138s0f1np1
   bpf:
     device_mode: "driver"
-    verifier_log_level: 0
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/end-ad/vinbero_router2.yaml
+++ b/examples/end-ad/vinbero_router2.yaml
@@ -4,8 +4,6 @@ internal:
     - ad-rt2svc   # Service side: return direction (IFACE-IN) arrives here
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/end-am/vinbero_router2.yaml
+++ b/examples/end-am/vinbero_router2.yaml
@@ -4,8 +4,6 @@ internal:
     - am-rt2svc   # Service side: return direction (IFACE-IN) arrives here
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/end-an/vinbero_router2.yaml
+++ b/examples/end-an/vinbero_router2.yaml
@@ -3,8 +3,6 @@ internal:
     - an-rt2rt1   # SRv6 side: the End.AN SID processes packets here
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/end-as/vinbero_router2.yaml
+++ b/examples/end-as/vinbero_router2.yaml
@@ -4,8 +4,6 @@ internal:
     - as-rt2svc   # Service side: return direction (IFACE-IN) arrives here
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/end-dt2-p2mp/vinbero_pe1.yaml
+++ b/examples/end-dt2-p2mp/vinbero_pe1.yaml
@@ -4,8 +4,6 @@ internal:
     - p2m-rt1rt2
   bpf:
     device_mode: generic
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/end-dt2-p2mp/vinbero_pe2.yaml
+++ b/examples/end-dt2-p2mp/vinbero_pe2.yaml
@@ -5,8 +5,6 @@ internal:
     - p2m-rt3rt2
   bpf:
     device_mode: generic
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8083"
   logger:

--- a/examples/end-dt2-p2mp/vinbero_pe3.yaml
+++ b/examples/end-dt2-p2mp/vinbero_pe3.yaml
@@ -4,8 +4,6 @@ internal:
     - p2m-rt4rt2
   bpf:
     device_mode: generic
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8084"
   logger:

--- a/examples/end-dt2/vinbero_router1.yaml
+++ b/examples/end-dt2/vinbero_router1.yaml
@@ -4,8 +4,6 @@ internal:
     - dt2-rt1rt2
   bpf:
     device_mode: generic
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/end-dt2/vinbero_router3.yaml
+++ b/examples/end-dt2/vinbero_router3.yaml
@@ -4,8 +4,6 @@ internal:
     - dt2-rt3rt2
   bpf:
     device_mode: generic
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8083"
   logger:

--- a/examples/end-dt2m-multihomed/smoke_api.sh
+++ b/examples/end-dt2m-multihomed/smoke_api.sh
@@ -80,8 +80,6 @@ internal:
     - $DUMMY_IF
   bpf:
     device_mode: generic
-    verifier_log_level: 1
-    verifier_log_size: 1073741823
   server:
     bind: "$BIND"
   logger:

--- a/examples/end-dt2m-multihomed/vinbero_pe1.yaml
+++ b/examples/end-dt2m-multihomed/vinbero_pe1.yaml
@@ -4,8 +4,6 @@ internal:
     - mh-pe1p
   bpf:
     device_mode: generic
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:18101"
   logger:

--- a/examples/end-dt2m-multihomed/vinbero_pe2.yaml
+++ b/examples/end-dt2m-multihomed/vinbero_pe2.yaml
@@ -4,8 +4,6 @@ internal:
     - mh-pe2p
   bpf:
     device_mode: generic
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:18102"
   logger:

--- a/examples/end-dt2m-multihomed/vinbero_pe3.yaml
+++ b/examples/end-dt2m-multihomed/vinbero_pe3.yaml
@@ -4,8 +4,6 @@ internal:
     - mh-pe3h2
   bpf:
     device_mode: generic
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:18103"
   logger:

--- a/examples/end-dt4/vinbero_router3.yaml
+++ b/examples/end-dt4/vinbero_router3.yaml
@@ -4,8 +4,6 @@ internal:
     - dt4-rt3rt2  # Interface towards router2
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/end-dt6/vinbero_router3.yaml
+++ b/examples/end-dt6/vinbero_router3.yaml
@@ -4,8 +4,6 @@ internal:
     - dt6-rt3rt2  # Interface towards router2
   bpf:
     device_mode: generic
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/end-dx2v/vinbero_router1.yaml
+++ b/examples/end-dx2v/vinbero_router1.yaml
@@ -4,8 +4,6 @@ internal:
     - dx2v-rt1rt2
   bpf:
     device_mode: generic
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/end-dx2v/vinbero_router3.yaml
+++ b/examples/end-dx2v/vinbero_router3.yaml
@@ -4,8 +4,6 @@ internal:
     - dx2v-rt3rt2
   bpf:
     device_mode: generic
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8083"
   logger:

--- a/examples/end-dx4/vinbero_router3.yaml
+++ b/examples/end-dx4/vinbero_router3.yaml
@@ -4,8 +4,6 @@ internal:
     - dx4-rt3rt2  # Interface towards router2 (with prefix)
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/end-dx6/vinbero_router3.yaml
+++ b/examples/end-dx6/vinbero_router3.yaml
@@ -4,8 +4,6 @@ internal:
     - dx6-rt3rt2  # Interface towards router2 (with prefix)
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/end-t/vinbero_router2.yaml
+++ b/examples/end-t/vinbero_router2.yaml
@@ -4,8 +4,6 @@ internal:
     - end-t-rt2rt3  # Interface towards router3 (in VRF)
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/end-x/vinbero_router2.yaml
+++ b/examples/end-x/vinbero_router2.yaml
@@ -4,8 +4,6 @@ internal:
     - end-x-rt2rt3  # Interface towards router3 (with "end-x-" prefix)
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/end/vinbero_router2.yaml
+++ b/examples/end/vinbero_router2.yaml
@@ -4,8 +4,6 @@ internal:
     - end-rt2rt3  # Interface towards router3 (with "end-" prefix)
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/gtp4-encap/vinbero_router1.yaml
+++ b/examples/gtp4-encap/vinbero_router1.yaml
@@ -4,8 +4,6 @@ internal:
     - gtp4-rt1rt2  # Interface towards router2
   bpf:
     device_mode: generic
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/gtp4-encap/vinbero_router3.yaml
+++ b/examples/gtp4-encap/vinbero_router3.yaml
@@ -4,8 +4,6 @@ internal:
     - gtp4-rt3rt2  # Interface towards router2
   bpf:
     device_mode: generic
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8083"
   logger:

--- a/examples/gtp6-drop-in/vinbero_router1.yaml
+++ b/examples/gtp6-drop-in/vinbero_router1.yaml
@@ -4,8 +4,6 @@ internal:
     - gtdi-rt1rt2
   bpf:
     device_mode: generic
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/gtp6-encap/vinbero_router1.yaml
+++ b/examples/gtp6-encap/vinbero_router1.yaml
@@ -4,8 +4,6 @@ internal:
     - gtp6-rt1rt2
   bpf:
     device_mode: generic
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/gtp6-encap/vinbero_router3.yaml
+++ b/examples/gtp6-encap/vinbero_router3.yaml
@@ -4,8 +4,6 @@ internal:
     - gtp6-rt3rt2
   bpf:
     device_mode: generic
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8083"
   logger:

--- a/examples/headend-ecmp/vinbero_router1.yaml
+++ b/examples/headend-ecmp/vinbero_router1.yaml
@@ -5,8 +5,6 @@ internal:
     - hec-rt1r2b  # Interface towards router2b (path B)
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/headend-l2/vinbero_router1.yaml
+++ b/examples/headend-l2/vinbero_router1.yaml
@@ -4,8 +4,6 @@ internal:
     - hl2-rt1rt2  # Interface towards router2 (with prefix)
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/headend-l2/vinbero_router3.yaml
+++ b/examples/headend-l2/vinbero_router3.yaml
@@ -4,8 +4,6 @@ internal:
     - hl2-rt3rt2  # Interface towards router2
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8083"
   logger:

--- a/examples/headend-v4/vinbero_router1.yaml
+++ b/examples/headend-v4/vinbero_router1.yaml
@@ -4,8 +4,6 @@ internal:
     - hv4-rt1rt2  # Interface towards router2 (with prefix)
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/headend-v6/vinbero_router1.yaml
+++ b/examples/headend-v6/vinbero_router1.yaml
@@ -4,8 +4,6 @@ internal:
     - hv6-rt1rt2  # Interface towards router2 (with prefix)
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/interop-clab/scenarios/ecmp-2site/vinbero/vinbero.yml
+++ b/examples/interop-clab/scenarios/ecmp-2site/vinbero/vinbero.yml
@@ -8,8 +8,6 @@ internal:
   bpf:
     # generic mode: veth links in containerlab do not support native XDP.
     device_mode: "generic"
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "0.0.0.0:8080"
   logger:

--- a/examples/interop-clab/scenarios/evpn-2site/pe-osaka/vinbero.yml
+++ b/examples/interop-clab/scenarios/evpn-2site/pe-osaka/vinbero.yml
@@ -6,8 +6,6 @@ internal:
     - eth2
   bpf:
     device_mode: "generic"
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "0.0.0.0:8080"
   logger:

--- a/examples/interop-clab/scenarios/evpn-2site/pe-tokyo/vinbero.yml
+++ b/examples/interop-clab/scenarios/evpn-2site/pe-tokyo/vinbero.yml
@@ -6,8 +6,6 @@ internal:
     - eth2
   bpf:
     device_mode: "generic"
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "0.0.0.0:8080"
   logger:

--- a/examples/interop-clab/scenarios/evpn-multihoming/pe1/vinbero.yml
+++ b/examples/interop-clab/scenarios/evpn-multihoming/pe1/vinbero.yml
@@ -6,8 +6,6 @@ internal:
     - eth2
   bpf:
     device_mode: "generic"
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "0.0.0.0:8080"
   logger:

--- a/examples/interop-clab/scenarios/evpn-multihoming/pe2/vinbero.yml
+++ b/examples/interop-clab/scenarios/evpn-multihoming/pe2/vinbero.yml
@@ -5,8 +5,6 @@ internal:
     - eth2
   bpf:
     device_mode: "generic"
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "0.0.0.0:8080"
   logger:

--- a/examples/interop-clab/scenarios/evpn-multihoming/pe3/vinbero.yml
+++ b/examples/interop-clab/scenarios/evpn-multihoming/pe3/vinbero.yml
@@ -5,8 +5,6 @@ internal:
     - eth2
   bpf:
     device_mode: "generic"
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "0.0.0.0:8080"
   logger:

--- a/examples/interop-clab/scenarios/l3vpn-2site-auto/vinbero/vinbero.yml
+++ b/examples/interop-clab/scenarios/l3vpn-2site-auto/vinbero/vinbero.yml
@@ -8,8 +8,6 @@ internal:
     - eth2
   bpf:
     device_mode: "generic"
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "0.0.0.0:8080"
   logger:

--- a/examples/interop-clab/scenarios/l3vpn-2site/vinbero/vinbero.yml
+++ b/examples/interop-clab/scenarios/l3vpn-2site/vinbero/vinbero.yml
@@ -10,8 +10,6 @@ internal:
   bpf:
     # generic mode: veth links in containerlab do not support native XDP.
     device_mode: "generic"
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "0.0.0.0:8080"
   logger:

--- a/examples/interop-clab/scenarios/mup-2site-multivrf/mup-c/vinbero.yml
+++ b/examples/interop-clab/scenarios/mup-2site-multivrf/mup-c/vinbero.yml
@@ -3,8 +3,6 @@ internal:
     - eth1
   bpf:
     device_mode: "generic"
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "0.0.0.0:8080"
   logger:

--- a/examples/interop-clab/scenarios/mup-2site-multivrf/mup-gw/vinbero.yml
+++ b/examples/interop-clab/scenarios/mup-2site-multivrf/mup-gw/vinbero.yml
@@ -7,8 +7,6 @@ internal:
     - eth3
   bpf:
     device_mode: "generic"
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "0.0.0.0:8080"
   logger:

--- a/examples/interop-clab/scenarios/mup-2site-multivrf/mup-pe/vinbero.yml
+++ b/examples/interop-clab/scenarios/mup-2site-multivrf/mup-pe/vinbero.yml
@@ -7,8 +7,6 @@ internal:
     - eth3
   bpf:
     device_mode: "generic"
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "0.0.0.0:8080"
   logger:

--- a/examples/interop-clab/scenarios/mup-2site/mup-c/vinbero.yml
+++ b/examples/interop-clab/scenarios/mup-2site/mup-c/vinbero.yml
@@ -3,8 +3,6 @@ internal:
     - eth1
   bpf:
     device_mode: "generic"
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "0.0.0.0:8080"
   logger:

--- a/examples/interop-clab/scenarios/mup-2site/mup-gw/vinbero.yml
+++ b/examples/interop-clab/scenarios/mup-2site/mup-gw/vinbero.yml
@@ -6,8 +6,6 @@ internal:
     - eth2
   bpf:
     device_mode: "generic"
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "0.0.0.0:8080"
   logger:

--- a/examples/interop-clab/scenarios/mup-2site/mup-pe/vinbero.yml
+++ b/examples/interop-clab/scenarios/mup-2site/mup-pe/vinbero.yml
@@ -6,8 +6,6 @@ internal:
     - eth2
   bpf:
     device_mode: "generic"
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "0.0.0.0:8080"
   logger:

--- a/examples/interop-clab/scenarios/sr-policy-2site/vinbero/vinbero.yml
+++ b/examples/interop-clab/scenarios/sr-policy-2site/vinbero/vinbero.yml
@@ -10,8 +10,6 @@ internal:
   bpf:
     # generic mode: veth links in containerlab do not support native XDP.
     device_mode: "generic"
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "0.0.0.0:8080"
   logger:

--- a/examples/interop-clab/scenarios/sr-policy-bgp-2site/pe-osaka/vinbero.yml
+++ b/examples/interop-clab/scenarios/sr-policy-bgp-2site/pe-osaka/vinbero.yml
@@ -6,8 +6,6 @@ internal:
     - eth2
   bpf:
     device_mode: "generic"
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "0.0.0.0:8080"
   logger:

--- a/examples/interop-clab/scenarios/sr-policy-bgp-2site/pe-tokyo/vinbero.yml
+++ b/examples/interop-clab/scenarios/sr-policy-bgp-2site/pe-tokyo/vinbero.yml
@@ -6,8 +6,6 @@ internal:
     - eth2
   bpf:
     device_mode: "generic"
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "0.0.0.0:8080"
   logger:

--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -44,6 +44,10 @@ var pinnedControlMaps = []string{
 
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -cflags $BPF_CFLAGS Bpf ../../src/xdp_prog.c -- -I ../../src -I /usr/include/x86_64-linux-gnu
 
+// maxVerifierLogSize caps internal.bpf.verifier_log_size. The default in
+// the config is close to 1 GiB, which would be allocated per program.
+const maxVerifierLogSize = 64 * 1024 * 1024
+
 func ReadCollection(constants map[string]any, cfg *config.Config) (*BpfObjects, error) {
 	// Remove memory limit for BPF
 	if err := rlimit.RemoveMemlock(); err != nil {
@@ -95,8 +99,24 @@ func ReadCollection(constants map[string]any, cfg *config.Config) (*BpfObjects, 
 		}
 	}
 
-	collOpts := &ebpf.CollectionOptions{
-		Programs: ebpf.ProgramOptions{LogSizeStart: 64 * 1024 * 1024, LogLevel: ebpf.LogLevelInstruction},
+	// No verifier log is requested by default. cilium/ebpf asks the kernel
+	// for one on its own when a program fails to verify, so the only thing
+	// an unconditional log buys is the cost of producing it: the verifier
+	// writes a line per instruction for every program in the collection, on
+	// every load. internal.bpf.verifier_log_level turns it back on when a
+	// load needs to be debugged.
+	collOpts := &ebpf.CollectionOptions{}
+	if cfg != nil && cfg.InternalConfig.BpfOptions.VerifierLogLevel > 0 {
+		logSize := cfg.InternalConfig.BpfOptions.VerifierLogSize
+		if logSize == 0 || logSize > maxVerifierLogSize {
+			// The buffer is per program and grows on demand, so a huge
+			// configured value only costs memory up front.
+			logSize = maxVerifierLogSize
+		}
+		collOpts.Programs = ebpf.ProgramOptions{
+			LogLevel:     ebpf.LogLevel(cfg.InternalConfig.BpfOptions.VerifierLogLevel),
+			LogSizeStart: logSize,
+		}
 	}
 	if cfg != nil && cfg.Setting.PinMaps.Enabled {
 		pinPath := cfg.Setting.PinMaps.Path

--- a/pkg/bpf/shared_collection_test.go
+++ b/pkg/bpf/shared_collection_test.go
@@ -1,0 +1,140 @@
+package bpf
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+// Loading the collection runs the verifier over every program in it, which
+// costs seconds, and the tests in this package did it well over a hundred
+// times -- the same programs, verified again and again. The loaded objects
+// only depend on the constants they were built with, so load one collection
+// per distinct set and give every test the map state it would have had from
+// a fresh load.
+//
+// The collections are never closed: they live as long as the test binary,
+// and the kernel reclaims them when it exits.
+var (
+	sharedCollMu sync.Mutex
+	sharedColls  = map[string]*BpfObjects{}
+)
+
+func sharedCollectionKey(constants map[string]any) string {
+	if len(constants) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(constants))
+	for name := range constants {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	key := ""
+	for _, name := range names {
+		key += fmt.Sprintf("%s=%v;", name, constants[name])
+	}
+	return key
+}
+
+// sharedCollection returns the collection for constants, loading it on first
+// use, with every map back in the state a fresh load would have left it.
+func sharedCollection(tb testing.TB, constants map[string]any) *BpfObjects {
+	tb.Helper()
+	sharedCollMu.Lock()
+	defer sharedCollMu.Unlock()
+
+	key := sharedCollectionKey(constants)
+	if objs, ok := sharedColls[key]; ok {
+		resetSharedCollection(tb, objs)
+		return objs
+	}
+	objs, err := ReadCollection(constants, nil)
+	if err != nil {
+		tb.Fatalf("Failed to load BPF objects: %v", err)
+	}
+	sharedColls[key] = objs
+	return objs
+}
+
+// resetSharedCollection empties every map a test could have written.
+// PROG_ARRAYs are left alone: they hold the tail-call targets that
+// ReadCollection populated, and clearing them would break dispatch.
+func resetSharedCollection(tb testing.TB, objs *BpfObjects) {
+	tb.Helper()
+	maps := reflect.ValueOf(objs.BpfMaps)
+	for i := range maps.NumField() {
+		m, ok := maps.Field(i).Interface().(*ebpf.Map)
+		if !ok || m == nil {
+			continue
+		}
+		if err := clearMap(m); err != nil {
+			tb.Fatalf("failed to reset map %s: %v", maps.Type().Field(i).Name, err)
+		}
+	}
+}
+
+func clearMap(m *ebpf.Map) error {
+	info, err := m.Info()
+	if err != nil {
+		return err
+	}
+	switch info.Type {
+	case ebpf.ProgramArray:
+		return nil
+	case ebpf.Array, ebpf.PerCPUArray:
+		return zeroArray(m, info)
+	default:
+		return deleteAllKeys(m, info)
+	}
+}
+
+// zeroArray writes a zero value back to every index. Array maps have no
+// delete, and their entries exist from the moment the map is created.
+func zeroArray(m *ebpf.Map, info *ebpf.MapInfo) error {
+	zero := make([]byte, info.ValueSize)
+	perCPU := info.Type == ebpf.PerCPUArray
+	var value any = zero
+	if perCPU {
+		cpus, err := ebpf.PossibleCPU()
+		if err != nil {
+			return err
+		}
+		values := make([][]byte, cpus)
+		for i := range values {
+			values[i] = make([]byte, info.ValueSize)
+		}
+		value = values
+	}
+	for i := uint32(0); i < info.MaxEntries; i++ {
+		if err := m.Put(i, value); err != nil {
+			return fmt.Errorf("index %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// deleteAllKeys drains a hash or LPM trie. Keys are collected first: the
+// iterator's behavior while the map is being modified is not defined.
+func deleteAllKeys(m *ebpf.Map, info *ebpf.MapInfo) error {
+	var keys [][]byte
+	key := make([]byte, info.KeySize)
+	value := make([]byte, info.ValueSize)
+	iter := m.Iterate()
+	for iter.Next(&key, &value) {
+		keys = append(keys, append([]byte(nil), key...))
+	}
+	if err := iter.Err(); err != nil {
+		return err
+	}
+	for _, k := range keys {
+		if err := m.Delete(k); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/bpf/xdp_test_helpers_test.go
+++ b/pkg/bpf/xdp_test_helpers_test.go
@@ -75,11 +75,7 @@ func newXDPTestHelperWithStats(tb testing.TB) *xdpTestHelper {
 
 func newXDPTestHelperWithConstants(tb testing.TB, constants map[string]any) *xdpTestHelper {
 	tb.Helper()
-	objs, err := ReadCollection(constants, nil)
-	if err != nil {
-		tb.Fatalf("Failed to load BPF objects: %v", err)
-	}
-	tb.Cleanup(func() { _ = objs.Close() })
+	objs := sharedCollection(tb, constants)
 	return &xdpTestHelper{
 		t:      tb,
 		objs:   objs,

--- a/pkg/config/internal.go
+++ b/pkg/config/internal.go
@@ -21,9 +21,16 @@ type LoggerConfig struct {
 }
 
 type BpfConfig struct {
-	DeviceMode       string `yaml:"device_mode,omitempty" default:"driver"`
-	VerifierLogLevel int    `yaml:"verifier_log_level,omitempty" default:"2"`
-	VerifierLogSize  uint32 `yaml:"verifier_log_size,omitempty" default:"1073741823"`
+	DeviceMode string `yaml:"device_mode,omitempty" default:"driver"`
+	// VerifierLogLevel asks the kernel for a verifier log on every program
+	// load: 1 for instructions, 2 for branches. Off by default because the
+	// log costs real time per load and cilium/ebpf already requests one on
+	// its own when a program fails to verify. Turn it on to debug a load.
+	VerifierLogLevel int `yaml:"verifier_log_level,omitempty" default:"0"`
+	// VerifierLogSize is the starting size of that log buffer, per program.
+	// It grows on demand, and is capped so a large value cannot commit
+	// hundreds of megabytes up front.
+	VerifierLogSize uint32 `yaml:"verifier_log_size,omitempty" default:"0"`
 }
 
 // ServerConfig holds the gRPC/Connect server configuration

--- a/vinbero.yml
+++ b/vinbero.yml
@@ -4,8 +4,6 @@ internal:
     - eth2
   bpf:
     device_mode: "driver"
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "0.0.0.0:8080"
   logger:


### PR DESCRIPTION
## 概要

`pkg/bpf` の full suite が 927 秒かかっていました。原因は 2 つで、どちらも同じ検証を何度も繰り返していたことです。修正後は **7 秒**になります。

| 対象 | 修正前 | 修正後 |
|---|---|---|
| `pkg/bpf` | 927 s | 7 s |
| `pkg/server` | 40 s | 1 s |

## 1. verifier ログを毎回要求していた

`ReadCollection` が collection load のたびに、60 本以上の全プログラムについて命令単位の verifier ログを要求し、プログラムごとに 64 MiB のバッファを確保していました。

```go
Programs: ebpf.ProgramOptions{LogSizeStart: 64 * 1024 * 1024, LogLevel: ebpf.LogLevelInstruction},
```

このログは検証に失敗したときにしか使いませんが、cilium/ebpf は失敗時に自分でログ付きの再試行をします。つまり誰も読まないテキストを毎回生成していただけで、1 回の load に約 4.5 秒かかっていました。

`internal.bpf.verifier_log_level` と `verifier_log_size` は config に存在しながら配線されていなかったので、今回配線しました。既定は off で、load をデバッグするときだけ有効にします。バッファサイズは上限を設けて、従来の既定値である 1 GiB がプログラムごとに確保されないようにしています。example と benchmark の config からはこの 2 行を削除しました。失敗時は放っておいてもログが出ます。

## 2. テストが collection を毎回ロードしていた

このパッケージの 136 個のテストがそれぞれ collection を組み立てていました。同じプログラムを 136 回 verifier に通し、毎回同じ結果を得ていたことになります。

ロード結果は build 時の constants にしか依存しないので、constants の組ごとに 1 つだけ保持し、各テストには fresh load 相当の map 状態を渡す形にしました。渡すときに全 map を空にします。ただし tail call の飛び先を持つ PROG_ARRAY は対象外です。

## 検証

- `go test ./pkg/...` 全パッケージ pass
- `-shuffle=on` を 3 回実行してすべて pass。順序依存は入っていません
- 実行されたテスト本数が修正前と一致することを確認しました (skip はゼロ)
- `make test-bpf-load` (kernel 6.12) pass
- netns example の end と end-dt4 を実行し、いずれも pass。end の hop limit assertion も通ります