### PR TITLE
fix(bpf): finish the verifier log change and reset the plugin slots

### DIFF
--- a/docs/design/ja/configuration.md
+++ b/docs/design/ja/configuration.md
@@ -31,15 +31,16 @@ internal:
 | キー | 型 | デフォルト | 説明 |
 |---|---|---|---|
 | `device_mode` | enum | `driver` | XDP attach mode。`generic` / `driver` / `offload` |
-| `verifier_log_level` | int | `2` | eBPF verifier ログレベル (0-4) |
-| `verifier_log_size` | uint32 | `1073741823` | verifier log バッファサイズ |
+| `verifier_log_level` | int | `0` | eBPF verifier のログレベル。0 で無効、1 で branch、2 で命令単位 |
+| `verifier_log_size` | uint32 | `0` | verifier log バッファの初期サイズ。0 で既定値、上限は 64 MiB |
 
 ```yaml
 internal:
   bpf:
     device_mode: generic       # veth / netns テスト時は generic
-    verifier_log_level: 2
 ```
+
+`verifier_log_level` は既定で無効です。ログはプログラムごとに生成されるため、有効にすると load が目に見えて遅くなります。検証に失敗した場合は指定しなくてもライブラリがログ付きで再試行するので、通常は触る必要がありません。load そのものを追いたいときだけ 1 か 2 を設定します。
 
 `device_mode` の使い分け:
 - `generic`: どの NIC / veth でも動く汎用モード。dev / test 向け
@@ -237,7 +238,6 @@ internal:
     - plgcnt-rt2rt3
   bpf:
     device_mode: generic          # veth は native XDP 非対応
-    verifier_log_level: 2
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/docs/design/ja/configuration.md
+++ b/docs/design/ja/configuration.md
@@ -32,7 +32,7 @@ internal:
 |---|---|---|---|
 | `device_mode` | enum | `driver` | XDP attach mode。`generic` / `driver` / `offload` |
 | `verifier_log_level` | int | `0` | eBPF verifier のログレベル。0 で無効、1 で branch、2 で命令単位 |
-| `verifier_log_size` | uint32 | `0` | verifier log バッファの初期サイズ。0 で既定値、上限は 64 MiB |
+| `verifier_log_size` | uint32 | `0` | verifier log バッファの初期サイズ。0 で cilium/ebpf の既定に任せ、上限は 64 MiB |
 
 ```yaml
 internal:
@@ -40,7 +40,7 @@ internal:
     device_mode: generic       # veth / netns テスト時は generic
 ```
 
-`verifier_log_level` は既定で無効です。ログはプログラムごとに生成されるため、有効にすると load が目に見えて遅くなります。検証に失敗した場合は指定しなくてもライブラリがログ付きで再試行するので、通常は触る必要がありません。load そのものを追いたいときだけ 1 か 2 を設定します。
+`verifier_log_level` は既定で無効です。ログはプログラムごとに生成されるため、有効にすると load が目に見えて遅くなります。検証に失敗した場合は指定しなくても cilium/ebpf が branch レベルのログ付きで再試行するので、通常は触る必要がありません。設定が変えるのは失敗時の error に載るログの詳細度で、2 にすると命令単位になります。load に成功したプログラムのログは出力しません。
 
 `device_mode` の使い分け:
 - `generic`: どの NIC / veth でも動く汎用モード。dev / test 向け

--- a/examples/end-lbs/vinbero_router2.yaml
+++ b/examples/end-lbs/vinbero_router2.yaml
@@ -4,8 +4,6 @@ internal:
     - lbs-rt2rt3  # Interface towards router3 (with "lbs-" prefix)
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8097"
   logger:

--- a/examples/end-replace/vinbero_router2.yaml
+++ b/examples/end-replace/vinbero_router2.yaml
@@ -4,8 +4,6 @@ internal:
     - repl-rt2rt3  # Interface towards router3 (with "repl-" prefix)
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8095"
   logger:

--- a/examples/end-replace/vinbero_router3.yaml
+++ b/examples/end-replace/vinbero_router3.yaml
@@ -3,8 +3,6 @@ internal:
     - repl-rt3rt2  # Interface towards router2 (with "repl-" prefix)
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8096"
   logger:

--- a/examples/end-ua/vinbero_router2.yaml
+++ b/examples/end-ua/vinbero_router2.yaml
@@ -4,8 +4,6 @@ internal:
     - end-ua-rt2rt3  # Interface towards router3 (with "end-ua-" prefix)
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:

