### PR TITLE
test(examples): End.LBS end-to-end scenario and docs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -153,6 +153,7 @@ jobs:
           - end-ut
           - end-udt4
           - end-replace
+          - end-lbs
           - headend-v4
           - headend-v6
           - headend-l2

--- a/docs/design/ja/usid.md
+++ b/docs/design/ja/usid.md
@@ -268,6 +268,15 @@ ICMPv6 を生成しない点 (R03/R14 は silent drop) と、segment list の上
 
 verifier の教訓を 2 つ helper に焼き込んでいます。値の範囲チェックを clang が subtract-and-mask 形に書き換えると元 register が narrow されないので、block 長は使用直前に mask してから比較します。また可変 offset の packet pointer は、固定 offset で行った data_end チェックを引き継がないため、導出した pointer 自身を data_end と比較します。
 
+## End.LBS / End.XLBS (Locator-Block Swap)
+
+RFC 9800 Sec.7 の Locator-Block Swap を、NEXT-C-SID (Sec.7.1.1 / 7.2.1) と REPLACE-CSID (Sec.7.1.2 / 7.2.2) の両 flavor で実装しています。routing domain の境界で、残りの C-SID 列を target block B2/m の上へ載せ替える behavior です。
+
+- 新しい tail call slot は使いません。target block は aux の usid variant に追加した local property (`target_block[16]` + byte 単位の長さ) で、非ゼロなら uN / uA / End(REP) / End.X(REP) の advance が in place でなく target block 上に新 DA を合成します。API の 4 action (`END_LBS` / `END_XLBS` / `END_LBS_REPLACE` / `END_XLBS_REPLACE`、enum 値は plugin action 範囲を避けて 100 番台) は登録時に base action へ写像され、List は aux から逆写像して返します
+- NEXT 系は N05-N06 の置換です。A = B2 とし、DA の Argument を A の bits [m..m+AL-1] へ copy して DA にします。terminal (Argument ゼロ) は無変更で、swap 後は同一 entry に再 match しないため、新 block 側の local SID は既存の re-dispatch が拾います
+- REPLACE 系は R20 の置換です。A = B2 に C-SID を [m..m+LNFL-1]、index を下位 bit に書き、旧 Argument は持ち越しません。stack 上で合成して固定 offset の 16 byte copy 1 回で書くため、可変 offset の packet write は発生しません
+- m は byte 境界で、NEXT では m <= base SID の block+node(+function) 幅、REPLACE では m + LNFL/8 <= 15 (index byte を残す) を登録時に検証します。target の m より後ろの bit はゼロであることも検証します
+
 ## headend 側
 
 headend は変更していません。H.Encaps.Red は segment が 1 つのとき SRH なしの encap を出すので、pre-packed の container を segment list として渡せばそのまま uSID のパケットになります。SR Policy の transport list を container へ自動 packing する処理は未実装です。
@@ -284,9 +293,9 @@ headend は変更していません。H.Encaps.Red は segment が 1 つのと�
 
 ## 検証
 
-データプレーンの単体テストは `pkg/bpf/xdp_usid_test.go` (NEXT-C-SID) と `pkg/bpf/xdp_replace_test.go` (REPLACE-C-SID) です。`BPF_PROG_TEST_RUN` の素の環境では FIB lookup が転送先を返さないため、戻り値だけでは正しい shift と guard による drop を区別できず、出力パケットの DA と hop limit を直接 assert しています。adjacency 転送の decap を実際に観測するテストだけは、veth pair と permanent neighbor entry を作って lookup を成功させ、redirect と宛先 MAC まで assert します。
+データプレーンの単体テストは `pkg/bpf/xdp_usid_test.go` (NEXT-C-SID)、`pkg/bpf/xdp_replace_test.go` (REPLACE-C-SID)、`pkg/bpf/xdp_lbs_test.go` (End.LBS / End.XLBS) です。`BPF_PROG_TEST_RUN` の素の環境では FIB lookup が転送先を返さないため、戻り値だけでは正しい shift と guard による drop を区別できず、出力パケットの DA と hop limit を直接 assert しています。adjacency 転送の decap を実際に観測するテストだけは、veth pair と permanent neighbor entry を作って lookup を成功させ、redirect と宛先 MAC まで assert します。
 
