### PR TITLE
test(examples): uT / uDT4 / uN+USD end-to-end scenarios and uSID docs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -149,6 +149,9 @@ jobs:
           - end-an
           - end-un
           - end-ua
+          - end-un-usd
+          - end-ut
+          - end-udt4
           - headend-v4
           - headend-v6
           - headend-l2

--- a/docs/design/ja/usid.md
+++ b/docs/design/ja/usid.md
@@ -1,15 +1,16 @@
-# uSID (NEXT-C-SID) の uN と uA
+# uSID (NEXT-C-SID) の uN / uA / uT
 
 ## 概要
 
 このドキュメントは RFC 9800 の NEXT-C-SID flavor による uSID のデータプレーンとコントロールプレーンの設計を説明します。uSID は 128 bit の IPv6 アドレス 1 つに複数の SID を詰め込む圧縮方式で、SRH を短縮または省略できるため encap の MTU オーバーヘッドが減ります。
 
-Vinbero が実装するのは uN と uA の 2 つです。uN は End の、uA は End.X の NEXT-C-SID 版です。SID 構造は F3216 に固定します。
+Vinbero が shift 系として実装するのは uN と uA と uT の 3 つです。uN は End の、uA は End.X の、uT は End.T の NEXT-C-SID 版です。SID 構造は F3216 に固定します。uDT4 のような terminal behavior は専用実装を持たず、既存の End.* を zero-padded /128 に登録する形で container の最終 uSID になります (後述)。
 
 | behavior | 対応する classic behavior | trigger prefix | 1 回の実行で消費する幅 | 転送先 |
 |---|---|---|---|---|
 | uN | End | /48 (block + node) | 16 bit (node) | shift 後の DA を FIB で解決 |
 | uA | End.X | /64 (block + node + function) | 32 bit (node + function) | 設定した adjacency |
+| uT | End.T | /48 (block + node) | 16 bit (node) | shift 後の DA を SID に bind した VRF table で解決 |
 
 ## SID 構造と用語
 
@@ -37,16 +38,16 @@ CSID 0x0000 は container の終端を示す予約値です。node CSID にも f
 
 ## dispatch 経路
 
-uN と uA は SRH の有無に関係なく動きます。shift 処理は SRH を読まないので、両方の入口から同じ core 関数へ入ります。
+uN / uA / uT は SRH の有無に関係なく動きます。shift 処理は SRH を読まないので、両方の入口から同じ core 関数へ入ります。
 
 - SRH ありのパケットは `process_srv6_localsid` が `sid_function_map` を引き、`DISPATCH_LOCALSID` として endpoint slot へ tail call します
-- SRH なしのパケットは `process_srv6_decap_nosrh` が入口です。この経路には従来、inner protocol が IPIP / IPv6 / Ethernet のときだけ decap するという gate がありました。uSID は任意の upper-layer protocol を運ぶため、lookup を先に行い、hit した entry が uN か uA なら gate を通す形に変えています。他の action の到達性は変わりません
+- SRH なしのパケットは `process_srv6_decap_nosrh` が入口です。この経路には従来、inner protocol が IPIP / IPv6 / Ethernet のときだけ decap するという gate がありました。uSID は任意の upper-layer protocol を運ぶため、lookup を先に行い、hit した entry が uN / uA / uT なら gate を通す形に変えています。他の action の到達性は変わりません
 
 `sid_function_map` は LPM trie なので、/48 や /64 の locator prefix エントリと、container 終端の /128 service SID エントリが同居できます。終端 DA では /128 が longest match で勝つため、uDT4 のような terminal behavior は従来の実装のまま動きます。
 
 どこで table を引き、その結果がどの分岐を決めるかを図にすると次のようになります。丸括弧付きの箱が BPF map です。
 
-tail call の飛び先は uN / uA 固定ではなく、hit した entry の action の slot です。SRH なし経路の 2 つの判定は、どの slot へ飛ぶかではなく、そもそも tail call するかどうかを決めています。uN / uA は upper-layer protocol を問わず通し、それ以外の action は従来どおり tunnel payload のときだけ通します。uN / uA 以外の slot に入ったパケットはこの図の対象外で、既存の behavior がそのまま処理します。
+tail call の飛び先は uN / uA / uT 固定ではなく、hit した entry の action の slot です。SRH なし経路の 2 つの判定は、どの slot へ飛ぶかではなく、そもそも tail call するかどうかを決めています。uN / uA / uT は upper-layer protocol を問わず通し、それ以外の action は従来どおり tunnel payload のときだけ通します。uN / uA / uT 以外の slot に入ったパケットはこの図の対象外で、既存の behavior がそのまま処理します。
 
 ```mermaid
 flowchart TD
@@ -56,7 +57,7 @@ flowchart TD
     L1 -->|miss| PASS0["XDP_PASS"]
     L2 -->|miss| PASS0
     L1 -->|hit| TC
-    L2 -->|hit| G{"action は uN / uA か"}
+    L2 -->|hit| G{"action は uN / uA / uT か"}
     G -->|yes| TC
     G -->|no| GATE{"inner proto が<br/>IPIP / IPv6 / Ethernet か"}
     GATE -->|yes| TC
@@ -116,7 +117,7 @@ container に自ノードの uSID が連続して並ぶことがあります。�
 
 - 同じ entry に再ヒットした場合は loop 内で続けて shift します。上限は 5 回で、F3216 の container が最大 6 uSID を持つことから導かれます
 - 別の local entry にヒットした場合は、その entry の action と aux で tailcall context を書き直し、対応する slot へ tail call します。別の uN でも、terminal behavior でも同じ扱いです。slot が空か context の書き込みに失敗した場合は fail-closed で drop します
-- ただし SRH の無いパケットには例外があります。ヒットした entry が uN でも uA でもなく、inner protocol が IPIP / IPv6 / Ethernet のいずれでもない場合は tail call せず kernel に渡します。多くの endpoint slot は IPv6 ヘッダの直後を無条件に SRH として parse するので、そこへ SRH の無いパケットを渡すと upper-layer ヘッダを Routing header として読んでしまうためです。これは no-SRH dispatcher が非 uN/uA の entry に課しているゲートと同じ条件です
+- ただし SRH の無いパケットには例外があります。ヒットした entry が uN / uA / uT のいずれでもなく、inner protocol が IPIP / IPv6 / Ethernet のいずれでもない場合は tail call せず kernel に渡します。多くの endpoint slot は IPv6 ヘッダの直後を無条件に SRH として parse するので、そこへ SRH の無いパケットを渡すと upper-layer ヘッダを Routing header として読んでしまうためです。これは no-SRH dispatcher が uN / uA / uT 以外の entry に課しているゲートと同じ条件です
 - 自ノードのどの SID でもない場合は転送します
 
 uA はこの loop を持ちません。uA は adjacency へ転送する behavior なので、RFC 9800 Sec.4.1.2 のとおり、同じ uA が container に 2 回現れるなら adjacency も 2 回通るのが正しい挙動です。
@@ -129,6 +130,7 @@ neighbor 未解決を表す `BPF_FIB_LKUP_RET_NO_NEIGH` だけは扱いが分か
 
 - uN は kernel に渡します。uN の FIB lookup のキーは shift 後の DA そのものなので、kernel は同じ転送判断をやり直します。classic End と同じ動作です。kernel に渡す直前に、この実行で減らした hop limit を 1 戻します。`ip6_forward` がもう一度減らすためで、戻さないと hop limit 2 のパケットが 1 論理 hop で Time Exceeded になります。結果として消費は論理 hop あたり 1 のままです
 - uA は drop します。uA は設定した adjacency へ転送する behavior で、kernel に渡すと DA 側の経路で転送されてしまいます。shift 後の DA に経路がない構成では ICMPv6 unreachable が返ります。uA の nexthop は neighbor が解決済みである必要があり、これは classic End.X と同じ制約です
+- uT も drop します。VRF に属さない interface に届いたパケットに対して、kernel は ingress interface の VRF 所属で経路を引くため、SID に bind した table での lookup を再現できません。uT の経路では NDP の事前解決が必要です。この規則は shift 経路だけでなく SRH 終端の fall-through にも共通で、`endpoint_fib_redirect_core` は fib ifindex が ingress と異なる lookup の未解決を kernel へ渡さず drop し、SL=0 の USD decap 後の inner lookup も bind した VRF table で行います (classic End.T も同じ経路を通るため、VRF 束縛時の挙動はこの形に統一されています)
 
 ### container がこのノードで終わる場合
 
@@ -136,9 +138,25 @@ Argument がゼロになったら classic behavior へ fall through します。
 
 この経路には 2 つの形があります。1 つは shift を 1 回も行わなかった場合で、DA は uN SID そのものです。もう 1 つは container が自ノードの uSID だけで構成されていた場合で、DA は shift されて uN SID まで縮んでいます。どちらも kernel が見る DA は自ノードの SID なので、書き換え済みのパケットを渡してよいのはここだけです。ただしこれは uN SID がノードのローカルアドレスとして設定されていることを前提にします。設定がないと kernel は locator prefix の経路でルーティングを試みます。
 
+例外が USD flavor です。SRH なしの container 終端で entry の flavor が USD、かつ inner が IPIP / IPv6 の tunnel payload なら、kernel に渡す代わりに outer IPv6 を剥がして inner パケットを FIB 転送します。H.Encaps.Red は単一 container のとき SRH を出さないため、SRH あり SL=0 を前提にした既存の USD 処理 (`endpoint_handle_usd`) はこの形を扱えず、ここが唯一の追加点です。decap ヘルパは tailcall 側 (`tailcall_endpoint.c`) にあるため、core は sentinel (`USID_RET_USD_NOSRH`) を返して判断だけを伝えます。uT では decap 後の FIB も VRF table になります。PSP と USP は pop すべき SRH が存在しないため、この経路では何もしません (SRH ありの終端では classic End への fall-through で 3 flavor とも従来どおり適用されます)。uA の USD は未対応です。End.X の USD は inner の FIB lookup でなく adjacency への転送であり、共有ヘルパでは意味が変わるためです。
+
+## uT
+
+uT (RFC 9800 Sec.4.1.3) は uN と同じ /48・同じ 16 bit shift・同じ loop で、shift 後の FIB lookup が SID に bind した VRF table で行われる点だけが違います。実装も `process_end_un_core` を `is_ut` リテラル付きで共有し、呼び出し側の tailcall body (`tailcall_endpoint_end_ut`、slot 28) が 1 を渡します。`__always_inline` の定数畳み込みで死んだ側の分岐は消えるため、uN の slot に End.T のコードは混入しません。
+
+aux に新しい variant は増やしていません。uT は nexthop を持たないので、usid variant の先頭 4 byte (uA なら nexthop の先頭) に VRF ifindex を書き、data plane は l3vrf view で読みます。uN は先頭が全ゼロなので `aux_vrf_or_ingress_ifindex` の ingress fallback と両立します。uA が nexthop variant と layout を揃えているのと同じ view aliasing です。
+
+Argument がゼロになったときの fall-through は `process_end_t` で、classic End.T として VRF table を引きます。
+
+RFC 9800 Sec.4.1.3 は shift 後の lookup を table T で行うと定めていますが、shift 後の DA が自ノードの local SID に一致した場合だけは、uN と同じく loop 内で直接消費または re-dispatch し、table T を引きません。これは意図した設計です。XDP は自分宛の FIB 転送で自プログラムに再入できないため、loop 内消費が動作する唯一の形であることに加え、宛先が自ノードの local SID なら送信者は uT を経由せず /128 に直接パケットを当てられるので、この短絡が VRF 分離の迂回になることはありません。
+
+## terminal uSID (uDT4 / uDT6 / uDT46 / uDX4 / uDX6)
+
+`sid_function_map` の lookup はすべて prefixlen 128 なので、zero-padded な終端 uSID に /128 で既存の End.DT4 などを登録すると、uN / uT の /48 より longest match で勝ちます。shift loop が自ノードの別 entry に着地した場合も、その entry の action の slot へ tail call で引き継ぐため、`[uN, 自ノードの uDT4]` のような container も 1 ノード内で完結します。専用 action・専用コードは不要で、`examples/end-udt4/` が Linux oracle との比較でこれを実証しています。なお Linux の seg6local は shift 後の DA を自ノードの local SID へ転送できない (FIB 経由の self-forward になる) ため、この 1 ノード内引き継ぎは Vinbero 側だけの検証です。
+
 ## マップとエントリ
 
-新しいマップは追加していません。uN と uA は既存の `sid_function_map` と `sid_aux_map` を使います。
+新しいマップは追加していません。uN / uA / uT は既存の `sid_function_map` と `sid_aux_map` を使います。
 
 aux は union で、uSID 用の variant を追加しました。
 
@@ -160,7 +178,7 @@ data plane が引く table に、誰が何を書くかは次のとおりです�
 
 ```mermaid
 flowchart LR