--- a/examples/end-udt4/vinbero_router3.yaml
+++ b/examples/end-udt4/vinbero_router3.yaml
@@ -4,8 +4,6 @@ internal:
     - udt4-rt3h2   # Interface towards host2 (in vrf100)
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8092"
   logger:

--- a/examples/end-un-usd/vinbero_router3.yaml
+++ b/examples/end-un-usd/vinbero_router3.yaml
@@ -4,8 +4,6 @@ internal:
     - unusd-rt3h2   # Interface towards host2
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8094"
   logger:

--- a/examples/end-un/vinbero_router2.yaml
+++ b/examples/end-un/vinbero_router2.yaml
@@ -4,8 +4,6 @@ internal:
     - end-un-rt2rt3  # Interface towards router3 (with "end-un-" prefix)
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8087"
   logger:

--- a/examples/end-ut/vinbero_router2.yaml
+++ b/examples/end-ut/vinbero_router2.yaml
@@ -4,8 +4,6 @@ internal:
     - ut-rt2rt3  # Interface towards router3 (with "ut-" prefix)
   bpf:
     device_mode: generic  # Required for veth pairs
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8093"
   logger:

--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -46,7 +46,8 @@ var pinnedControlMaps = []string{
 
 // maxVerifierLogSize caps internal.bpf.verifier_log_size. The buffer is
 // allocated per program and grows on demand, so the cap only stops a large
-// configured value from committing that much memory up front.
+// configured value from committing that much memory up front. Leaving the
+// setting at zero commits nothing: cilium/ebpf sizes the buffer itself.
 const maxVerifierLogSize = 64 * 1024 * 1024
 
 func ReadCollection(constants map[string]any, cfg *config.Config) (*BpfObjects, error) {
@@ -108,8 +109,10 @@ func ReadCollection(constants map[string]any, cfg *config.Config) (*BpfObjects, 
 	// load needs to be debugged.
 	collOpts := &ebpf.CollectionOptions{}
 	if cfg != nil && cfg.InternalConfig.BpfOptions.VerifierLogLevel > 0 {
+		// Zero leaves LogSizeStart unset so cilium/ebpf picks its own
+		// starting size and grows from there.
 		logSize := cfg.InternalConfig.BpfOptions.VerifierLogSize
-		if logSize == 0 || logSize > maxVerifierLogSize {
+		if logSize > maxVerifierLogSize {
 			logSize = maxVerifierLogSize
 		}
 		collOpts.Programs = ebpf.ProgramOptions{

--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -44,8 +44,9 @@ var pinnedControlMaps = []string{
 
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -cflags $BPF_CFLAGS Bpf ../../src/xdp_prog.c -- -I ../../src -I /usr/include/x86_64-linux-gnu
 
-// maxVerifierLogSize caps internal.bpf.verifier_log_size. The default in
-// the config is close to 1 GiB, which would be allocated per program.
+// maxVerifierLogSize caps internal.bpf.verifier_log_size. The buffer is
+// allocated per program and grows on demand, so the cap only stops a large
+// configured value from committing that much memory up front.
 const maxVerifierLogSize = 64 * 1024 * 1024
 
 func ReadCollection(constants map[string]any, cfg *config.Config) (*BpfObjects, error) {
@@ -109,8 +110,6 @@ func ReadCollection(constants map[string]any, cfg *config.Config) (*BpfObjects, 
 	if cfg != nil && cfg.InternalConfig.BpfOptions.VerifierLogLevel > 0 {
 		logSize := cfg.InternalConfig.BpfOptions.VerifierLogSize
 		if logSize == 0 || logSize > maxVerifierLogSize {
-			// The buffer is per program and grows on demand, so a huge
-			// configured value only costs memory up front.
 			logSize = maxVerifierLogSize
 		}
 		collOpts.Programs = ebpf.ProgramOptions{

--- a/pkg/bpf/shared_collection_test.go
+++ b/pkg/bpf/shared_collection_test.go
@@ -61,9 +61,13 @@ func sharedCollection(tb testing.TB, constants map[string]any) *BpfObjects {
 	return objs
 }
 
-// resetSharedCollection empties every map a test could have written.
-// PROG_ARRAYs are left alone: they hold the tail-call targets that
-// ReadCollection populated, and clearing them would break dispatch.
+// resetSharedCollection empties every map a test could have written and
+// puts the tail-call targets back.
+//
+// The PROG_ARRAYs cannot be left alone: tests register extra slots in them,
+// a plugin slot for instance, and do not always remove them, so the next
+// test would not get what a fresh load gives it. Emptying them and calling
+// populateProgArrays restores exactly the built-in targets.
 func resetSharedCollection(tb testing.TB, objs *BpfObjects) {
 	tb.Helper()
 	maps := reflect.ValueOf(objs.BpfMaps)
@@ -76,6 +80,9 @@ func resetSharedCollection(tb testing.TB, objs *BpfObjects) {
 			tb.Fatalf("failed to reset map %s: %v", maps.Type().Field(i).Name, err)
 		}
 	}
+	if err := populateProgArrays(objs); err != nil {
+		tb.Fatalf("failed to restore the tail-call targets: %v", err)
+	}
 }
 
 func clearMap(m *ebpf.Map) error {
@@ -84,8 +91,6 @@ func clearMap(m *ebpf.Map) error {
 		return err
 	}
 	switch info.Type {
-	case ebpf.ProgramArray:
-		return nil
 	case ebpf.Array, ebpf.PerCPUArray:
 		return zeroArray(m, info)
 	default:

--- a/pkg/bpf/shared_collection_test.go
+++ b/pkg/bpf/shared_collection_test.go
@@ -43,6 +43,11 @@ func sharedCollectionKey(constants map[string]any) string {
 
 // sharedCollection returns the collection for constants, loading it on first
 // use, with every map back in the state a fresh load would have left it.
+//
+// The reset is what keeps tests apart, so a test gets one helper: taking a
+// second one wipes the map state the first has already written. A test that
+// needs two configurations puts them on distinct keys of the same helper, or
+// splits into two tests.
 func sharedCollection(tb testing.TB, constants map[string]any) *BpfObjects {
 	tb.Helper()
 	sharedCollMu.Lock()
@@ -123,7 +128,9 @@ func zeroArray(m *ebpf.Map, info *ebpf.MapInfo) error {
 	return nil
 }
 
-// deleteAllKeys drains a hash or LPM trie. Keys are collected first: the
+// deleteAllKeys drains every map type that supports delete, which is all of
+// them except the arrays: hashes, LPM tries and the PROG_ARRAYs whose
+// tail-call targets populateProgArrays puts back. Keys are collected first: the
 // iterator's behavior while the map is being modified is not defined.
 func deleteAllKeys(m *ebpf.Map, info *ebpf.MapInfo) error {
 	var keys [][]byte

--- a/pkg/bpf/xdp_replace_test.go
+++ b/pkg/bpf/xdp_replace_test.go
@@ -55,6 +55,10 @@ func replDA(csid uint32, idx uint8) net.IP {
 func TestXDPProgEndReplace(t *testing.T) {
 	h := newXDPTestHelper(t)
 	h.createSidFunctionReplace("fd00:aabb:ccdd:1111:2222::/80", actionEndReplace, 0, [16]byte{}, 4)
+	// The USD subtest needs the same behavior with a different flavor. It
+	// goes on its own locator rather than a second helper, whose map reset
+	// would drop the entry above out from under the later subtests.
+	h.createSidFunctionReplace("fd00:aabb:ccdd:3333:4444::/80", actionEndReplace, flavorUSD, [16]byte{}, 4)
 
 	src := net.ParseIP("fd00:1:1::1")
 
@@ -202,16 +206,17 @@ func TestXDPProgEndReplace(t *testing.T) {
 	t.Run("terminal non-tunnel payload with USD passes up", func(t *testing.T) {
 		// RFC 8986 Sec.4.16.3: USD decaps tunnelled payloads only; a plain
 		// ICMPv6 terminal packet keeps normal upper-layer processing.
-		h2 := newXDPTestHelper(t)
-		h2.createSidFunctionReplace("fd00:aabb:ccdd:1111:2222::/80", actionEndReplace, flavorUSD, [16]byte{}, 4)
 		segs := []net.IP{mkContainer32(0, 0, 0, 0)}
-		pkt, err := buildSRv6Packet(src, replDA(0x11112222, 0), segs, 0)
+		pkt, err := buildSRv6Packet(src, replDA(0x33334444, 0), segs, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
-		ret, _ := h2.run(pkt)
+		ret, out := h.run(pkt)
 		if ret != XDP_PASS {
 			t.Errorf("expected XDP_PASS, got %d", ret)
+		}
+		if got, want := outPktDA(t, out), replDA(0x33334444, 0); !got.Equal(want) {
+			t.Errorf("DA = %v, want %v (untouched)", got, want)
 		}
 	})
 

--- a/pkg/config/internal.go
+++ b/pkg/config/internal.go
@@ -24,13 +24,14 @@ type BpfConfig struct {
 	DeviceMode string `yaml:"device_mode,omitempty" default:"driver"`
 	// VerifierLogLevel asks the kernel for a verifier log on every program
 	// load: 1 logs branches, 2 logs every instruction. Off by default
-	// because the
-	// log costs real time per load and cilium/ebpf already requests one on
-	// its own when a program fails to verify. Turn it on to debug a load.
+	// because the log costs real time per load and cilium/ebpf already
+	// requests a branch-level one on its own when a program fails to
+	// verify. Set it to 2 to get instruction-level detail in that failure.
 	VerifierLogLevel int `yaml:"verifier_log_level,omitempty" default:"0"`
 	// VerifierLogSize is the starting size of that log buffer, per program.
 	// It grows on demand, and is capped so a large value cannot commit
-	// hundreds of megabytes up front.
+	// hundreds of megabytes up front. Zero leaves the starting size to
+	// cilium/ebpf.
 	VerifierLogSize uint32 `yaml:"verifier_log_size,omitempty" default:"0"`
 }
 

--- a/pkg/config/internal.go
+++ b/pkg/config/internal.go
@@ -23,7 +23,8 @@ type LoggerConfig struct {
 type BpfConfig struct {
 	DeviceMode string `yaml:"device_mode,omitempty" default:"driver"`
 	// VerifierLogLevel asks the kernel for a verifier log on every program
-	// load: 1 for instructions, 2 for branches. Off by default because the
+	// load: 1 logs branches, 2 logs every instruction. Off by default
+	// because the
 	// log costs real time per load and cilium/ebpf already requests one on
 	// its own when a program fails to verify. Turn it on to debug a load.
 	VerifierLogLevel int `yaml:"verifier_log_level,omitempty" default:"0"`

--- a/sdk/examples/plugin-acl-prefix/vinbero_config.yaml
+++ b/sdk/examples/plugin-acl-prefix/vinbero_config.yaml
@@ -4,8 +4,6 @@ internal:
     - plgacl-rt2rt3
   bpf:
     device_mode: generic
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8083"
   logger:

--- a/sdk/examples/plugin-counter/vinbero_config.yaml
+++ b/sdk/examples/plugin-counter/vinbero_config.yaml
@@ -4,8 +4,6 @@ internal:
     - plgcnt-rt2rt3
   bpf:
     device_mode: generic
-    verifier_log_level: 2
-    verifier_log_size: 1073741823
   server:
     bind: "127.0.0.1:8082"
   logger:


### PR DESCRIPTION
## 概要

#151 のレビューで Copilot が挙げた 4 点のうち、merge に間に合わなかった分を直します。

## 内容

- **config のコメントが log level を逆に説明していた**。cilium/ebpf では 1 が `LogLevelBranch`、2 が `LogLevelInstruction` です。設定値を選ぶ利用者を誤らせるので直します
- **SDK のサンプル config が取り残されていた**。`sdk/examples/plugin-counter` と `plugin-acl-prefix` の 2 本に `verifier_log_level: 2` と `verifier_log_size: 1073741823` が残っており、これらは全 load で命令単位のログを要求し続けていました
- **`docs/design/ja/configuration.md` が旧既定値を案内していた**。表の既定値を 0 に直し、既定で無効である理由と、有効にすると load が遅くなることを書き添えます
- **共有 collection が PROG_ARRAY を初期化していなかった**。plugin のテストがスロットを登録したまま戻さないため、以降のテストが fresh load と同じ状態を受け取れていませんでした。全キーを消してから `populateProgArrays` で組み込みターゲットだけを復元します
- `maxVerifierLogSize` のコメントから、既定が 1 GiB だという記述を削除します。既定は 0 になっています

## 検証

- `go test ./pkg/bpf` の失敗集合が、この変更の前後で完全に一致することを確認しました。PROG_ARRAY を消すかどうかで挙動は変わりません
- plugin のテストは単体でも suite でも pass します

## 手元の環境について

この作業中、手元では約 38 本のテストが落ちますが、変更とは無関係です。ホストが RA で IPv6 のデフォルト経路を受け取っており、`bpf_fib_lookup` が成功してしまうため、FIB miss を前提にしたテスト (ECMP など) が `XDP_PASS` ではなく `XDP_REDIRECT` を観測します。未変更の main でも同じ 38 本が落ちます。CI は影響を受けていません。

テストがホストの経路表に依存している点自体は改善の余地がありますが、この PR の範囲外とします。