-E2E の netns example は 6 本です。end-un / end-ua / end-udt4 は Linux kernel の seg6local を oracle にした 2 phase、end-ut と end-un-usd と end-replace は kernel に対応する native 実装がないため Vinbero 側で完結する検証です (uT: next-csid flavor は End / End.X のみ。USD: seg6local End は `flavors usd` を拒否します。REPLACE-CSID: seg6local に実装がありません)。
+E2E の netns example は 7 本です。end-un / end-ua / end-udt4 は Linux kernel の seg6local を oracle にした 2 phase、end-ut と end-un-usd と end-replace と end-lbs は kernel に対応する native 実装がないため Vinbero 側で完結する検証です (uT: next-csid flavor は End / End.X のみ。USD: seg6local End は `flavors usd` を拒否します。REPLACE-CSID: seg6local に実装がありません)。
 
 | example | 対象 | Linux 側の設定 | kernel 要件 |
 |---|---|---|---|
@@ -296,6 +305,7 @@ E2E の netns example は 6 本です。end-un / end-ua / end-udt4 は Linux ker
 | `examples/end-ut/` | uT | oracle なし (main table blackhole で VRF lookup を証明) | VRF 対応 |
 | `examples/end-un-usd/` | uN + USD | oracle なし (到達自体が decap の証明) | - |
 | `examples/end-replace/` | End(REP) | oracle なし (2 台の Vinbero を 4 hop 往復する walk) | - |
+| `examples/end-lbs/` | End.LBS | oracle なし (block A を blackhole して swap を構造証明) | - |
 
 Linux の seg6local で 1 回の実行が消費する幅は `nflen` です。`lblen` は shift せずに残す locator block の長さで、SID の prefix 長は `lblen + nflen` になります。uA は node と function を同時に消費するので、prefix が /64 になる `nflen 32` が正しく、`nflen 16` は function CSID を DA に残す uN の形になります。
 
@@ -305,7 +315,7 @@ end-ua の router2 は terminal SID への経路を持たないので、uA が�
 
 - BGP 統合は未着手です。uSID locator からの service SID 送出と、受信した service SID からの encap source 導出が残っています。後者は `decodeRemoteSrc` が locator base を仮定している点に手を入れる必要があります
 - 第三者実装との interop シナリオはまだありません
-- End.LBS と End.XLBS は実装していません。REPLACE-C-SID は End / End.X のみで、End.T / End.B6 / End.BM への適用は未対応です
+- REPLACE-C-SID の End.T / End.B6 / End.BM への適用は未対応です
 - NEXT-C-SID は 32 bit uSID と F3216 以外の SID 構造に対応していません。shift の offset がコンパイル時定数なので、`usid_block_len` を緩めるだけでは足りず `src/endpoint/srv6_endpoint_usid.h` の定数も同時に変える必要があります (REPLACE-C-SID は block 可変・C-SID 32/16 に対応済みです)
 - SR Policy の transport list を container へ自動 packing する処理はありません
 - `locator_ref` からの uN / uA / uT / REPLACE 登録はできません

--- a/docs/loadmap.md
+++ b/docs/loadmap.md
@@ -67,8 +67,8 @@
 |----------------------|-------------|-------------------------------------------------------------|-----------|
 | NEXT-CSID            | Partial     | uN / uA / uT + terminal uDT*/uDX* via /128, F3216 only      | RFC 9800 |
 | REPLACE-CSID         | Partial     | End / End.X, 32/16-bit C-SIDs, single flavor                | RFC 9800 |
-| End.LBS              |             | Locator-Block Swap                                          | RFC 9800 |
-| End.XLBS             |             | L3 cross-connect and Locator-Block Swap                     | RFC 9800 |
+| End.LBS              | Supported   | Locator-Block Swap (NEXT-C-SID / REPLACE-CSID)              | RFC 9800 |
+| End.XLBS             | Supported   | L3 cross-connect and Locator-Block Swap (NEXT / REPLACE)    | RFC 9800 |
 
 NEXT-C-SID の実装範囲は次のとおりです。設計と運用上の注意は [uSID (NEXT-C-SID)](design/ja/usid.md) を参照してください。
 
@@ -79,6 +79,8 @@ NEXT-C-SID の実装範囲は次のとおりです。設計と運用上の注意
 - trigger prefix は uSID 専用にしてください。prefix 内のアドレスは uN / uA / uT SID 自身を除いてすべて container とみなされ、upper-layer protocol に関係なく shift されて転送されます
 - 登録は trigger prefix の明示指定のみで、locator_ref からの登録には未対応です
 - BGP からの uSID service SID の送受信と、第三者実装との interop は未着手です