-    OP["operator (vbctl)"] --> RPC1["SidFunctionService<br/>SidFunctionCreate"]
+    OP["operator (vinbero CLI)"] --> RPC1["SidFunctionService<br/>SidFunctionCreate"]
     OP --> RPCD["SidFunctionService<br/>SidFunctionDelete"]
     OP --> RPC2["LocatorService<br/>LocatorCreate"]
 
@@ -201,7 +219,7 @@ BGP へ渡す SID Structure sub-sub-TLV は LBL/LNL/FL/AL = 32/16/16/0 です。
 
 ### SID function の登録
 
-uN と uA は `trigger_prefix` の明示指定のみを受け付けます。`locator_ref` からの登録には未対応です。
+uN / uA / uT は `trigger_prefix` の明示指定のみを受け付けます。`locator_ref` からの登録には未対応です。
 
 登録時の検査は次のとおりです。
 
@@ -217,10 +235,19 @@ uA は 16 bit の function CSID を消費するので、その prefix を含む 
 
 ```bash
 # uN
-vbctl sid create --trigger-prefix fd00:aaaa:b002::/48 --action END_UN
+vinbero sid create --trigger-prefix fd00:aaaa:b002::/48 --action END_UN
 
 # uA
-vbctl sid create --trigger-prefix fd00:aaaa:b002:a003::/64 --action END_UA --nexthop fc00:23::1
+vinbero sid create --trigger-prefix fd00:aaaa:b002:a003::/64 --action END_UA --nexthop fc00:23::1
+
+# uT (vrf_name は必須で、実在の VRF device であることを検証します)
+vinbero sid create --trigger-prefix fd00:aaaa:b002::/48 --action END_UT --vrf-name vrf100
+
+# terminal uDT4 (zero-padded /128、専用 action なし)
+vinbero sid create --trigger-prefix fd00:aaaa:b002:d004::/128 --action END_DT4 --vrf-name vrf100
+
+# uN + USD flavor
+vinbero sid create --trigger-prefix fd00:aaaa:b002::/48 --action END_UN --flavor USD
 ```
 
 `--usid-block-len` は SID 構造を明示する場合に使います。既定は 32 で、現状は 32 以外を受け付けません。
@@ -232,10 +259,10 @@ headend は変更していません。H.Encaps.Red は segment が 1 つのと�
 ## 運用上の制約
 
 - trigger prefix は uSID 専用にしてください。uN の /48 と uA の /64 は wildcard なので、その prefix に入るアドレスは SID 自身を除いてすべて container とみなされ、upper-layer protocol に関係なく shift されて転送されます。classic SRv6 でよくある、locator の中にノードの loopback も採番する構成にすると、そのアドレス宛の BGP や SSH が data path 側で書き換えられて到達しなくなります
-- uN と uA の SID 自身はノードのローカルアドレスとして設定してください
+- uN / uA / uT の SID 自身はノードのローカルアドレスとして設定してください
 - uA の nexthop は neighbor が解決済みである必要があります
 - flavor は単一値のみです。PSP と USP の組み合わせのような複数 flavor の同時指定は、既存の classic 実装と同じく未対応です
-- IPv6 拡張ヘッダを挟んだ NEXT-C-SID 処理は未対応です。dispatcher は IPv6 ヘッダの直後にある SRH しか認識しないので、Hop-by-Hop や Destination Options を挟んだパケットは SRH 無しの経路に入ります。uN と uA はそれを container として shift して転送し、Hop-by-Hop の option は処理しません。RFC 9800 は SRH と Hop-by-Hop と Destination Options をたどった後にも NEXT-C-SID を実行するよう求めているので、ここは仕様との差です
+- IPv6 拡張ヘッダを挟んだ NEXT-C-SID 処理は未対応です。dispatcher は IPv6 ヘッダの直後にある SRH しか認識しないので、Hop-by-Hop や Destination Options を挟んだパケットは SRH 無しの経路に入ります。uN / uA / uT はそれを container として shift して転送し、Hop-by-Hop の option は処理しません。RFC 9800 は SRH と Hop-by-Hop と Destination Options をたどった後にも NEXT-C-SID を実行するよう求めているので、ここは仕様との差です
 - shift 経路は SRH を検証しないので、壊れた routing header を持つパケットもそのまま中継します。RFC 9800 の疑似コードは Argument が非ゼロのとき SRH を見ないため、この点は仕様どおりです。変更前は kernel が受け取って落としていました
 - upper-layer checksum について、RFC 9800 Sec.6.5 は最終宛先を pseudo-header の DA として計算するよう定めています。これに従わず途中の container のアドレスで計算した送信元のパケットは、最終到達点で不一致になります。TCP と UDP に限らず ICMPv6 も同じです。実運用の uSID は H.Encaps 経由の encap トラフィックなので問題になりません
 
@@ -243,12 +270,15 @@ headend は変更していません。H.Encaps.Red は segment が 1 つのと�
 
 データプレーンの単体テストは `pkg/bpf/xdp_usid_test.go` です。`BPF_PROG_TEST_RUN` の環境では FIB が必ず失敗するため、戻り値だけでは正しい shift と guard による drop を区別できません。したがって出力パケットの DA と hop limit を直接 assert しています。
 
-E2E は netns example の 2 本で、どちらも Linux kernel の seg6local next-csid flavor を oracle にして 2 phase で確認します。
+E2E の netns example は 5 本です。end-un / end-ua / end-udt4 は Linux kernel の seg6local を oracle にした 2 phase、end-ut と end-un-usd は kernel に対応する native 実装がないため Vinbero 単独の検証です (uT: next-csid flavor は End / End.X のみ。USD: seg6local End は `flavors usd` を拒否します)。
 
 | example | 対象 | Linux 側の設定 | kernel 要件 |
 |---|---|---|---|
 | `examples/end-un/` | uN | `action End flavors next-csid lblen 32 nflen 16` | 6.1 以上 |
 | `examples/end-ua/` | uA | `action End.X flavors next-csid lblen 32 nflen 32` | 6.6 以上 |
+| `examples/end-udt4/` | terminal uDT4 | `action End.DT4 vrftable 100` (/128) + next-csid uN | 6.1 以上 |
+| `examples/end-ut/` | uT | oracle なし (main table blackhole で VRF lookup を証明) | VRF 対応 |
+| `examples/end-un-usd/` | uN + USD | oracle なし (到達自体が decap の証明) | - |
 
 Linux の seg6local で 1 回の実行が消費する幅は `nflen` です。`lblen` は shift せずに残す locator block の長さで、SID の prefix 長は `lblen + nflen` になります。uA は node と function を同時に消費するので、prefix が /64 になる `nflen 32` が正しく、`nflen 16` は function CSID を DA に残す uN の形になります。
 
