### PR TITLE
test(examples): REPLACE-CSID end-to-end scenario and docs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -152,6 +152,7 @@ jobs:
           - end-un-usd
           - end-ut
           - end-udt4
+          - end-replace
           - headend-v4
           - headend-v6
           - headend-l2

--- a/docs/design/ja/usid.md
+++ b/docs/design/ja/usid.md
@@ -1,4 +1,4 @@
-# uSID (NEXT-C-SID) の uN / uA / uT
+# uSID の uN / uA / uT と REPLACE-C-SID
 
 ## 概要
 
@@ -250,7 +250,23 @@ vinbero sid create --trigger-prefix fd00:aaaa:b002:d004::/128 --action END_DT4 -
 vinbero sid create --trigger-prefix fd00:aaaa:b002::/48 --action END_UN --flavor USD
 ```
 
-`--usid-block-len` は SID 構造を明示する場合に使います。既定は 32 で、現状は 32 以外を受け付けません。
+`--usid-block-len` は SID 構造を明示する場合に使います。NEXT-C-SID 系 (uN/uA/uT) では既定が 32 で、32 以外を受け付けません。REPLACE-C-SID 系 (END_REPLACE / END_X_REPLACE) では必須で、byte 境界の任意長を取ります (`--csid-len` は 32 既定 / 16)。
+
+## REPLACE-C-SID (End / End.X)
+
+RFC 9800 Sec.4.2 の REPLACE-CSID flavor を `SRV6_LOCAL_ACTION_END_REPLACE` (29) と `END_X_REPLACE` (30) として実装しています。NEXT-C-SID が DA の中で shift するのに対し、REPLACE は packed container を SRH の segment list に置き、DA の Argument 下位 bit (LNFL=32 なら 2 bit、16 なら 3 bit) が container 内の index を運びます。endpoint は container を歩く間も跨ぐときも DA の C-SID 部分 (bits [LBL..LBL+LNFL-1]) だけを書き換えます (跨ぎでは index を K-1 に戻すだけです)。次の 128 bit SID を丸ごとロードするのは、container が zero C-SID で早期に終わったとき (R06-R10) だけで、そのとき segment list の次の entry は packed container でなく完全な SID です (RFC の R01-R21)。
+
+- SID 構造は可変です。locator block は byte 境界の任意長、C-SID 長は 32 bit (RFC 必須) と 16 bit (任意) の 2 つをコンパイル時定数の 2 系統として実装し、aux の `csid_len_bytes` で選びます。block 長も aux (`block_len_bytes`) にあり、block + C-SID は 120 bit 以下 (index の byte 15 を prefix の外に残すため)
+- trigger prefix は block + C-SID です。C-SID 0 は container 終端の予約値なので登録を拒否します
+- terminal 条件 (S02) は「SL==0 かつ (Index==0 または SegList[0][Index-1]==0)」で、SL==0 だけでは終端になりません。列の最終 C-SID は任意の behavior でよく、DA の argument bit が変動するため /128 でなく block + C-SID の prefix で登録して受けます
+- flavor は entry.Flavor をそのまま使います。PSP は RFC 9800 Sec.4.2.8 の 2 挿入点 (R09 の後は素の SL==0、R20 の後は R20.1 の複合条件)、USP/USD は S02 terminal で既存の SL=0 handler を呼びます。SRH なし (reduced encap) の bare SID は uN と同じ USD decap 経路に乗ります (End.X(REP) は uA と同じく kernel 渡し)
+- 転送は uN と同じ `usid_forward` です。End(REP) は置換後 DA の FIB (NO_NEIGH は kernel 渡し)、End.X(REP) は aux nexthop (fail-closed)
+- End.X(REP) の terminal USD は classic End.X と同じく decap 後の inner を FIB で転送します。RFC 8986 Sec.4.16.3 は adjacency J への転送を求めており、ここは classic 実装と共通の既知の差分です
+- REPLACE には uN のような同一ノード連続 C-SID の loop 内消費はありません。shift でなく FIB 転送で次の C-SID に進む方式のため、連続する C-SID は異なるノードに置く前提です (RFC の想定どおり)
+
+ICMPv6 を生成しない点 (R03/R14 は silent drop) と、segment list の上限を max_LE でなく `MAX_SEGMENTS` とする点は codebase 全体の方針に合わせています。
+
+verifier の教訓を 2 つ helper に焼き込んでいます。値の範囲チェックを clang が subtract-and-mask 形に書き換えると元 register が narrow されないので、block 長は使用直前に mask してから比較します。また可変 offset の packet pointer は、固定 offset で行った data_end チェックを引き継がないため、導出した pointer 自身を data_end と比較します。
 
 ## headend 側
 
@@ -268,9 +284,9 @@ headend は変更していません。H.Encaps.Red は segment が 1 つのと�
 
 ## 検証
 
-データプレーンの単体テストは `pkg/bpf/xdp_usid_test.go` です。`BPF_PROG_TEST_RUN` の環境では FIB が必ず失敗するため、戻り値だけでは正しい shift と guard による drop を区別できません。したがって出力パケットの DA と hop limit を直接 assert しています。
+データプレーンの単体テストは `pkg/bpf/xdp_usid_test.go` (NEXT-C-SID) と `pkg/bpf/xdp_replace_test.go` (REPLACE-C-SID) です。`BPF_PROG_TEST_RUN` の環境では FIB が必ず失敗するため、戻り値だけでは正しい shift と guard による drop を区別できません。したがって出力パケットの DA と hop limit を直接 assert しています。
 
-E2E の netns example は 5 本です。end-un / end-ua / end-udt4 は Linux kernel の seg6local を oracle にした 2 phase、end-ut と end-un-usd は kernel に対応する native 実装がないため Vinbero 単独の検証です (uT: next-csid flavor は End / End.X のみ。USD: seg6local End は `flavors usd` を拒否します)。
+E2E の netns example は 6 本です。end-un / end-ua / end-udt4 は Linux kernel の seg6local を oracle にした 2 phase、end-ut と end-un-usd と end-replace は kernel に対応する native 実装がないため Vinbero 側で完結する検証です (uT: next-csid flavor は End / End.X のみ。USD: seg6local End は `flavors usd` を拒否します。REPLACE-CSID: seg6local に実装がありません)。
 
 | example | 対象 | Linux 側の設定 | kernel 要件 |
 |---|---|---|---|
@@ -279,6 +295,7 @@ E2E の netns example は 5 本です。end-un / end-ua / end-udt4 は Linux ker
 | `examples/end-udt4/` | terminal uDT4 | `action End.DT4 vrftable 100` (/128) + next-csid uN | 6.1 以上 |
 | `examples/end-ut/` | uT | oracle なし (main table blackhole で VRF lookup を証明) | VRF 対応 |
 | `examples/end-un-usd/` | uN + USD | oracle なし (到達自体が decap の証明) | - |
+| `examples/end-replace/` | End(REP) | oracle なし (2 台の Vinbero を 4 hop 往復する walk) | - |
 
 Linux の seg6local で 1 回の実行が消費する幅は `nflen` です。`lblen` は shift せずに残す locator block の長さで、SID の prefix 長は `lblen + nflen` になります。uA は node と function を同時に消費するので、prefix が /64 になる `nflen 32` が正しく、`nflen 16` は function CSID を DA に残す uN の形になります。
 
@@ -288,10 +305,10 @@ end-ua の router2 は terminal SID への経路を持たないので、uA が�
 
 - BGP 統合は未着手です。uSID locator からの service SID 送出と、受信した service SID からの encap source 導出が残っています。後者は `decodeRemoteSrc` が locator base を仮定している点に手を入れる必要があります
 - 第三者実装との interop シナリオはまだありません
-- REPLACE-C-SID と End.LBS と End.XLBS は実装していません
-- 32 bit uSID と F3216 以外の SID 構造には対応していません。shift の offset がコンパイル時定数なので、`usid_block_len` を緩めるだけでは足りず `src/endpoint/srv6_endpoint_usid.h` の定数も同時に変える必要があります
+- End.LBS と End.XLBS は実装していません。REPLACE-C-SID は End / End.X のみで、End.T / End.B6 / End.BM への適用は未対応です
+- NEXT-C-SID は 32 bit uSID と F3216 以外の SID 構造に対応していません。shift の offset がコンパイル時定数なので、`usid_block_len` を緩めるだけでは足りず `src/endpoint/srv6_endpoint_usid.h` の定数も同時に変える必要があります (REPLACE-C-SID は block 可変・C-SID 32/16 に対応済みです)
 - SR Policy の transport list を container へ自動 packing する処理はありません
-- `locator_ref` からの uN / uA / uT 登録はできません
+- `locator_ref` からの uN / uA / uT / REPLACE 登録はできません
 - flavor は単一値のみで、PSP+USP のような組合せは classic と同じく未対応です
 - uA の USD は未対応です (End.X の USD は adjacency への転送で、DA ベースの decap 転送とは別実装が必要です)
 - SRH なし終端の USD は nexthdr が直接 IPIP / IPv6 の場合だけ decap します。Hop-by-Hop や Destination Options を挟むパケットは既存 dispatcher 全体の方針どおり extension header 非対応で、kernel への local delivery に fall through します (DA は自ノードの SID なので情報漏洩にはなりません)

--- a/docs/loadmap.md
+++ b/docs/loadmap.md
@@ -66,7 +66,7 @@
 | Function             | Status      | Description                                                 | Reference |
 |----------------------|-------------|-------------------------------------------------------------|-----------|
 | NEXT-CSID            | Partial     | uN / uA / uT + terminal uDT*/uDX* via /128, F3216 only      | RFC 9800 |
-| REPLACE-CSID         |             | Compressed SID with replace-based encoding                  | RFC 9800 |
+| REPLACE-CSID         | Partial     | End / End.X, 32/16-bit C-SIDs, single flavor                | RFC 9800 |
 | End.LBS              |             | Locator-Block Swap                                          | RFC 9800 |
 | End.XLBS             |             | L3 cross-connect and Locator-Block Swap                     | RFC 9800 |
 
@@ -79,6 +79,8 @@ NEXT-C-SID の実装範囲は次のとおりです。設計と運用上の注意
 - trigger prefix は uSID 専用にしてください。prefix 内のアドレスは uN / uA / uT SID 自身を除いてすべて container とみなされ、upper-layer protocol に関係なく shift されて転送されます
 - 登録は trigger prefix の明示指定のみで、locator_ref からの登録には未対応です
 - BGP からの uSID service SID の送受信と、第三者実装との interop は未着手です
+
+REPLACE-CSID は End / End.X を実装しています (`SRV6_LOCAL_ACTION_END_REPLACE` / `END_X_REPLACE`)。C-SID 長は 32 bit (必須) と 16 bit (任意)、locator block は byte 境界の任意長で、trigger prefix は block + C-SID です。列の最終 C-SID は任意の behavior を block + C-SID の prefix で登録して受けます (`examples/end-replace/` 参照)。End.T/End.B6/End.BM への REPLACE 適用と locator / BGP 統合は未着手です。
 
 ### Service programming (draft)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -76,6 +76,7 @@ sudo ./teardown.sh # クリーンアップ
 | `end-ut/` | uT | NEXT-C-SID の shift + VRF table 転送 (RFC 9800、F3216) |
 | `end-udt4/` | uDT4 | container 最終 uSID の End.DT4 (zero-padded /128 の LPM 優先) |
 | `end-un-usd/` | uN + USD | SRH なし container 終端での outer decap |
+| `end-replace/` | End(REP) | REPLACE-CSID の container walk (RFC 9800、32bit C-SID) |
 
 ### Headend Functions
 | ディレクトリ | 機能 | 説明 |

--- a/examples/end-replace/README.ja.md
+++ b/examples/end-replace/README.ja.md
@@ -1,0 +1,60 @@
+# end-replace — REPLACE-CSID の End
+
+*(English: [README.md](./README.md))*
+
+REPLACE-CSID flavor の End (RFC 9800 Sec.4.2) を検証します。packed な
+C-SID container は SRH の segment list に置かれ、DA の Argument 下位
+bit が container 内の index を運び、各 endpoint は container を歩きな
+がら DA の C-SID 部分だけを書き換えます。
+
+Linux oracle phase はありません。seg6local が実装するのは NEXT-C-SID
+flavor だけのためです。代わりに C-SID 列を 2 台の Vinbero ノード間で
+往復させ、ping の到達と r2 → r3 link の TX packet counter の両方を
+検証します。到達だけでは index の壊れ方によって中間 hop を飛ばしても
+成功し得るため、counter が echo あたり 2 回の通過を固定します。
+
+設計は [`docs/design/ja/usid.md`](../../docs/design/ja/usid.md) を参照して
+ください。
+
+## トポロジ
+
+```mermaid
+graph LR
+    host1 --- router1
+    router1 --- router2
+    router2 --- router3
+    router3 --- host2
+```
+
+C-SID 計画 (48 bit block fd00:aabb:ccdd、32 bit C-SID、K=4):
+
+- router2 (Vinbero): C-SID b2b2:1 と b2b2:2 の End(REP) (/80)
+- router3 (Vinbero): C-SID b3b3:1 の End(REP) (/80)
+- router3 (Linux): C-SID b3b3:d の terminal End.DX4。REPLACE 列の最終
+  C-SID は任意の behavior でよく、DA の argument bit が変動するため
+  block + C-SID の /80 で match させます
+
+列 [b2b2:1 (DA), b3b3:1, b2b2:2, b3b3:d] は 1 つの container
+(`0:0:b3b3:d:b2b2:2:b3b3:1`) に収まり、パケットは
+r2 → r3 → r2 → r3 と渡って、router2 での container 跨ぎ (Index 0 →
+K-1) と 2 回の container 内置換を通ります。
+
+## 必要条件
+
+- seg6 encap をサポートする iproute2 (headend から見ると container は
+  普通の segment list entry です)
+
+## 使い方
+
+```bash
+sudo ./setup.sh
+sudo ./test.sh
+sudo ./teardown.sh
+```
+
+## 検証内容
+
+1. forward の ping が到達し、かつ r2 → r3 の TX counter が echo あた
+   り 2 回分増えます。両者を合わせて 4 つの walk step を固定します。
+   b2b2:2 を飛ばす index の壊れ方では到達はしても通過が 1 回になります
+2. 返り方向が native の baseline として動きます

--- a/examples/end-replace/README.md
+++ b/examples/end-replace/README.md
@@ -1,0 +1,61 @@
+# end-replace — End with REPLACE-CSID
+
+*(日本語: [README.ja.md](./README.ja.md))*
+
+Exercises End with the REPLACE-CSID flavor (RFC 9800 Sec.4.2): packed
+C-SID containers live in the SRH segment list, the DA's low Argument
+bits carry the container index, and each endpoint replaces only the
+C-SID part of the DA while walking the container.
+
+There is no Linux oracle phase: seg6local implements only the
+NEXT-C-SID flavor. Instead the C-SID sequence ping-pongs between two
+Vinbero nodes, and the test asserts both delivery and the r2 -> r3
+link's TX packet counter: delivery alone could not rule out a broken
+index that jumps straight to the terminal C-SID, so the counter pins
+the two crossings per echo.
+
+See [`docs/design/ja/usid.md`](../../docs/design/ja/usid.md) for the design.
+
+## Topology
+
+```mermaid
+graph LR
+    host1 --- router1
+    router1 --- router2
+    router2 --- router3
+    router3 --- host2
+```
+
+C-SID plan (48-bit block fd00:aabb:ccdd, 32-bit C-SIDs, K=4):
+
+- router2 (Vinbero): End(REP) at C-SIDs b2b2:1 and b2b2:2 (/80)
+- router3 (Vinbero): End(REP) at C-SID b3b3:1 (/80)
+- router3 (Linux): terminal End.DX4 at C-SID b3b3:d — the last C-SID of
+  a REPLACE sequence can be any behavior, and it matches the block+C-SID
+  /80 because the DA's argument bits vary
+
+The sequence [b2b2:1 (DA), b3b3:1, b2b2:2, b3b3:d] packs into one
+container (`0:0:b3b3:d:b2b2:2:b3b3:1`), so the packet crosses
+r2 → r3 → r2 → r3 and exercises the container cross (Index 0 → K-1) at
+router2 and two in-container replacements.
+
+## Requirements
+
+- iproute2 with seg6 encap support (the containers are ordinary segment
+  list entries from the headend's point of view)
+
+## Usage
+
+```bash
+sudo ./setup.sh
+sudo ./test.sh
+sudo ./teardown.sh
+```
+
+## What is verified
+
+1. The forward ping is delivered and the r2 -> r3 TX counter grows by
+   two crossings per echo, which together pin all four walk steps: a
+   broken index that skipped the b2b2:2 step would still deliver but
+   cross the link only once
+2. The return direction works as a native baseline

--- a/examples/end-replace/setup.sh
+++ b/examples/end-replace/setup.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# examples/end-replace/setup.sh
+# Setup End with REPLACE-CSID (RFC 9800 Sec.4.2) demonstration environment
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Note: Linux interface names are limited to 15 chars, so use short prefix
+export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-repl-}"
+
+source "${SCRIPT_DIR}/../common/topologies/three_router.sh"
+
+ns_router1="${TOPO_NS_PREFIX}router1"
+ns_router2="${TOPO_NS_PREFIX}router2"
+ns_router3="${TOPO_NS_PREFIX}router3"
+veth_rt1_h1="${TOPO_NS_PREFIX}rt1h1"
+veth_rt1_rt2="${TOPO_NS_PREFIX}rt1rt2"
+veth_rt2_rt1="${TOPO_NS_PREFIX}rt2rt1"
+veth_rt2_rt3="${TOPO_NS_PREFIX}rt2rt3"
+veth_rt3_h2="${TOPO_NS_PREFIX}rt3h2"
+veth_rt3_rt2="${TOPO_NS_PREFIX}rt3rt2"
+
+# Setup base topology
+setup_three_router_topology
+
+# REPLACE-CSID plan (48-bit block fd00:aabb:ccdd, 32-bit C-SIDs, K=4):
+#   r2: End(REP)  C-SIDs b2b2:1 and b2b2:2   (/80, Vinbero)
+#   r3: End(REP)  C-SID  b3b3:1              (/80, Vinbero)
+#   r3: terminal  C-SID  b3b3:d              (/80, Linux End.DX4)
+# C-SID sequence: [b2b2:1 (in the DA), b3b3:1, b2b2:2, b3b3:d], so the
+# packet ping-pongs r2 -> r3 -> r2 -> r3 and every walk shape runs on the
+# wire: the container cross at r2 (Index 0 -> K-1) and two in-container
+# replacements. The single packed container is the SRH segment list entry
+#   pos3=b3b3:1  pos2=b2b2:2  pos1=b3b3:d  pos0=0
+# which reads as the IPv6 literal 0:0:b3b3:d:b2b2:2:b3b3:1.
+#
+# There is no Linux oracle phase: seg6local implements only the
+# NEXT-C-SID flavor, so REPLACE-CSID has nothing native to compare
+# against. test.sh asserts delivery plus the r2 -> r3 TX packet counter
+# (two crossings per echo), since delivery alone cannot rule out a
+# broken index skipping the middle C-SIDs.
+print_info "Configuring REPLACE-CSID settings..."
+
+# router1: headend towards host2 + return terminal End.DX4
+ns_sysctl "$ns_router1" net.ipv6.conf.${veth_rt1_h1}.seg6_enabled 1
+ns_sysctl "$ns_router1" net.ipv6.conf.${veth_rt1_rt2}.seg6_enabled 1
+ns_sysctl "$ns_router1" net.ipv4.conf.${veth_rt1_rt2}.rp_filter 0
+ns_sysctl "$ns_router1" net.ipv4.conf.${veth_rt1_h1}.rp_filter 0
+
+run ip netns exec "$ns_router1" ip route add 172.0.2.0/24 encap seg6 mode encap segs fd00:aabb:ccdd:b2b2:1::,0:0:b3b3:d:b2b2:2:b3b3:1 dev "$veth_rt1_rt2"
+run ip netns exec "$ns_router1" ip -6 route add fd00:aabb:ccdd::/48 via fc00:12::2 dev "$veth_rt1_rt2"
+run ip netns exec "$ns_router1" ip -6 route del local fc00:1::1 2>/dev/null || true
+run ip netns exec "$ns_router1" ip -6 route add local fc00:1::1/128 encap seg6local action End.DX4 nh4 172.0.1.1 dev "$veth_rt1_h1"
+
+# router2: two End(REP) C-SIDs under Vinbero (registered in test.sh).
+# The block routes towards r3 for C-SIDs this node does not own.
+ns_sysctl "$ns_router2" net.ipv6.conf.${veth_rt2_rt1}.seg6_enabled 1
+ns_sysctl "$ns_router2" net.ipv6.conf.${veth_rt2_rt3}.seg6_enabled 1
+run ip netns exec "$ns_router2" ip -6 route add fd00:aabb:ccdd::/48 via fc00:23::1 dev "$veth_rt2_rt3"
+
+# router3: one End(REP) C-SID under Vinbero + the terminal (Linux
+# End.DX4 on the /80: the last C-SID of a REPLACE sequence can be any
+# behavior, and the DA's argument bits vary, so the terminal matches the
+# block + C-SID prefix rather than a /128).
+ns_sysctl "$ns_router3" net.ipv6.conf.${veth_rt3_h2}.seg6_enabled 1
+ns_sysctl "$ns_router3" net.ipv6.conf.${veth_rt3_rt2}.seg6_enabled 1
+ns_sysctl "$ns_router3" net.ipv4.conf.${veth_rt3_rt2}.rp_filter 0
+ns_sysctl "$ns_router3" net.ipv4.conf.${veth_rt3_h2}.rp_filter 0
+
+run ip netns exec "$ns_router3" ip -6 route add fd00:aabb:ccdd::/48 via fc00:23::2 dev "$veth_rt3_rt2"
+run ip netns exec "$ns_router3" ip -6 route add local fd00:aabb:ccdd:b3b3:d::/80 encap seg6local action End.DX4 nh4 172.0.2.1 dev "$veth_rt3_h2"
+
+# Return path: host2 -> host1 over the native baseline
+run ip netns exec "$ns_router3" ip route add 172.0.1.0/24 encap seg6 mode encap segs fc00:1::1 dev "$veth_rt3_rt2"
+
+# Pre-resolve NDP (bpf_fib_lookup needs resolved neighbours)
+print_info "Pre-resolving NDP..."
+ip netns exec "$ns_router1" ping6 -c 1 -W 2 fc00:12::2 > /dev/null 2>&1 || true
+ip netns exec "$ns_router2" ping6 -c 1 -W 2 fc00:23::1 > /dev/null 2>&1 || true
+ip netns exec "$ns_router2" ping6 -c 1 -W 2 fc00:12::1 > /dev/null 2>&1 || true
+ip netns exec "$ns_router3" ping6 -c 1 -W 2 fc00:23::2 > /dev/null 2>&1 || true
+
+echo ""
+echo "=========================================="
+echo "SRv6 REPLACE-CSID Setup Complete!"
+echo "=========================================="
+echo "C-SID sequence (block fd00:aabb:ccdd/48, 32-bit C-SIDs):"
+echo "  b2b2:1 (r2) -> b3b3:1 (r3) -> b2b2:2 (r2) -> b3b3:d (r3, End.DX4)"
+echo "Packed container: 0:0:b3b3:d:b2b2:2:b3b3:1"
+echo "Return path: fc00:1::1 (End.DX4 on r1)"
+echo ""
+print_success "Ready for testing!"

--- a/examples/end-replace/teardown.sh
+++ b/examples/end-replace/teardown.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# examples/end-replace/teardown.sh
+# Teardown REPLACE-CSID demonstration environment
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-repl-}"
+
+source "${SCRIPT_DIR}/../common/topologies/three_router.sh"
+
+echo "=========================================="
+echo "Tearing down SRv6 REPLACE-CSID environment"
+echo "=========================================="
+
+# vinberod is started and stopped within test.sh (its EXIT trap fires even
+# on an aborted run), so teardown only removes the namespaces.
+teardown_three_router_topology
+
+echo ""
+echo "=========================================="
+print_success "Cleanup complete!"
+echo "=========================================="

--- a/examples/end-replace/test.sh
+++ b/examples/end-replace/test.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# examples/end-replace/test.sh
+# Test End with REPLACE-CSID: a four-hop C-SID walk across two Vinbero nodes
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../common/test_utils.sh"
+
+check_root
+
+VINBEROD_BIN="${SCRIPT_DIR}/../../out/bin/vinberod"
+VINBERO_BIN="${SCRIPT_DIR}/../../out/bin/vinbero"
+
+export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-repl-}"
+ns_host1="${TOPO_NS_PREFIX}host1"
+ns_host2="${TOPO_NS_PREFIX}host2"
+ns_router2="${TOPO_NS_PREFIX}router2"
+ns_router3="${TOPO_NS_PREFIX}router3"
+veth_rt2_rt3="${TOPO_NS_PREFIX}rt2rt3"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+VINBERO_PID_R2=""
+VINBERO_PID_R3=""
+
+cleanup() {
+    # Guard against PID reuse: only kill if the PID is still our vinberod.
+    for pid in "$VINBERO_PID_R2" "$VINBERO_PID_R3"; do
+        if [ -n "$pid" ] && [ "$(ps -o comm= -p "$pid" 2>/dev/null)" = "vinberod" ]; then
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+        fi
+    done
+}
+trap cleanup EXIT
+
+echo "=========================================="
+echo "SRv6 REPLACE-CSID Operation Test"
+echo "=========================================="
+echo ""
+echo "No Linux oracle phase: seg6local implements only the NEXT-C-SID"
+echo "flavor, so there is nothing native to compare REPLACE-CSID against."
+echo ""
+
+print_info "Starting Vinbero on $ns_router2 and $ns_router3..."
+start_vinbero "$ns_router2" "${SCRIPT_DIR}/vinbero_router2.yaml" "/tmp/vinbero_end_replace_r2.log"
+VINBERO_PID_R2=$VINBERO_LAST_PID
+start_vinbero "$ns_router3" "${SCRIPT_DIR}/vinbero_router3.yaml" "/tmp/vinbero_end_replace_r3.log"
+VINBERO_PID_R3=$VINBERO_LAST_PID
+wait_vinbero_ready "$ns_router2" "127.0.0.1:8095" 10
+wait_vinbero_ready "$ns_router3" "127.0.0.1:8096" 10
+
+print_info "Registering the End(REP) C-SIDs (block 48, csid 32)..."
+ip netns exec "$ns_router2" ${VINBERO_BIN} -s http://127.0.0.1:8095 \
+  sid create --trigger-prefix fd00:aabb:ccdd:b2b2:1::/80 --action END_REPLACE --usid-block-len 48
+ip netns exec "$ns_router2" ${VINBERO_BIN} -s http://127.0.0.1:8095 \
+  sid create --trigger-prefix fd00:aabb:ccdd:b2b2:2::/80 --action END_REPLACE --usid-block-len 48
+ip netns exec "$ns_router3" ${VINBERO_BIN} -s http://127.0.0.1:8096 \
+  sid create --trigger-prefix fd00:aabb:ccdd:b3b3:1::/80 --action END_REPLACE --usid-block-len 48
+print_success "SID functions registered"
+
+sleep 1
+
+# The forward ping only arrives if all four walk steps work: the
+# container cross at r2 (Index 0 -> 3), the in-container replacements at
+# r3 and r2, and the terminal End.DX4 match on the /80 at r3. Delivery
+# alone cannot prove the middle hops (a broken index that jumps straight
+# to the terminal C-SID would still ping), so the r2 -> r3 link's TX
+# counter pins the ping-pong: each echo request crosses it twice.
+tx_before=$(ip netns exec "$ns_router2" cat /sys/class/net/${veth_rt2_rt3}/statistics/tx_packets)
+test_ping_with_counter "$ns_host1" 172.0.2.1 "host1 -> host2 (REPLACE-CSID walk r2->r3->r2->r3)"
+tx_after=$(ip netns exec "$ns_router2" cat /sys/class/net/${veth_rt2_rt3}/statistics/tx_packets)
+tx_delta=$((tx_after - tx_before))
+if [ "$tx_delta" -ge 6 ]; then
+    print_success "walk traversal: PASS (r2->r3 tx +${tx_delta}, 2 crossings x 3 echoes)"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    print_error "walk traversal: FAIL (r2->r3 tx +${tx_delta}, want >= 6: the b2b2:2 step was skipped)"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+test_ping_with_counter "$ns_host2" 172.0.1.1 "host2 -> host1 (return, native)"
+
+print_info "Stopping Vinbero..."
+cleanup
+VINBERO_PID_R2=""
+VINBERO_PID_R3=""
+
+echo ""
+echo "=========================================="
+echo "Test Summary"
+echo "=========================================="
+echo "Passed: $TESTS_PASSED"
+echo "Failed: $TESTS_FAILED"
+echo ""
+
+if [ $TESTS_FAILED -gt 0 ]; then
+    print_error "Some tests failed"
+    exit 1
+else
+    print_success "All tests passed!"
+    exit 0
+fi

--- a/examples/end-replace/vinbero_router2.yaml
+++ b/examples/end-replace/vinbero_router2.yaml
@@ -1,0 +1,24 @@
+internal:
+  devices:
+    - repl-rt2rt1  # Interface towards router1 (with "repl-" prefix)
+    - repl-rt2rt3  # Interface towards router3 (with "repl-" prefix)
+  bpf:
+    device_mode: generic  # Required for veth pairs
+    verifier_log_level: 2
+    verifier_log_size: 1073741823
+  server:
+    bind: "127.0.0.1:8095"
+  logger:
+    level: debug
+    format: text
+    no_color: false
+    add_caller: true
+
+settings:
+  entries:
+    sid_function:
+      capacity: 1024
+    headendv4:
+      capacity: 1024
+    headendv6:
+      capacity: 1024

--- a/examples/end-replace/vinbero_router3.yaml
+++ b/examples/end-replace/vinbero_router3.yaml
@@ -1,0 +1,23 @@
+internal:
+  devices:
+    - repl-rt3rt2  # Interface towards router2 (with "repl-" prefix)
+  bpf:
+    device_mode: generic  # Required for veth pairs
+    verifier_log_level: 2
+    verifier_log_size: 1073741823
+  server:
+    bind: "127.0.0.1:8096"
+  logger:
+    level: debug
+    format: text
+    no_color: false
+    add_caller: true
+
+settings:
+  entries:
+    sid_function:
+      capacity: 1024
+    headendv4:
+      capacity: 1024
+    headendv6:
+      capacity: 1024


### PR DESCRIPTION
## Summary

- `examples/end-replace/` (CI matrix): no Linux oracle exists (seg6local implements only NEXT-C-SID), so the C-SID sequence ping-pongs between two Vinbero nodes instead. One packed container carries [b3b3:1, b2b2:2, b3b3:d] behind the DA's b2b2:1; the packet crosses r2 → r3 → r2 → r3 and delivery proves the container cross, both in-container replacements, and the block+C-SID /80 terminal match (a Linux End.DX4 — the last C-SID of a REPLACE sequence can be any behavior).
- `docs/design/ja/usid.md` gains a REPLACE-C-SID section (geometry, S02 semantics, flavor insertion points, the End.X-USD limitation shared with classic End.X, and the two verifier lessons); the roadmap entry moves to Partial.

## Testing

Local run: end-replace 2/2 (four-hop walk + native return).

Stacked on #157.