+
+End.LBS / End.XLBS は NEXT-C-SID と REPLACE-CSID の両 flavor で実装しています。API では専用 action として登録し、実体は uN / uA / End(REP) / End.X(REP) の slot に target block を local property として持たせる形で動きます (`examples/end-lbs/` 参照)。
 
 REPLACE-CSID は End / End.X を実装しています (`SRV6_LOCAL_ACTION_END_REPLACE` / `END_X_REPLACE`)。C-SID 長は 32 bit (必須) と 16 bit (任意)、locator block は byte 境界の任意長で、trigger prefix は block + C-SID です。列の最終 C-SID は任意の behavior を block + C-SID の prefix で登録して受けます (`examples/end-replace/` 参照)。End.T/End.B6/End.BM への REPLACE 適用と locator / BGP 統合は未着手です。
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -77,6 +77,7 @@ sudo ./teardown.sh # クリーンアップ
 | `end-udt4/` | uDT4 | container 最終 uSID の End.DT4 (zero-padded /128 の LPM 優先) |
 | `end-un-usd/` | uN + USD | SRH なし container 終端での outer decap |
 | `end-replace/` | End(REP) | REPLACE-CSID の container walk (RFC 9800、32bit C-SID) |
+| `end-lbs/` | End.LBS | locator block swap で C-SID 列を別 block へ載せ替え (RFC 9800 Sec.7) |
 
 ### Headend Functions
 | ディレクトリ | 機能 | 説明 |

--- a/examples/end-lbs/README.ja.md
+++ b/examples/end-lbs/README.ja.md
@@ -1,0 +1,51 @@
+# end-lbs — End.LBS (Locator-Block Swap)
+
+*(English: [README.md](./README.md))*
+
+End.LBS (RFC 9800 Sec.7.1) を検証します。routing domain の境界で、残り
+の C-SID 列をひとつの locator block から別の block へ載せ替える behavior
+です。実体は uN slot で動き、target block は SID の local property
+(`--target-block`) として持ちます。shift は in place でなく target block
+の上に新しい DA を合成します。
+
+Linux oracle phase はありません。seg6local は End.LBS もその土台の
+compressed-SID flavor も実装していないためです。代わりに構造で証明しま
+す。block A は境界ノードより先で blackhole されているため、swap された
+DA だけが block B にしか存在しない terminal に到達できます。
+
+## トポロジ
+
+```mermaid
+graph LR
+    host1 --- router1
+    router1 --- router2
+    router2 --- router3
+    router3 --- host2
+```
+
+- block A は fd00:aaaa/32 (r1 側、r2 より先は blackhole)、block B は
+  fd77:7777:7777/48 (r3 側) です
+- router1 は H.Encaps.Red で単一 container fd00:aaaa:b002:d004:: を付与
+  し、返り方向を fc00:1::1 で終端します
+- router2 (Vinbero) が fd00:aaaa:b002::/48 の End.LBS を持ちます。
+  target block は fd77:7777:7777::/48 で、argument (d004...) が target
+  block 上に copy され fd77:7777:7777:d004:: になります
+- router3 は fd77:7777:7777:d004::/128 を Linux End.DX4 で終端します
+
+## 使い方
+
+```bash
+sudo ./setup.sh
+sudo ./test.sh
+sudo ./teardown.sh
+```
+
+## 検証内容
+
+1. forward の ping が block swap を通って届きます。素の uN shift なら
+   block A の DA fd00:aaaa:d004:: になり router2 の blackhole で落ちる
+   ため、到達自体が swap を固定します
+2. 返り方向が native の baseline として動きます
+
+End.XLBS と REPLACE-CSID variant は同じ aux property を共有し、
+data plane の単体テスト (`pkg/bpf/xdp_lbs_test.go`) が押さえています。