@@ -261,4 +291,7 @@ end-ua の router2 は terminal SID への経路を持たないので、uA が�
 - REPLACE-C-SID と End.LBS と End.XLBS は実装していません
 - 32 bit uSID と F3216 以外の SID 構造には対応していません。shift の offset がコンパイル時定数なので、`usid_block_len` を緩めるだけでは足りず `src/endpoint/srv6_endpoint_usid.h` の定数も同時に変える必要があります
 - SR Policy の transport list を container へ自動 packing する処理はありません
-- `locator_ref` からの uN / uA 登録はできません
+- `locator_ref` からの uN / uA / uT 登録はできません
+- flavor は単一値のみで、PSP+USP のような組合せは classic と同じく未対応です
+- uA の USD は未対応です (End.X の USD は adjacency への転送で、DA ベースの decap 転送とは別実装が必要です)
+- SRH なし終端の USD は nexthdr が直接 IPIP / IPv6 の場合だけ decap します。Hop-by-Hop や Destination Options を挟むパケットは既存 dispatcher 全体の方針どおり extension header 非対応で、kernel への local delivery に fall through します (DA は自ノードの SID なので情報漏洩にはなりません)

--- a/docs/loadmap.md
+++ b/docs/loadmap.md
@@ -65,15 +65,18 @@
 
 | Function             | Status      | Description                                                 | Reference |
 |----------------------|-------------|-------------------------------------------------------------|-----------|
-| NEXT-CSID            | Partial     | uN (End) / uA (End.X), F3216 only, single flavor            | RFC 9800 |
+| NEXT-CSID            | Partial     | uN / uA / uT + terminal uDT*/uDX* via /128, F3216 only      | RFC 9800 |
 | REPLACE-CSID         |             | Compressed SID with replace-based encoding                  | RFC 9800 |
 | End.LBS              |             | Locator-Block Swap                                          | RFC 9800 |
 | End.XLBS             |             | L3 cross-connect and Locator-Block Swap                     | RFC 9800 |
 
-uN / uA の主な制約は次のとおりです。設計と運用上の注意は [uSID (NEXT-C-SID) の uN と uA](design/ja/usid.md) を参照してください。
+NEXT-C-SID の実装範囲は次のとおりです。設計と運用上の注意は [uSID (NEXT-C-SID)](design/ja/usid.md) を参照してください。
 
-- SID 構造は F3216 (block 32 bit、uSID 16 bit) のみで、flavor は単一値のみです。trigger prefix は uN が /48、uA が /64 です
-- trigger prefix は uSID 専用にしてください。prefix 内のアドレスは uN / uA SID 自身を除いてすべて container とみなされ、upper-layer protocol に関係なく shift されて転送されます
+- shift 系は uN (End)、uA (End.X)、uT (End.T、VRF table に bind) を実装しています。trigger prefix は uN / uT が /48、uA が /64 です
+- uDT4/uDT6/uDT46/uDX4/uDX6 のような terminal behavior は専用 action を持ちません。既存の End.* を zero-padded /128 に登録すると LPM で uN /48 に勝ち、container の最終 uSID として動きます (`examples/end-udt4/` で実証)
+- flavor は単一値のみです。SRH ありの container 終端では PSP/USP/USD が classic End への fall-through で適用され、SRH なし (H.Encaps.Red) の終端では USD の outer decap を実装しています (`examples/end-un-usd/`)。uA の USD は未対応です
+- SID 構造は F3216 (block 32 bit、uSID 16 bit) のみです
+- trigger prefix は uSID 専用にしてください。prefix 内のアドレスは uN / uA / uT SID 自身を除いてすべて container とみなされ、upper-layer protocol に関係なく shift されて転送されます
 - 登録は trigger prefix の明示指定のみで、locator_ref からの登録には未対応です
 - BGP からの uSID service SID の送受信と、第三者実装との interop は未着手です
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -73,6 +73,9 @@ sudo ./teardown.sh # クリーンアップ
 | `end-dx2v/` | End.DX2V | VLAN単位のL2クロスコネクト |
 | `end-un/` | uN | NEXT-C-SID の shift 転送 (RFC 9800、F3216) |
 | `end-ua/` | uA | NEXT-C-SID の shift + adjacency 転送 (RFC 9800、F3216) |
+| `end-ut/` | uT | NEXT-C-SID の shift + VRF table 転送 (RFC 9800、F3216) |
+| `end-udt4/` | uDT4 | container 最終 uSID の End.DT4 (zero-padded /128 の LPM 優先) |
+| `end-un-usd/` | uN + USD | SRH なし container 終端での outer decap |
 
 ### Headend Functions
 | ディレクトリ | 機能 | 説明 |

--- a/examples/end-udt4/README.ja.md
+++ b/examples/end-udt4/README.ja.md
@@ -1,0 +1,63 @@
+# end-udt4 — uDT4 (container 最終 uSID の End.DT4)
+
+*(English: [README.md](./README.md))*
+
+NEXT-C-SID container (RFC 9800、F3216) の最終 uSID として置いた End.DT4
+を検証します。Vinbero に uDT4 専用の action はありません。zero-padded な
+/128 (fd00:aaaa:b003:d004::) に既存の END_DT4 を登録すると、同一ノードの
+uN /48 に longest-prefix match で勝ちます。この example はその性質の
+end-to-end の実証で、まず Linux kernel を oracle として、次に Vinbero XDP
+で確認します。
+
+設計は [`docs/design/ja/usid.md`](../../docs/design/ja/usid.md) を参照して
+ください。
+
+## トポロジ
+
+```mermaid
+graph LR
+    host1 --- router1
+    router1 --- router2
+    router2 --- router3
+    router3 --- host2
+    router3 -.vrf100.- host2
+```
+
+- router1 は Linux seg6 encap で forward container を付与し、返り方向を
+  fc00:1::1 (End.DX4) で終端します
+- router2 は素の IPv6 転送です
+- router3 が uN /48 (fd00:aaaa:b003::/48) と uDT4 /128
+  (fd00:aaaa:b003:d004::、vrf100 への End.DT4) の両方を持ちます。Phase 1
+  は Linux seg6local、phase 2 は Vinbero が同じ SID を担当します
+
+## 必要条件
+
+- Linux kernel 6.1 以上 (seg6local next-csid flavor、VRF)
+- iproute2 6.0 以上
+
+## 使い方
+
+```bash
+sudo ./setup.sh
+sudo ./test.sh
+sudo ./teardown.sh
+```
+
+## 検証内容
+
+1. Linux oracle: /48 と /128 を両方入れた状態で container
+   fd00:aaaa:b003:d004:: が vrf100 に届きます。zero-padded /128 が uN /48
+   に longest-prefix match で勝つことの確認です
+2. Vinbero: native route を削除し、API で END_UN (/48) と END_DT4
+   (/128、vrf100) を登録して同じ container が届くことを確認します
+3. Vinbero のみ: 2 uSID の container fd00:aaaa:b003:b003:d004:: を使い
+   ます。uN が 1 回 shift すると、shift 後の DA が同一ノードの uDT4 /128
+   に着地します。Vinbero は XDP loop 内でこの引き継ぎを re-dispatch しま
+   すが、Linux seg6local は shift 後の DA を自ノードの local SID へ転送
+   できないため、oracle phase ではこの container を使いません
+
+## 補足
+
+uDT6 と uDT46 は inner の address family が違うだけ、uDX4/uDX6 は VRF
+table の代わりに設定済み nexthop を使うだけで、いずれもこの END_DT4 と
+同じく既存の End.* behavior を zero-padded /128 に登録する形で動きます。

--- a/examples/end-udt4/README.md
+++ b/examples/end-udt4/README.md
@@ -1,0 +1,64 @@
+# end-udt4 — uDT4 (End.DT4 as the last uSID)
+
+*(日本語: [README.ja.md](./README.ja.md))*
+
+Exercises uDT4: End.DT4 placed as the last uSID of a NEXT-C-SID container
+(RFC 9800, F3216). There is no dedicated uDT4 action in Vinbero -- the
+existing END_DT4 registered at the zero-padded /128
+(fd00:aaaa:b003:d004::) wins the LPM over the uN /48 on the same node.
+This example is the end-to-end proof of that property, first against the
+Linux kernel oracle and then with Vinbero XDP.
+
+See [`docs/design/ja/usid.md`](../../docs/design/ja/usid.md) for the design.
+
+## Topology
+
+```mermaid
+graph LR
+    host1 --- router1
+    router1 --- router2
+    router2 --- router3
+    router3 --- host2
+    router3 -.vrf100.- host2
+```
+
+- router1 pushes the forward container with Linux seg6 encap, and
+  terminates the return direction on fc00:1::1 (End.DX4)
+- router2 is plain IPv6 transit
+- router3 holds both the uN /48 (fd00:aaaa:b003::/48) and the uDT4 /128
+  (fd00:aaaa:b003:d004::, End.DT4 into vrf100). Phase 1 serves both from
+  Linux seg6local, phase 2 from Vinbero
+
+## Requirements
+
+- Linux kernel 6.1 or later (seg6local next-csid flavor, VRF)
+- iproute2 6.0 or later
+
+## Usage
+
+```bash
+sudo ./setup.sh
+sudo ./test.sh
+sudo ./teardown.sh
+```
+
+## What is verified
+
+1. Linux oracle: with both the /48 and the /128 installed, the container
+   fd00:aaaa:b003:d004:: is delivered into vrf100 -- the zero-padded /128
+   wins the longest-prefix match over the uN /48
+2. Vinbero: the native routes are removed, END_UN (/48) and END_DT4
+   (/128, vrf100) are registered through the API, and the same container
+   is delivered again
+3. Vinbero only: the two-uSID container fd00:aaaa:b003:b003:d004::. The
+   uN shifts once and the shifted DA lands on this node's own uDT4 /128.
+   Vinbero re-dispatches that hand-off inside the XDP loop; Linux
+   seg6local cannot forward a shifted DA back into its own local SID, so
+   the oracle phase never sees this container
+
+## Notes
+
+uDT6 and uDT46 differ from this example only in the inner address family,
+and uDX4/uDX6 only in using a configured nexthop instead of a VRF table:
+all of them are the existing End.* behaviors registered at a zero-padded
+/128, exactly like the END_DT4 here.

--- a/examples/end-udt4/setup.sh
+++ b/examples/end-udt4/setup.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# examples/end-udt4/setup.sh
+# Setup uDT4 (End.DT4 as the last uSID of a NEXT-C-SID container) environment
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Note: Linux interface names are limited to 15 chars, so use short prefix
+export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-udt4-}"
+
+source "${SCRIPT_DIR}/../common/topologies/three_router.sh"
+
+ns_router1="${TOPO_NS_PREFIX}router1"
+ns_router2="${TOPO_NS_PREFIX}router2"
+ns_router3="${TOPO_NS_PREFIX}router3"
+veth_rt1_h1="${TOPO_NS_PREFIX}rt1h1"
+veth_rt1_rt2="${TOPO_NS_PREFIX}rt1rt2"
+veth_rt2_rt1="${TOPO_NS_PREFIX}rt2rt1"
+veth_rt2_rt3="${TOPO_NS_PREFIX}rt2rt3"
+veth_rt3_h2="${TOPO_NS_PREFIX}rt3h2"
+veth_rt3_rt2="${TOPO_NS_PREFIX}rt3rt2"
+
+# Setup base topology
+setup_three_router_topology
+
+# uSID plan (F3216: 32-bit block fd00:aaaa, 16-bit uSIDs):
+#   r3 node b003: uN    fd00:aaaa:b003::/48
+#                 uDT4  fd00:aaaa:b003:d004::/128 (vrf100, zero-padded)
+# Forward container: fd00:aaaa:b003:d004::
+#   With both routes installed, the zero-padded /128 must win the LPM over
+#   the uN /48 and decap into vrf100 -- the property this example proves.
+#   test.sh phase 2 additionally switches the headend to the two-uSID
+#   container fd00:aaaa:b003:b003:d004:: (shift at r3, then its own uDT4):
+#   Vinbero consumes that hand-off inside the XDP loop, while Linux
+#   seg6local cannot forward a shifted DA back into its own local SID, so
+#   the oracle phase never sees that container.
+print_info "Configuring uDT4 (NEXT-C-SID terminal) settings..."
+
+# router1: headend towards host2 + terminal End.DX4 for the return direction
+ns_sysctl "$ns_router1" net.ipv6.conf.${veth_rt1_h1}.seg6_enabled 1
+ns_sysctl "$ns_router1" net.ipv6.conf.${veth_rt1_rt2}.seg6_enabled 1
+ns_sysctl "$ns_router1" net.ipv4.conf.${veth_rt1_rt2}.rp_filter 0
+ns_sysctl "$ns_router1" net.ipv4.conf.${veth_rt1_h1}.rp_filter 0
+
+run ip netns exec "$ns_router1" ip route add 172.0.2.0/24 encap seg6 mode encap segs fd00:aaaa:b003:d004:: dev "$veth_rt1_rt2"
+run ip netns exec "$ns_router1" ip -6 route add fd00:aaaa:b003::/48 via fc00:12::2 dev "$veth_rt1_rt2"
+run ip netns exec "$ns_router1" ip -6 route del local fc00:1::1 2>/dev/null || true
+run ip netns exec "$ns_router1" ip -6 route add local fc00:1::1/128 encap seg6local action End.DX4 nh4 172.0.1.1 dev "$veth_rt1_h1"
+
+# router2: plain IPv6 transit towards the uSID block
+run ip netns exec "$ns_router2" ip -6 route add fd00:aaaa:b003::/48 via fc00:23::1 dev "$veth_rt2_rt3"
+
+# router3: uN + uDT4 (vrf100). Phase 1 of test.sh uses the Linux-native
+# routes below as the oracle; phase 2 removes them and reinstalls the same
+# SIDs via Vinbero.
+ns_sysctl "$ns_router3" net.ipv6.conf.${veth_rt3_h2}.seg6_enabled 1
+ns_sysctl "$ns_router3" net.ipv6.conf.${veth_rt3_rt2}.seg6_enabled 1
+ns_sysctl "$ns_router3" net.ipv4.conf.all.rp_filter 0
+ns_sysctl "$ns_router3" net.ipv4.conf.default.rp_filter 0
+ns_sysctl "$ns_router3" net.ipv4.conf.${veth_rt3_rt2}.rp_filter 0
+ns_sysctl "$ns_router3" net.ipv4.conf.${veth_rt3_h2}.rp_filter 0
+
+# VRF for the uDT4 target table
+run ip netns exec "$ns_router3" ip link add vrf100 type vrf table 100
+run ip netns exec "$ns_router3" ip link set vrf100 up
+ip netns exec "$ns_router3" ip rule add l3mdev protocol kernel prio 1000 2>/dev/null || true
+ns_sysctl "$ns_router3" net.vrf.strict_mode 1
+run ip netns exec "$ns_router3" ip link set "$veth_rt3_h2" master vrf100
+
+# The bare uN SID is a local address on the node: a container that ends on
+# the plain uN (not the uDT4) is handed up for local delivery.
+run ip netns exec "$ns_router3" ip -6 addr add fd00:aaaa:b003::/128 dev lo nodad
+
+# Return path: host2 -> host1 (in table 100, since rt3h2 is enslaved)
+run ip netns exec "$ns_router3" ip route add 172.0.1.0/24 encap seg6 mode encap segs fc00:1::1 dev "$veth_rt3_rt2" table 100
+
+# Linux-native oracle: uN (next-csid) + End.DT4 at the zero-padded /128
+run ip netns exec "$ns_router3" ip -6 route add local fd00:aaaa:b003::/48 encap seg6local action End flavors next-csid lblen 32 nflen 16 dev "$veth_rt3_rt2"
+run ip netns exec "$ns_router3" ip -6 route add local fd00:aaaa:b003:d004::/128 encap seg6local action End.DT4 vrftable 100 dev lo
+
+# Pre-resolve NDP/ARP (bpf_fib_lookup needs resolved neighbours)
+print_info "Pre-resolving NDP/ARP..."
+ip netns exec "$ns_router1" ping6 -c 1 -W 2 fc00:12::2 > /dev/null 2>&1 || true
+ip netns exec "$ns_router2" ping6 -c 1 -W 2 fc00:23::1 > /dev/null 2>&1 || true
+ip netns exec "$ns_router3" ping6 -c 1 -W 2 fc00:23::2 > /dev/null 2>&1 || true
+ip netns exec "$ns_router3" ip vrf exec vrf100 ping -c 1 -W 2 172.0.2.1 > /dev/null 2>&1 || true
+
+echo ""
+echo "=========================================="
+echo "SRv6 uDT4 (NEXT-C-SID terminal) Setup Complete!"
+echo "=========================================="
+echo "uSID plan (block fd00:aaaa/32, 16-bit uSIDs):"
+echo "  r3: uN    fd00:aaaa:b003::/48"
+echo "  r3: uDT4  fd00:aaaa:b003:d004::/128 (End.DT4, vrf100)"
+echo "Forward container: fd00:aaaa:b003:d004:: (direct uDT4; test.sh phase 2"
+echo "  also exercises fd00:aaaa:b003:b003:d004:: -- shift, then own uDT4)"
+echo "Return path: fc00:1::1 (End.DX4 on r1)"
+echo ""
+print_success "Ready for testing!"

--- a/examples/end-udt4/teardown.sh
+++ b/examples/end-udt4/teardown.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# examples/end-udt4/teardown.sh
+# Teardown uDT4 (NEXT-C-SID terminal) demonstration environment
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-udt4-}"
+
+source "${SCRIPT_DIR}/../common/topologies/three_router.sh"
+
+echo "=========================================="
+echo "Tearing down SRv6 uDT4 environment"
+echo "=========================================="
+
+# vinberod is started and stopped within test.sh (its EXIT trap fires even
+# on an aborted run), so teardown only removes the namespaces.
+teardown_three_router_topology
+
+echo ""
+echo "=========================================="
+print_success "Cleanup complete!"
+echo "=========================================="