--- a/examples/end-lbs/README.md
+++ b/examples/end-lbs/README.md
@@ -1,0 +1,51 @@
+# end-lbs — End.LBS (Locator-Block Swap)
+
+*(日本語: [README.ja.md](./README.ja.md))*
+
+Exercises End.LBS (RFC 9800 Sec.7.1): at a routing-domain boundary the
+remaining C-SID sequence is re-homed from one locator block to another.
+The behavior runs in the uN slot with the target block as a SID property
+(`--target-block`); the shift composes the new DA on the target block
+instead of in place.
+
+There is no Linux oracle phase: seg6local implements neither End.LBS nor
+the compressed-SID flavors it builds on. The proof is structural: block
+A is blackholed past the boundary node, so only a swapped DA can reach
+the terminal, which exists only in block B.
+
+## Topology
+
+```mermaid
+graph LR
+    host1 --- router1
+    router1 --- router2
+    router2 --- router3
+    router3 --- host2
+```
+
+- Block A is fd00:aaaa/32 (r1 side, blackholed past r2); block B is
+  fd77:7777:7777/48 (r3 side)
+- router1 pushes the single container fd00:aaaa:b002:d004:: with
+  H.Encaps.Red and terminates the return direction on fc00:1::1
+- router2 (Vinbero) holds End.LBS at fd00:aaaa:b002::/48 with target
+  block fd77:7777:7777::/48: the argument (d004...) is copied onto the
+  target block, producing fd77:7777:7777:d004::
+- router3 terminates fd77:7777:7777:d004::/128 with Linux End.DX4
+
+## Usage
+
+```bash
+sudo ./setup.sh
+sudo ./test.sh
+sudo ./teardown.sh
+```
+
+## What is verified
+
+1. The forward ping is delivered through the block swap. A plain uN
+   shift would produce the block-A DA fd00:aaaa:d004:: and die in
+   router2's blackhole, so delivery pins the swap itself
+2. The return direction works as a native baseline
+
+End.XLBS and the REPLACE-CSID variants share the same aux property and
+are covered by the data-plane unit tests (`pkg/bpf/xdp_lbs_test.go`).