--- a/examples/end-udt4/test.sh
+++ b/examples/end-udt4/test.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# examples/end-udt4/test.sh
+# Test uDT4 (End.DT4 as the last uSID) against the Linux seg6local oracle
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../common/test_utils.sh"
+
+check_root
+
+VINBEROD_BIN="${SCRIPT_DIR}/../../out/bin/vinberod"
+VINBERO_BIN="${SCRIPT_DIR}/../../out/bin/vinbero"
+VINBERO_CONFIG="${SCRIPT_DIR}/vinbero_router3.yaml"
+
+export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-udt4-}"
+ns_host1="${TOPO_NS_PREFIX}host1"
+ns_host2="${TOPO_NS_PREFIX}host2"
+ns_router1="${TOPO_NS_PREFIX}router1"
+ns_router3="${TOPO_NS_PREFIX}router3"
+veth_rt1_rt2="${TOPO_NS_PREFIX}rt1rt2"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+VINBERO_PID=""
+
+cleanup() {
+    # Guard against PID reuse: only kill if the PID is still our vinberod.
+    if [ -n "$VINBERO_PID" ] && [ "$(ps -o comm= -p "$VINBERO_PID" 2>/dev/null)" = "vinberod" ]; then
+        kill "$VINBERO_PID" 2>/dev/null || true
+        wait "$VINBERO_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+echo "=========================================="
+echo "SRv6 uDT4 (NEXT-C-SID terminal) Test"
+echo "=========================================="
+echo ""
+
+# Phase 1: Linux seg6local (next-csid uN + End.DT4 /128) as the oracle.
+# Both routes are installed, so a delivered ping proves the zero-padded
+# /128 wins the LPM over the uN /48.
+echo "=========================================="
+echo "Phase 1: Linux Native uN + End.DT4"
+echo "=========================================="
+
+print_info "Linux native routes are already installed on $ns_router3 (from setup.sh)"
+
+test_ping_with_counter "$ns_host1" 172.0.2.1 "host1 -> host2 (Linux native /128 over /48)"
+test_ping_with_counter "$ns_host2" 172.0.1.1 "host2 -> host1 (return, native)"
+
+print_info "Removing Linux native routes from $ns_router3..."
+# Both oracle routes must actually go away, or phase 2 passes vacuously.
+ip netns exec "$ns_router3" ip -6 route del local fd00:aaaa:b003::/48
+ip netns exec "$ns_router3" ip -6 route del local fd00:aaaa:b003:d004::/128
+
+echo ""
+
+# Phase 2: the same SIDs served by Vinbero XDP. The uDT4 needs no dedicated
+# action: it is the existing END_DT4 registered at the zero-padded /128,
+# which wins the LPM over the uN /48 -- that is the property under test.
+echo "=========================================="
+echo "Phase 2: Vinbero XDP uN + END_DT4 /128"
+echo "=========================================="
+
+print_info "Starting Vinbero on $ns_router3..."
+start_vinbero "$ns_router3" "${VINBERO_CONFIG}" "/tmp/vinbero_end_udt4_test.log"
+VINBERO_PID=$VINBERO_LAST_PID
+wait_vinbero_ready "$ns_router3" "127.0.0.1:8092" 10
+
+print_info "Registering the uN /48 and the uDT4 /128..."
+ip netns exec "$ns_router3" ${VINBERO_BIN} -s http://127.0.0.1:8092 \
+  sid create --trigger-prefix fd00:aaaa:b003::/48 --action END_UN
+ip netns exec "$ns_router3" ${VINBERO_BIN} -s http://127.0.0.1:8092 \
+  sid create --trigger-prefix fd00:aaaa:b003:d004::/128 --action END_DT4 --vrf-name vrf100
+print_success "SID functions registered"
+
+sleep 1
+
+# Pre-resolve NDP/ARP (bpf_fib_lookup needs resolved neighbours)
+print_info "Pre-resolving NDP/ARP..."
+ip netns exec "$ns_router3" ping6 -c 1 -W 1 fc00:23::2 > /dev/null 2>&1 || true
+ip netns exec "$ns_router3" ip vrf exec vrf100 ping -c 1 -W 1 172.0.2.1 > /dev/null 2>&1 || true
+
+test_ping_with_counter "$ns_host1" 172.0.2.1 "host1 -> host2 (Vinbero /128 over /48)"
+test_ping_with_counter "$ns_host2" 172.0.1.1 "host2 -> host1 (return, native)"
+
+# The two-uSID container [b003, b003:d004]: the uN shifts once and the
+# shifted DA lands on this node's own uDT4 /128. Vinbero re-dispatches that
+# inside the XDP loop; Linux seg6local cannot forward a shifted DA back
+# into its own local SID, which is why this container only appears in the
+# Vinbero phase.
+print_info "Switching the headend to the two-uSID container (shift, then own uDT4)..."
+ip netns exec "$ns_router1" ip route replace 172.0.2.0/24 encap seg6 mode encap segs fd00:aaaa:b003:b003:d004:: dev "$veth_rt1_rt2"
+
+test_ping_with_counter "$ns_host1" 172.0.2.1 "host1 -> host2 (Vinbero uN shift -> own uDT4)"
+
+print_info "Stopping Vinbero..."
+kill $VINBERO_PID 2>/dev/null || true
+wait $VINBERO_PID 2>/dev/null || true
+
+echo ""
+echo "=========================================="
+echo "Test Summary"
+echo "=========================================="
+echo "Passed: $TESTS_PASSED"
+echo "Failed: $TESTS_FAILED"
+echo ""
+
+if [ $TESTS_FAILED -gt 0 ]; then
+    print_error "Some tests failed"
+    exit 1
+else
+    print_success "All tests passed!"
+    exit 0
+fi

--- a/examples/end-udt4/vinbero_router3.yaml
+++ b/examples/end-udt4/vinbero_router3.yaml
@@ -1,0 +1,24 @@
+internal:
+  devices:
+    - udt4-rt3rt2  # Interface towards router2 (with "udt4-" prefix)
+    - udt4-rt3h2   # Interface towards host2 (in vrf100)
+  bpf:
+    device_mode: generic  # Required for veth pairs
+    verifier_log_level: 2
+    verifier_log_size: 1073741823
+  server:
+    bind: "127.0.0.1:8092"
+  logger:
+    level: debug
+    format: text
+    no_color: false
+    add_caller: true
+
+settings:
+  entries:
+    sid_function:
+      capacity: 1024
+    headendv4:
+      capacity: 1024
+    headendv6:
+      capacity: 1024

--- a/examples/end-un-usd/README.ja.md
+++ b/examples/end-un-usd/README.ja.md
@@ -1,0 +1,57 @@
+# end-un-usd — uN + USD (SRH なし decap)
+
+*(English: [README.md](./README.md))*
+
+SRH なし container の終端における uN (RFC 9800、F3216) の USD flavor を
+検証します。H.Encaps.Red は単一 container のとき SRH を出さないため、
+従来の USD 処理 (SRH あり、SL=0) は適用されません。そのパケットの DA が
+bare uN SID で、エントリが USD flavor を持つとき、Vinbero は外側 IPv6 を
+剥がして inner パケットを転送します。
+
+Linux oracle phase はありません。kernel の seg6local End は "flavors
+usd" を受け付けない (実装済みは PSP と NEXT-C-SID のみ) ためです。到達
+すること自体が証明になります。USD がなければ encap されたままのパケット
+が kernel に渡され、宛先には届きません。
+
+設計は [`docs/design/ja/usid.md`](../../docs/design/ja/usid.md) を参照して
+ください。
+
+## トポロジ
+
+```mermaid
+graph LR
+    host1 --- router1
+    router1 --- router2
+    router2 --- router3
+    router3 --- host2
+```
+
+- router1 は H.Encaps.Red で単一 uSID の container fd00:aaaa:b003:: を
+  付与し (bare uN SID、SRH なし、IPIP payload)、返り方向を fc00:1::1
+  (End.DX4) で終端します
+- router2 は素の IPv6 転送です
+- router3 が USD flavor 付きの uN です (Vinbero、fd00:aaaa:b003::/48)。
+  外側 IPv6 を剥がして inner IPv4 を host2 へ転送します
+
+## 必要条件
+
+- iproute2 6.0 以上 (encap.red)
+
+## 使い方
+
+```bash
+sudo ./setup.sh
+sudo ./test.sh
+sudo ./teardown.sh
+```
+
+## 検証内容
+
+1. bare SID かつ SRH なしのパケットが router3 で decap され、inner IPv4
+   が host2 に届きます
+2. 返り方向が native の baseline として動きます
+
+PSP と USP には SRH なしの対応物がありません。pop すべき SRH が存在しな
+いためです。したがってこの経路で専用処理を持つ flavor は USD だけです。
+SRH がある場合は 3 つの flavor すべてが従来の End への fall-through で
+適用されます (`examples/end-un/` を参照)。

--- a/examples/end-un-usd/README.md
+++ b/examples/end-un-usd/README.md
@@ -1,0 +1,57 @@
+# end-un-usd — uN + USD (no-SRH decap)
+
+*(日本語: [README.ja.md](./README.ja.md))*
+
+Exercises the USD flavor on a uN (RFC 9800, F3216) at the end of a no-SRH
+container. H.Encaps.Red with a single container emits no SRH, so the
+classic USD handling (SRH present, SL=0) never applies; when such a
+packet's DA is the bare uN SID and the entry carries the USD flavor,
+Vinbero strips the outer IPv6 and forwards the inner packet.
+
+There is no Linux oracle phase: the kernel's seg6local End rejects
+"flavors usd" (only PSP and NEXT-C-SID are implemented), so there is
+nothing native to compare against. Delivery itself is the proof: without
+USD the still-encapsulated packet is handed to the kernel and never
+reaches the destination.
+
+See [`docs/design/ja/usid.md`](../../docs/design/ja/usid.md) for the design.
+
+## Topology
+
+```mermaid
+graph LR
+    host1 --- router1
+    router1 --- router2
+    router2 --- router3
+    router3 --- host2
+```
+
+- router1 pushes the single-uSID container fd00:aaaa:b003:: with
+  H.Encaps.Red (bare uN SID, no SRH, IPIP payload), and terminates the
+  return direction on fc00:1::1 (End.DX4)
+- router2 is plain IPv6 transit
+- router3 is the uN with the USD flavor (Vinbero, fd00:aaaa:b003::/48):
+  the outer IPv6 is stripped and the inner IPv4 is forwarded to host2
+
+## Requirements
+
+- iproute2 6.0 or later (encap.red)
+
+## Usage
+
+```bash
+sudo ./setup.sh
+sudo ./test.sh
+sudo ./teardown.sh
+```
+
+## What is verified
+
+1. The bare-SID, no-SRH packet is decapped at router3 and the inner IPv4
+   reaches host2
+2. The return direction works as a native baseline
+
+PSP and USP have no no-SRH counterpart -- there is no SRH to pop -- so USD
+is the only flavor with dedicated handling on this path. With an SRH
+present, all three flavors already apply through the classic End
+fall-through (see `examples/end-un/`).

--- a/examples/end-un-usd/setup.sh
+++ b/examples/end-un-usd/setup.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# examples/end-un-usd/setup.sh
+# Setup uN + USD (decap at the end of a no-SRH uSID container) environment
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Note: Linux interface names are limited to 15 chars, so use short prefix
+export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-unusd-}"
+
+source "${SCRIPT_DIR}/../common/topologies/three_router.sh"
+
+ns_router1="${TOPO_NS_PREFIX}router1"
+ns_router2="${TOPO_NS_PREFIX}router2"
+ns_router3="${TOPO_NS_PREFIX}router3"
+veth_rt1_h1="${TOPO_NS_PREFIX}rt1h1"
+veth_rt1_rt2="${TOPO_NS_PREFIX}rt1rt2"
+veth_rt2_rt1="${TOPO_NS_PREFIX}rt2rt1"
+veth_rt2_rt3="${TOPO_NS_PREFIX}rt2rt3"
+veth_rt3_h2="${TOPO_NS_PREFIX}rt3h2"
+veth_rt3_rt2="${TOPO_NS_PREFIX}rt3rt2"
+
+# Setup base topology
+setup_three_router_topology
+
+# uSID plan (F3216: 32-bit block fd00:aaaa, 16-bit uSIDs):
+#   r3 node b003: uN fd00:aaaa:b003::/48 with the USD flavor
+# Forward path: r1 sends H.Encaps.Red with the single-uSID container
+# fd00:aaaa:b003:: -- a bare uN SID and no SRH on the wire. At r3 the
+# Argument is already zero, so this is the container's end; USD strips the
+# outer IPv6 and forwards the inner IPv4 to host2 over the connected
+# route. Without USD the packet would be handed to the kernel still
+# encapsulated and go nowhere.
+#
+# There is no Linux oracle phase: the kernel's seg6local End rejects
+# "flavors usd" (only PSP and NEXT-C-SID are implemented), so there is
+# nothing native to compare against.
+print_info "Configuring uN + USD settings..."
+
+# router1: headend towards host2 (H.Encaps.Red) + return terminal End.DX4
+ns_sysctl "$ns_router1" net.ipv6.conf.${veth_rt1_h1}.seg6_enabled 1
+ns_sysctl "$ns_router1" net.ipv6.conf.${veth_rt1_rt2}.seg6_enabled 1
+ns_sysctl "$ns_router1" net.ipv4.conf.${veth_rt1_rt2}.rp_filter 0
+ns_sysctl "$ns_router1" net.ipv4.conf.${veth_rt1_h1}.rp_filter 0
+
+run ip netns exec "$ns_router1" ip route add 172.0.2.0/24 encap seg6 mode encap.red segs fd00:aaaa:b003:: dev "$veth_rt1_rt2"
+run ip netns exec "$ns_router1" ip -6 route add fd00:aaaa:b003::/48 via fc00:12::2 dev "$veth_rt1_rt2"
+run ip netns exec "$ns_router1" ip -6 route del local fc00:1::1 2>/dev/null || true
+run ip netns exec "$ns_router1" ip -6 route add local fc00:1::1/128 encap seg6local action End.DX4 nh4 172.0.1.1 dev "$veth_rt1_h1"
+
+# router2: plain IPv6 transit towards the uSID block
+run ip netns exec "$ns_router2" ip -6 route add fd00:aaaa:b003::/48 via fc00:23::1 dev "$veth_rt2_rt3"
+
+# router3: uN + USD under Vinbero (registered in test.sh) + return headend
+ns_sysctl "$ns_router3" net.ipv6.conf.${veth_rt3_h2}.seg6_enabled 1
+ns_sysctl "$ns_router3" net.ipv6.conf.${veth_rt3_rt2}.seg6_enabled 1
+ns_sysctl "$ns_router3" net.ipv4.conf.${veth_rt3_rt2}.rp_filter 0
+ns_sysctl "$ns_router3" net.ipv4.conf.${veth_rt3_h2}.rp_filter 0
+
+# The bare uN SID is a local address on the node, as an operator would
+# configure it; USD intercepts the tunnelled packets before delivery.
+run ip netns exec "$ns_router3" ip -6 addr add fd00:aaaa:b003::/128 dev lo nodad
+
+run ip netns exec "$ns_router3" ip route add 172.0.1.0/24 encap seg6 mode encap segs fc00:1::1 dev "$veth_rt3_rt2"
+
+# Pre-resolve NDP/ARP (bpf_fib_lookup needs resolved neighbours; the
+# post-decap IPv4 hop towards host2 needs ARP)
+print_info "Pre-resolving NDP/ARP..."
+ip netns exec "$ns_router1" ping6 -c 1 -W 2 fc00:12::2 > /dev/null 2>&1 || true
+ip netns exec "$ns_router2" ping6 -c 1 -W 2 fc00:23::1 > /dev/null 2>&1 || true
+ip netns exec "$ns_router3" ping6 -c 1 -W 2 fc00:23::2 > /dev/null 2>&1 || true
+ip netns exec "$ns_router3" ping -c 1 -W 2 172.0.2.1 > /dev/null 2>&1 || true
+
+echo ""
+echo "=========================================="
+echo "SRv6 uN + USD Setup Complete!"
+echo "=========================================="
+echo "uSID plan (block fd00:aaaa/32, 16-bit uSIDs):"
+echo "  r3: uN fd00:aaaa:b003::/48, flavor USD"
+echo "Forward (H.Encaps.Red, no SRH): container fd00:aaaa:b003:: -> USD decap at r3"
+echo "Return path: fc00:1::1 (End.DX4 on r1)"
+echo ""
+print_success "Ready for testing!"

--- a/examples/end-un-usd/teardown.sh
+++ b/examples/end-un-usd/teardown.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# examples/end-un-usd/teardown.sh
+# Teardown uN + USD demonstration environment
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-unusd-}"
+
+source "${SCRIPT_DIR}/../common/topologies/three_router.sh"
+
+echo "=========================================="
+echo "Tearing down SRv6 uN + USD environment"
+echo "=========================================="
+
+# vinberod is started and stopped within test.sh (its EXIT trap fires even
+# on an aborted run), so teardown only removes the namespaces.
+teardown_three_router_topology
+
+echo ""
+echo "=========================================="
+print_success "Cleanup complete!"
+echo "=========================================="

--- a/examples/end-un-usd/test.sh
+++ b/examples/end-un-usd/test.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# examples/end-un-usd/test.sh
+# Test uN + USD: outer decap at the end of a no-SRH uSID container
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../common/test_utils.sh"
+
+check_root
+
+VINBEROD_BIN="${SCRIPT_DIR}/../../out/bin/vinberod"
+VINBERO_BIN="${SCRIPT_DIR}/../../out/bin/vinbero"
+VINBERO_CONFIG="${SCRIPT_DIR}/vinbero_router3.yaml"
+
+export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-unusd-}"
+ns_host1="${TOPO_NS_PREFIX}host1"
+ns_host2="${TOPO_NS_PREFIX}host2"
+ns_router3="${TOPO_NS_PREFIX}router3"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+VINBERO_PID=""
+
+cleanup() {
+    # Guard against PID reuse: only kill if the PID is still our vinberod.
+    if [ -n "$VINBERO_PID" ] && [ "$(ps -o comm= -p "$VINBERO_PID" 2>/dev/null)" = "vinberod" ]; then
+        kill "$VINBERO_PID" 2>/dev/null || true
+        wait "$VINBERO_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+echo "=========================================="
+echo "SRv6 uN + USD Operation Test"
+echo "=========================================="
+echo ""
+echo "No Linux oracle phase: the kernel's seg6local End rejects"
+echo "\"flavors usd\", so there is nothing native to compare against."
+echo ""
+
+print_info "Starting Vinbero on $ns_router3..."
+start_vinbero "$ns_router3" "${VINBERO_CONFIG}" "/tmp/vinbero_end_un_usd_test.log"
+VINBERO_PID=$VINBERO_LAST_PID
+wait_vinbero_ready "$ns_router3" "127.0.0.1:8094" 10
+
+print_info "Registering the uN SID with the USD flavor..."
+ip netns exec "$ns_router3" ${VINBERO_BIN} -s http://127.0.0.1:8094 \
+  sid create --trigger-prefix fd00:aaaa:b003::/48 --action END_UN --flavor USD
+print_success "SID function registered"
+
+sleep 1
+
+# Pre-resolve ARP for the post-decap IPv4 hop.
+ip netns exec "$ns_router3" ping -c 1 -W 1 172.0.2.1 > /dev/null 2>&1 || true
+
+# The forward packet arrives at r3 as a bare uN SID with no SRH and an
+# IPIP payload. Delivery proves the USD branch decapped and forwarded the
+# inner IPv4; without USD the encapsulated packet is handed to the kernel
+# and never reaches host2.
+test_ping_with_counter "$ns_host1" 172.0.2.1 "host1 -> host2 (uN USD decap, no SRH)"
+test_ping_with_counter "$ns_host2" 172.0.1.1 "host2 -> host1 (return, native)"
+
+print_info "Stopping Vinbero..."
+kill $VINBERO_PID 2>/dev/null || true
+wait $VINBERO_PID 2>/dev/null || true
+
+echo ""
+echo "=========================================="
+echo "Test Summary"
+echo "=========================================="
+echo "Passed: $TESTS_PASSED"
+echo "Failed: $TESTS_FAILED"
+echo ""
+
+if [ $TESTS_FAILED -gt 0 ]; then
+    print_error "Some tests failed"
+    exit 1
+else
+    print_success "All tests passed!"
+    exit 0
+fi

--- a/examples/end-un-usd/vinbero_router3.yaml
+++ b/examples/end-un-usd/vinbero_router3.yaml
@@ -1,0 +1,24 @@
+internal:
+  devices:
+    - unusd-rt3rt2  # Interface towards router2 (with "unusd-" prefix)
+    - unusd-rt3h2   # Interface towards host2
+  bpf:
+    device_mode: generic  # Required for veth pairs
+    verifier_log_level: 2
+    verifier_log_size: 1073741823
+  server:
+    bind: "127.0.0.1:8094"
+  logger:
+    level: debug
+    format: text
+    no_color: false
+    add_caller: true
+
+settings:
+  entries:
+    sid_function:
+      capacity: 1024
+    headendv4:
+      capacity: 1024
+    headendv6:
+      capacity: 1024

--- a/examples/end-ut/README.ja.md
+++ b/examples/end-ut/README.ja.md
@@ -1,0 +1,59 @@
+# end-ut — uT (NEXT-C-SID の End.T)
+
+*(English: [README.md](./README.md))*
+
+End.T の NEXT-C-SID flavor である uT (RFC 9800 Sec.4.1.3、F3216) を検証
+します。shift は uN と同じ 16 bit で、shift 後の転送 lookup が default
+FIB でなく SID に bind した VRF table で行われる点だけが異なります。
+
+Linux oracle phase はありません。seg6local の next-csid flavor は End と
+End.X だけにあり、uT に相当する native 実装が存在しないためです。代わり
+に VRF binding を直接証明します。main table では shift 後の宛先を
+blackhole しているので、ping が届くのは table 100 経由の場合だけです。
+
+設計は [`docs/design/ja/usid.md`](../../docs/design/ja/usid.md) を参照して
+ください。
+
+## トポロジ
+
+```mermaid
+graph LR
+    host1 --- router1
+    router1 --- router2
+    router2 --- router3
+    router3 --- host2
+```
+
+- router1 は H.Encaps.Red で forward container
+  fd00:aaaa:b002:b003:d004:: を付与します。単一 container は SRH を出さ
+  ないため、router2 の uT は SRH なしの dispatch 経路で動きます。返り方
+  向は fc00:1::1 (End.DX4) で終端します
+- router2 が uT です (Vinbero、fd00:aaaa:b002::/48、vrf100)。
+  fd00:aaaa:b003::/48 への経路は table 100 にだけあり、main table は
+  blackhole です
+- router3 は forward 方向を fd00:aaaa:b003:d004::/128 (Linux End.DX4)
+  で終端し、返り container を付与します
+
+## 必要条件
+
+- VRF をサポートする Linux kernel
+- iproute2 6.0 以上 (encap.red)
+
+## 使い方
+
+```bash
+sudo ./setup.sh
+sudo ./test.sh
+sudo ./teardown.sh
+```
+
+## 検証内容
+
+1. SRH なしの container が router2 で shift され、table 100 経由で転送
+   されます。main table の blackhole により、VRF table を引いたことが保
+   証されます。素の uN の挙動 (default FIB) ならパケットは落ちます
+2. 返り方向が native の baseline として動きます
+
+uT は uN と違い NO_NEIGH で fail-closed です。VRF に属さない interface
+に届いたパケットに対して kernel は VRF-scoped lookup を再現できないため
+で、setup.sh と test.sh は通信前に NDP を事前解決します。

--- a/examples/end-ut/README.md
+++ b/examples/end-ut/README.md
@@ -1,0 +1,59 @@
+# end-ut — uT (End.T with NEXT-C-SID)
+
+*(日本語: [README.ja.md](./README.ja.md))*
+
+Exercises uT, the NEXT-C-SID flavor of End.T (RFC 9800 Sec.4.1.3, F3216):
+the same 16-bit shift as uN, but the forwarding lookup after the shift
+runs in the VRF table bound to the SID instead of the default FIB.
+
+There is no Linux oracle phase: seg6local's next-csid flavor exists for
+End and End.X only, so there is nothing native to compare uT against.
+Instead the test proves the VRF binding directly -- the main table
+blackholes the shifted destination, so a delivered ping is only possible
+through table 100.
+
+See [`docs/design/ja/usid.md`](../../docs/design/ja/usid.md) for the design.
+
+## Topology
+
+```mermaid
+graph LR
+    host1 --- router1
+    router1 --- router2
+    router2 --- router3
+    router3 --- host2
+```
+
+- router1 pushes the forward container fd00:aaaa:b002:b003:d004:: with
+  H.Encaps.Red -- a single container emits no SRH, so router2's uT runs on
+  the no-SRH dispatch path -- and terminates the return direction on
+  fc00:1::1 (End.DX4)
+- router2 is the uT (Vinbero, fd00:aaaa:b002::/48, vrf100). Table 100
+  holds the only route towards fd00:aaaa:b003::/48; the main table
+  blackholes it
+- router3 terminates the forward direction on fd00:aaaa:b003:d004::/128
+  (Linux End.DX4) and pushes the return container
+
+## Requirements
+
+- Linux kernel with VRF support
+- iproute2 6.0 or later (encap.red)
+
+## Usage
+
+```bash
+sudo ./setup.sh
+sudo ./test.sh
+sudo ./teardown.sh
+```
+
+## What is verified
+
+1. The no-SRH container is shifted at router2 and forwarded via table
+   100. The main-table blackhole guarantees the VRF table was consulted:
+   plain uN behavior (default FIB) would drop the packet
+2. The return direction works as a native baseline
+
+uT is fail-closed on NO_NEIGH, unlike uN: the kernel cannot repeat a
+VRF-scoped lookup for a packet that arrived on a non-VRF interface, so
+setup.sh and test.sh pre-resolve NDP before sending traffic.

--- a/examples/end-ut/setup.sh
+++ b/examples/end-ut/setup.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# examples/end-ut/setup.sh
+# Setup uT (End.T with NEXT-C-SID, RFC 9800 Sec.4.1.3) environment
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Note: Linux interface names are limited to 15 chars, so use short prefix
+export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-ut-}"
+
+source "${SCRIPT_DIR}/../common/topologies/three_router.sh"
+
+ns_router1="${TOPO_NS_PREFIX}router1"
+ns_router2="${TOPO_NS_PREFIX}router2"
+ns_router3="${TOPO_NS_PREFIX}router3"
+veth_rt1_h1="${TOPO_NS_PREFIX}rt1h1"
+veth_rt1_rt2="${TOPO_NS_PREFIX}rt1rt2"
+veth_rt2_rt1="${TOPO_NS_PREFIX}rt2rt1"
+veth_rt2_rt3="${TOPO_NS_PREFIX}rt2rt3"
+veth_rt3_h2="${TOPO_NS_PREFIX}rt3h2"
+veth_rt3_rt2="${TOPO_NS_PREFIX}rt3rt2"
+
+# Setup base topology
+setup_three_router_topology
+
+# uSID plan (F3216: 32-bit block fd00:aaaa, 16-bit uSIDs):
+#   r2 node b002: uT   fd00:aaaa:b002::/48, bound to vrf100 (table 100)
+#   r3 node b003: terminal fd00:aaaa:b003:d004::/128 (Linux End.DX4)
+# Forward container: fd00:aaaa:b002:b003:d004:: sent by r1 with
+# H.Encaps.Red (a single container emits no SRH), so r2's uT runs on the
+# no-SRH dispatch path. The shifted DA is routed in table 100 ONLY: the
+# main table carries a blackhole for the same prefix, so a delivered ping
+# proves the shift-and-forward used the VRF table (End.T semantics), not
+# the default FIB (which would be uN).
+#
+# There is no Linux oracle phase: seg6local's next-csid flavor exists for
+# End and End.X only, so uT has nothing native to compare against.
+print_info "Configuring uT (NEXT-C-SID) settings..."
+
+# router1: headend towards host2 (H.Encaps.Red) + return terminal End.DX4
+ns_sysctl "$ns_router1" net.ipv6.conf.${veth_rt1_h1}.seg6_enabled 1
+ns_sysctl "$ns_router1" net.ipv6.conf.${veth_rt1_rt2}.seg6_enabled 1
+ns_sysctl "$ns_router1" net.ipv4.conf.${veth_rt1_rt2}.rp_filter 0
+ns_sysctl "$ns_router1" net.ipv4.conf.${veth_rt1_h1}.rp_filter 0
+
+run ip netns exec "$ns_router1" ip route add 172.0.2.0/24 encap seg6 mode encap.red segs fd00:aaaa:b002:b003:d004:: dev "$veth_rt1_rt2"
+run ip netns exec "$ns_router1" ip -6 route add fd00:aaaa:b002::/48 via fc00:12::2 dev "$veth_rt1_rt2"
+run ip netns exec "$ns_router1" ip -6 route del local fc00:1::1 2>/dev/null || true
+run ip netns exec "$ns_router1" ip -6 route add local fc00:1::1/128 encap seg6local action End.DX4 nh4 172.0.1.1 dev "$veth_rt1_h1"
+
+# router2: uT under Vinbero (registered in test.sh). The VRF holds the only
+# usable route towards the next uSID node; the main table blackholes it.
+ns_sysctl "$ns_router2" net.ipv6.conf.${veth_rt2_rt1}.seg6_enabled 1
+ns_sysctl "$ns_router2" net.ipv6.conf.${veth_rt2_rt3}.seg6_enabled 1
+
+run ip netns exec "$ns_router2" ip link add vrf100 type vrf table 100
+run ip netns exec "$ns_router2" ip link set vrf100 up
+ip netns exec "$ns_router2" ip rule add l3mdev protocol kernel prio 1000 2>/dev/null || true
+
+# The bare uT SID is a local address: a container ending here is handed up.
+run ip netns exec "$ns_router2" ip -6 addr add fd00:aaaa:b002::/128 dev lo nodad
+
+run ip netns exec "$ns_router2" ip -6 route add fd00:aaaa:b003::/48 via fc00:23::1 dev "$veth_rt2_rt3" table 100
+run ip netns exec "$ns_router2" ip -6 route add blackhole fd00:aaaa:b003::/48
+
+# router3: terminal End.DX4 for the forward direction + return headend
+ns_sysctl "$ns_router3" net.ipv6.conf.${veth_rt3_h2}.seg6_enabled 1
+ns_sysctl "$ns_router3" net.ipv6.conf.${veth_rt3_rt2}.seg6_enabled 1
+ns_sysctl "$ns_router3" net.ipv4.conf.${veth_rt3_rt2}.rp_filter 0
+ns_sysctl "$ns_router3" net.ipv4.conf.${veth_rt3_h2}.rp_filter 0
+
+run ip netns exec "$ns_router3" ip route add 172.0.1.0/24 encap seg6 mode encap segs fc00:1::1 dev "$veth_rt3_rt2"
+run ip netns exec "$ns_router3" ip -6 route add local fd00:aaaa:b003:d004::/128 encap seg6local action End.DX4 nh4 172.0.2.1 dev "$veth_rt3_h2"
+
+# Pre-resolve NDP (bpf_fib_lookup answers NO_NEIGH otherwise, and uT is
+# fail-closed there: the kernel cannot repeat a VRF-scoped lookup for a
+# packet that arrived on a non-VRF interface)
+print_info "Pre-resolving NDP..."
+ip netns exec "$ns_router1" ping6 -c 1 -W 2 fc00:12::2 > /dev/null 2>&1 || true
+ip netns exec "$ns_router2" ping6 -c 1 -W 2 fc00:23::1 > /dev/null 2>&1 || true
+ip netns exec "$ns_router3" ping6 -c 1 -W 2 fc00:23::2 > /dev/null 2>&1 || true
+
+echo ""
+echo "=========================================="
+echo "SRv6 uT (NEXT-C-SID) Setup Complete!"
+echo "=========================================="
+echo "uSID plan (block fd00:aaaa/32, 16-bit uSIDs):"
+echo "  r2: uT       fd00:aaaa:b002::/48 (vrf100 = table 100; main table blackholes)"
+echo "  r3: terminal fd00:aaaa:b003:d004::/128 (End.DX4 -> host2)"
+echo "Forward container (H.Encaps.Red, no SRH): fd00:aaaa:b002:b003:d004::"
+echo "Return path: fc00:1::1 (End.DX4 on r1)"
+echo ""
+print_success "Ready for testing!"