--- a/examples/end-lbs/setup.sh
+++ b/examples/end-lbs/setup.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# examples/end-lbs/setup.sh
+# Setup End.LBS (RFC 9800 Sec.7.1, Locator-Block Swap) environment
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Note: Linux interface names are limited to 15 chars, so use short prefix
+export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-lbs-}"
+
+source "${SCRIPT_DIR}/../common/topologies/three_router.sh"
+
+ns_router1="${TOPO_NS_PREFIX}router1"
+ns_router2="${TOPO_NS_PREFIX}router2"
+ns_router3="${TOPO_NS_PREFIX}router3"
+veth_rt1_h1="${TOPO_NS_PREFIX}rt1h1"
+veth_rt1_rt2="${TOPO_NS_PREFIX}rt1rt2"
+veth_rt2_rt1="${TOPO_NS_PREFIX}rt2rt1"
+veth_rt2_rt3="${TOPO_NS_PREFIX}rt2rt3"
+veth_rt3_h2="${TOPO_NS_PREFIX}rt3h2"
+veth_rt3_rt2="${TOPO_NS_PREFIX}rt3rt2"
+
+# Setup base topology
+setup_three_router_topology
+
+# End.LBS plan: the routing domain boundary sits on r2. Block A is
+# fd00:aaaa/32 (r1 side), block B is fd77:7777:7777/48 (r3 side).
+#   r2: End.LBS  fd00:aaaa:b002::/48, target block fd77:7777:7777::/48
+#   r3: terminal fd77:7777:7777:d004::/128 (Linux End.DX4, block B)
+# The container fd00:aaaa:b002:d004:: enters in block A; the swap at r2
+# re-homes the remaining argument onto block B, producing
+# fd77:7777:7777:d004::. Block A is deliberately unrouted past r2 (a
+# blackhole), so a plain uN shift -- which would produce
+# fd00:aaaa:d004:: -- cannot reach r3: delivery proves the swap.
+#
+# There is no Linux oracle phase: seg6local implements neither End.LBS
+# nor the NEXT-C-SID/REPLACE-CSID variants of it.
+print_info "Configuring End.LBS settings..."
+
+# router1: headend towards host2 + return terminal End.DX4
+ns_sysctl "$ns_router1" net.ipv6.conf.${veth_rt1_h1}.seg6_enabled 1
+ns_sysctl "$ns_router1" net.ipv6.conf.${veth_rt1_rt2}.seg6_enabled 1
+ns_sysctl "$ns_router1" net.ipv4.conf.${veth_rt1_rt2}.rp_filter 0
+ns_sysctl "$ns_router1" net.ipv4.conf.${veth_rt1_h1}.rp_filter 0
+
+run ip netns exec "$ns_router1" ip route add 172.0.2.0/24 encap seg6 mode encap.red segs fd00:aaaa:b002:d004:: dev "$veth_rt1_rt2"
+run ip netns exec "$ns_router1" ip -6 route add fd00:aaaa:b002::/48 via fc00:12::2 dev "$veth_rt1_rt2"
+run ip netns exec "$ns_router1" ip -6 route del local fc00:1::1 2>/dev/null || true
+run ip netns exec "$ns_router1" ip -6 route add local fc00:1::1/128 encap seg6local action End.DX4 nh4 172.0.1.1 dev "$veth_rt1_h1"
+
+# router2: End.LBS under Vinbero (registered in test.sh). Block B routes
+# towards r3; block A is blackholed past this node, so only the swapped
+# DA can continue.
+ns_sysctl "$ns_router2" net.ipv6.conf.${veth_rt2_rt1}.seg6_enabled 1
+ns_sysctl "$ns_router2" net.ipv6.conf.${veth_rt2_rt3}.seg6_enabled 1
+run ip netns exec "$ns_router2" ip -6 route add fd77:7777:7777::/48 via fc00:23::1 dev "$veth_rt2_rt3"
+
+# The bare End.LBS SID is a local address: a container ending here
+# (Argument zero) is handed up unchanged, and the /128 outranks the
+# blackhole below.
+run ip netns exec "$ns_router2" ip -6 addr add fd00:aaaa:b002::/128 dev lo nodad
+run ip netns exec "$ns_router2" ip -6 route add blackhole fd00:aaaa::/32
+
+# router3: terminal End.DX4 in block B + return headend
+ns_sysctl "$ns_router3" net.ipv6.conf.${veth_rt3_h2}.seg6_enabled 1
+ns_sysctl "$ns_router3" net.ipv6.conf.${veth_rt3_rt2}.seg6_enabled 1
+ns_sysctl "$ns_router3" net.ipv4.conf.${veth_rt3_rt2}.rp_filter 0
+ns_sysctl "$ns_router3" net.ipv4.conf.${veth_rt3_h2}.rp_filter 0
+
+run ip netns exec "$ns_router3" ip route add 172.0.1.0/24 encap seg6 mode encap segs fc00:1::1 dev "$veth_rt3_rt2"
+run ip netns exec "$ns_router3" ip -6 route add local fd77:7777:7777:d004::/128 encap seg6local action End.DX4 nh4 172.0.2.1 dev "$veth_rt3_h2"
+
+# Pre-resolve NDP (bpf_fib_lookup needs resolved neighbours)
+print_info "Pre-resolving NDP..."
+ip netns exec "$ns_router1" ping6 -c 1 -W 2 fc00:12::2 > /dev/null 2>&1 || true
+ip netns exec "$ns_router2" ping6 -c 1 -W 2 fc00:23::1 > /dev/null 2>&1 || true
+ip netns exec "$ns_router3" ping6 -c 1 -W 2 fc00:23::2 > /dev/null 2>&1 || true
+
+echo ""
+echo "=========================================="
+echo "SRv6 End.LBS Setup Complete!"
+echo "=========================================="
+echo "Blocks: A = fd00:aaaa/32 (blackholed past r2), B = fd77:7777:7777/48"
+echo "  r2: End.LBS fd00:aaaa:b002::/48 -> target fd77:7777:7777::/48"
+echo "  r3: terminal fd77:7777:7777:d004::/128 (End.DX4 -> host2)"
+echo "Container: fd00:aaaa:b002:d004:: (block A in, block B out)"
+echo ""
+print_success "Ready for testing!"

--- a/examples/end-lbs/teardown.sh
+++ b/examples/end-lbs/teardown.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# examples/end-lbs/teardown.sh
+# Teardown End.LBS demonstration environment
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-lbs-}"
+
+source "${SCRIPT_DIR}/../common/topologies/three_router.sh"
+
+echo "=========================================="
+echo "Tearing down SRv6 End.LBS environment"
+echo "=========================================="
+
+# vinberod is started and stopped within test.sh (its EXIT trap fires even
+# on an aborted run), so teardown only removes the namespaces.
+teardown_three_router_topology
+
+echo ""
+echo "=========================================="
+print_success "Cleanup complete!"
+echo "=========================================="