--- a/examples/end-ut/teardown.sh
+++ b/examples/end-ut/teardown.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# examples/end-ut/teardown.sh
+# Teardown uT (NEXT-C-SID) demonstration environment
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-ut-}"
+
+source "${SCRIPT_DIR}/../common/topologies/three_router.sh"
+
+echo "=========================================="
+echo "Tearing down SRv6 uT environment"
+echo "=========================================="
+
+# vinberod is started and stopped within test.sh (its EXIT trap fires even
+# on an aborted run), so teardown only removes the namespaces.
+teardown_three_router_topology
+
+echo ""
+echo "=========================================="
+print_success "Cleanup complete!"
+echo "=========================================="

--- a/examples/end-ut/test.sh
+++ b/examples/end-ut/test.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# examples/end-ut/test.sh
+# Test uT (End.T with NEXT-C-SID): shift-and-forward bound to a VRF table
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../common/test_utils.sh"
+
+check_root
+
+VINBEROD_BIN="${SCRIPT_DIR}/../../out/bin/vinberod"
+VINBERO_BIN="${SCRIPT_DIR}/../../out/bin/vinbero"
+VINBERO_CONFIG="${SCRIPT_DIR}/vinbero_router2.yaml"
+
+export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-ut-}"
+ns_host1="${TOPO_NS_PREFIX}host1"
+ns_host2="${TOPO_NS_PREFIX}host2"
+ns_router2="${TOPO_NS_PREFIX}router2"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+VINBERO_PID=""
+
+cleanup() {
+    # Guard against PID reuse: only kill if the PID is still our vinberod.
+    if [ -n "$VINBERO_PID" ] && [ "$(ps -o comm= -p "$VINBERO_PID" 2>/dev/null)" = "vinberod" ]; then
+        kill "$VINBERO_PID" 2>/dev/null || true
+        wait "$VINBERO_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+echo "=========================================="
+echo "SRv6 uT (NEXT-C-SID) Operation Test"
+echo "=========================================="
+echo ""
+echo "No Linux oracle phase: seg6local's next-csid flavor covers End and"
+echo "End.X only, so there is nothing native to compare uT against."
+echo ""
+
+print_info "Starting Vinbero on $ns_router2..."
+start_vinbero "$ns_router2" "${VINBERO_CONFIG}" "/tmp/vinbero_end_ut_test.log"
+VINBERO_PID=$VINBERO_LAST_PID
+wait_vinbero_ready "$ns_router2" "127.0.0.1:8093" 10
+
+print_info "Registering the uT SID (locator-prefix entry, /48, vrf100)..."
+ip netns exec "$ns_router2" ${VINBERO_BIN} -s http://127.0.0.1:8093 \
+  sid create --trigger-prefix fd00:aaaa:b002::/48 --action END_UT --vrf-name vrf100
+print_success "SID function registered"
+
+sleep 1
+
+# Pre-resolve NDP again right before the traffic: uT is fail-closed on
+# NO_NEIGH (the kernel cannot repeat a VRF-scoped lookup), so a cold
+# neighbour table would black-hole the first pings.
+ip netns exec "$ns_router2" ping6 -c 1 -W 1 fc00:23::1 > /dev/null 2>&1 || true
+
+# The main table blackholes fd00:aaaa:b003::/48 (setup.sh), so this ping
+# is only delivered if the shift-and-forward ran in table 100: End.T
+# semantics, not plain uN.
+test_ping_with_counter "$ns_host1" 172.0.2.1 "host1 -> host2 (uT shift via vrf100, no SRH)"
+test_ping_with_counter "$ns_host2" 172.0.1.1 "host2 -> host1 (return, native)"
+
+print_info "Stopping Vinbero..."
+kill $VINBERO_PID 2>/dev/null || true
+wait $VINBERO_PID 2>/dev/null || true
+
+echo ""
+echo "=========================================="
+echo "Test Summary"
+echo "=========================================="
+echo "Passed: $TESTS_PASSED"
+echo "Failed: $TESTS_FAILED"
+echo ""
+
+if [ $TESTS_FAILED -gt 0 ]; then
+    print_error "Some tests failed"
+    exit 1
+else
+    print_success "All tests passed!"
+    exit 0
+fi

--- a/examples/end-ut/vinbero_router2.yaml
+++ b/examples/end-ut/vinbero_router2.yaml
@@ -1,0 +1,24 @@
+internal:
+  devices:
+    - ut-rt2rt1  # Interface towards router1 (with "ut-" prefix)
+    - ut-rt2rt3  # Interface towards router3 (with "ut-" prefix)
+  bpf:
+    device_mode: generic  # Required for veth pairs
+    verifier_log_level: 2
+    verifier_log_size: 1073741823
+  server:
+    bind: "127.0.0.1:8093"
+  logger:
+    level: debug
+    format: text
+    no_color: false
+    add_caller: true
+
+settings:
+  entries:
+    sid_function:
+      capacity: 1024
+    headendv4:
+      capacity: 1024
+    headendv6:
+      capacity: 1024


### PR DESCRIPTION
## Summary

Three new netns examples (all in the CI Integration Test matrix) plus design doc / roadmap updates.

- `examples/end-udt4/`: proves the terminal-uSID claim — END_DT4 registered at the zero-padded /128 wins the LPM over the uN /48, first against the Linux seg6local oracle and then under Vinbero. Also exercises the two-uSID container whose shift lands on the node's own uDT4: Vinbero re-dispatches that inside the XDP loop, while Linux seg6local cannot forward a shifted DA back into its own local SID, so that container only runs in the Vinbero phase.
- `examples/end-ut/`: no oracle exists (the kernel's next-csid flavor covers End/End.X only), so the VRF binding is proven directly — the main table blackholes the shifted destination and only a table-100 lookup delivers the ping. Uses H.Encaps.Red, so the uT runs on the no-SRH dispatch path.
- `examples/end-un-usd/`: the kernel's seg6local End rejects "flavors usd", so delivery itself is the proof — without USD the still-encapsulated no-SRH packet never reaches the destination.
- `docs/design/ja/usid.md` gains uT, terminal-uSID, and USD sections (including why the in-loop local re-match does not consult table T, and the extension-header limitation); `docs/loadmap.md` now describes the whole NEXT-C-SID coverage.

## Testing

Local runs: end-udt4 5/5, end-ut 2/2, end-un-usd 2/2.

Stacked on #153.