--- a/examples/end-lbs/test.sh
+++ b/examples/end-lbs/test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# examples/end-lbs/test.sh
+# Test End.LBS: the C-SID sequence crosses a locator-block boundary at r2
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../common/test_utils.sh"
+
+check_root
+
+VINBEROD_BIN="${SCRIPT_DIR}/../../out/bin/vinberod"
+VINBERO_BIN="${SCRIPT_DIR}/../../out/bin/vinbero"
+VINBERO_CONFIG="${SCRIPT_DIR}/vinbero_router2.yaml"
+
+export TOPO_NS_PREFIX="${TOPO_NS_PREFIX:-lbs-}"
+ns_host1="${TOPO_NS_PREFIX}host1"
+ns_host2="${TOPO_NS_PREFIX}host2"
+ns_router2="${TOPO_NS_PREFIX}router2"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+VINBERO_PID=""
+
+cleanup() {
+    # Guard against PID reuse: only kill if the PID is still our vinberod.
+    if [ -n "$VINBERO_PID" ] && [ "$(ps -o comm= -p "$VINBERO_PID" 2>/dev/null)" = "vinberod" ]; then
+        kill "$VINBERO_PID" 2>/dev/null || true
+        wait "$VINBERO_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+echo "=========================================="
+echo "SRv6 End.LBS Operation Test"
+echo "=========================================="
+echo ""
+echo "No Linux oracle phase: seg6local implements neither End.LBS nor the"
+echo "compressed-SID flavors it builds on."
+echo ""
+
+print_info "Starting Vinbero on $ns_router2..."
+start_vinbero "$ns_router2" "${VINBERO_CONFIG}" "/tmp/vinbero_end_lbs_test.log"
+VINBERO_PID=$VINBERO_LAST_PID
+wait_vinbero_ready "$ns_router2" "127.0.0.1:8097" 10
+
+print_info "Registering the End.LBS SID (target block fd77:7777:7777::/48)..."
+ip netns exec "$ns_router2" ${VINBERO_BIN} -s http://127.0.0.1:8097 \
+  sid create --trigger-prefix fd00:aaaa:b002::/48 --action END_LBS \
+  --target-block fd77:7777:7777::/48
+print_success "SID function registered"
+
+sleep 1
+ip netns exec "$ns_router2" ping6 -c 1 -W 1 fc00:23::1 > /dev/null 2>&1 || true
+
+# Block A is blackholed past r2, so this ping is only delivered when the
+# argument was re-homed onto block B (a plain uN shift would produce a
+# block-A DA and die in the blackhole).
+test_ping_with_counter "$ns_host1" 172.0.2.1 "host1 -> host2 (block A in, End.LBS swap, block B out)"
+test_ping_with_counter "$ns_host2" 172.0.1.1 "host2 -> host1 (return, native)"
+
+print_info "Stopping Vinbero..."
+kill $VINBERO_PID 2>/dev/null || true
+wait $VINBERO_PID 2>/dev/null || true
+
+echo ""
+echo "=========================================="
+echo "Test Summary"
+echo "=========================================="
+echo "Passed: $TESTS_PASSED"
+echo "Failed: $TESTS_FAILED"
+echo ""
+
+if [ $TESTS_FAILED -gt 0 ]; then
+    print_error "Some tests failed"
+    exit 1
+else
+    print_success "All tests passed!"
+    exit 0
+fi

--- a/examples/end-lbs/vinbero_router2.yaml
+++ b/examples/end-lbs/vinbero_router2.yaml
@@ -1,0 +1,24 @@
+internal:
+  devices:
+    - lbs-rt2rt1  # Interface towards router1 (with "lbs-" prefix)
+    - lbs-rt2rt3  # Interface towards router3 (with "lbs-" prefix)
+  bpf:
+    device_mode: generic  # Required for veth pairs
+    verifier_log_level: 2
+    verifier_log_size: 1073741823
+  server:
+    bind: "127.0.0.1:8097"
+  logger:
+    level: debug
+    format: text
+    no_color: false
+    add_caller: true
+
+settings:
+  entries:
+    sid_function:
+      capacity: 1024
+    headendv4:
+      capacity: 1024
+    headendv6:
+      capacity: 1024


### PR DESCRIPTION
## Summary

- `examples/end-lbs/` (CI matrix): no Linux oracle exists for any Sec.7 behavior, so the proof is structural — block A is blackholed past the boundary node, and the terminal exists only in block B, so delivery is possible only if the End.LBS swap re-homed the argument onto the target block (a plain uN shift would die in the blackhole).
- `docs/design/ja/usid.md` gains an LBS section (aux property, N05/R20 replacements, validation rules); the roadmap entries move to Supported.

## Testing

Local run: end-lbs 2/2.

Stacked on #162.