### PR TITLE
fix(bgp): tear down MUP and EVPN state on unusable replacement UPDATEs

### DIFF
--- a/docs/design/ja/srv6_bgp.md
+++ b/docs/design/ja/srv6_bgp.md
@@ -59,6 +59,8 @@ flowchart LR
 - encap entry の生成: 一致した経路を H.Encaps の headend エントリ (segments = [service SID]) に変換し、prefix を鍵にした eBPF の LPM trie (headend map) へ書きます。書き込みには owner tag を付け、後で同じ owner の経路だけを正確に withdraw できるようにします。
 - encap source: outer の送信元 IPv6 は、設定したローカル locator の prefix から取ります。
 
+BGP の UPDATE は属性全体の暗黙の置換なので、applier は追跡済み NLRI の再広告が使えない内容になったときも withdraw と同じ撤去を行います。service SID が使えなくなった再広告 (空のほか、全ゼロの `::` のような routable でない値。decode 時の検証で不正と判定された場合を含む) は、L3VPN の headend エントリ、EVPN RT2 の FDB / bd_peer、RT3 の flood bd_peer、per-EVI A-D の aliasing 寄与、MUP ISD/DSD の discovery とその解決先のセッションを撤去してから読み飛ばします。EVPN RT2/RT3 の撤去は、その状態を教えた PE (next hop) からの再広告に限定します (per-EVI A-D は従来どおり NLRI 単位で撤去します)。RT がどの import filter にも一致しなくなった再広告の撤去は、filter を持つ経路種別、つまり L3VPN、EVPN RT2/RT3 と per-EVI A-D (bridge-domain binding 不一致)、MUP の session route (T1ST/T2ST) に適用します。MUP の discovery route (ISD/DSD) は cross-VRF 解決のため import-RT filter を意図的に迂回するので、RT 不一致による撤去はありません。
+
 ```mermaid
 flowchart LR
     PEER["BGP peer"]

--- a/pkg/bgp/apply/empty_sid_replace_test.go
+++ b/pkg/bgp/apply/empty_sid_replace_test.go
@@ -1,0 +1,336 @@
+package apply
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/takehaya/vinbero/pkg/bgp"
+	"github.com/takehaya/vinbero/pkg/vrfbgp"
+)
+
+// A BGP UPDATE is an implicit replace. These tests pin that rule for the
+// MUP and EVPN appliers: a re-advertisement of a tracked NLRI whose SID
+// became unusable (empty -- e.g. it failed RFC 9252 Sec.7 validation on
+// decode) or whose RTs no longer match must tear the previous state down,
+// exactly like a withdraw, instead of leaving it forwarding.
+
+func TestApplyMUP_ISDUnusableSIDUpdateReplaces(t *testing.T) {
+	const (
+		rd   = "65100:1"
+		ue   = "10.1.0.1/32"
+		isdP = "172.16.0.0/24"
+		isid = "fd00:a:0:1::"
+	)
+	// "" is the decoder's no-SID rendering; "::" is what an all-zero SID
+	// decodes to; loopback, link-local, and multicast are parseable but
+	// unreachable from a remote PE -- all must tear down, not black-hole.
+	for _, badSID := range []string{"", "::", "::1", "fe80::1", "ff02::1"} {
+		t.Run("sid="+badSID, func(t *testing.T) {
+			fh := newFakeHeadend()
+			a := newMUPApplier(t, fh)
+			a.Apply(mupISD(rd, isdP, isid))
+			a.Apply(mupT1ST(rd, ue, "172.16.0.1", 256, 9, ""))
+			assertT1STBase(t, fh, ue, isid)
+
+			a.Apply(mupISD(rd, isdP, badSID)) // same key, SID became unusable
+			if len(fh.v4deleted) != 1 || fh.v4deleted[0] != ue {
+				t.Errorf("unusable-SID ISD update did not tear down the resolved T1ST; deleted=%v", fh.v4deleted)
+			}
+			if len(a.mupISD) != 0 {
+				t.Errorf("stale ISD entry survived the unusable-SID update: %v", a.mupISD)
+			}
+		})
+	}
+}
+
+// An unusable advertisement for a key that was never tracked must return
+// before the reconcile-all sweep: a flood of them is not allowed to drive
+// repeated whole-table reconciliation.
+func TestApplyMUP_ISDUnusableSIDUntrackedNoop(t *testing.T) {
+	fh := newFakeHeadend()
+	a := newMUPApplier(t, fh)
+	a.Apply(mupISD("65100:1", "172.16.0.0/24", "fd00:a:0:1::"))
+	a.Apply(mupT1ST("65100:1", "10.1.0.1/32", "172.16.0.1", 256, 9, ""))
+	a.Apply(mupISD("65100:1", "172.17.0.0/24", "")) // different, untracked key
+	if len(fh.v4deleted) != 0 {
+		t.Errorf("untracked unusable ISD tore down an unrelated session; deleted=%v", fh.v4deleted)
+	}
+	if len(a.mupISD) != 1 {
+		t.Errorf("tracked ISD count = %d, want 1", len(a.mupISD))
+	}
+}
+
+// A session route (T1ST) whose re-advertisement stops matching any MUP
+// import RT is dispatched as a withdraw: the installed downlink must not
+// survive it.
+func TestApplyMUP_T1STRTMismatchUpdateReplaces(t *testing.T) {
+	const (
+		rd   = "65100:1"
+		ue   = "10.1.0.1/32"
+		isdP = "172.16.0.0/24"
+		isid = "fd00:a:0:1::"
+	)
+	fh := newFakeHeadend()
+	vm := vrfbgp.NewManager()
+	if err := vm.Bind(vrfbgp.Binding{VRFName: "vrf-mup", Families: map[bgp.Family]vrfbgp.FamilyPolicy{
+		bgp.FamilyMUPIPv4: {RouteTargets: []vrfbgp.RouteTarget{{RT: testRTInterwork, Direction: vrfbgp.DirectionImport}}},
+	}}); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	a := NewApplier(fh, testLocatorManager(t), vm, &fakeFib{}, "LOC1", 65000, zap.NewNop())
+	a.Apply(mupISD(rd, isdP, isid))
+	a.Apply(mupT1ST(rd, ue, "172.16.0.1", 256, 9, ""))
+	assertT1STBase(t, fh, ue, isid)
+
+	replaced := mupT1ST(rd, ue, "172.16.0.1", 256, 9, "")
+	replaced.MUP.RTs = []string{"100:9999"}
+	a.Apply(replaced)
+	if len(fh.v4deleted) != 1 || fh.v4deleted[0] != ue {
+		t.Errorf("RT-mismatch T1ST update left the downlink installed; deleted=%v", fh.v4deleted)
+	}
+}
+
+func TestApplyMUP_DSDUnusableSIDUpdateReplaces(t *testing.T) {
+	const (
+		rd       = "65100:1"
+		endpoint = "192.0.2.100"
+		dsdAddr  = "10.0.0.1"
+	)
+	fh := newFakeHeadend()
+	a := newMUPApplier(t, fh)
+	a.Apply(mupDSD(rd, dsdAddr, 1, 2, "fd00:d:0:1::"))
+	a.Apply(mupT2ST(rd, endpoint, 0x100, 32, 1, 2, ""))
+	if _, ok := fh.mupUplink[mupUplinkKey{0, endpoint, 0x100, 32}]; !ok {
+		t.Fatal("uplink was not installed via the DSD")
+	}
+
+	a.Apply(mupDSD(rd, dsdAddr, 1, 2, "::")) // same key, SID became unusable
+	if _, ok := fh.mupUplink[mupUplinkKey{0, endpoint, 0x100, 32}]; ok {
+		t.Error("empty-SID DSD update left the resolved uplink installed")
+	}
+	if len(a.mupDSD) != 0 {
+		t.Errorf("stale DSD entry survived the empty-SID update: %v", a.mupDSD)
+	}
+}
+
+// Same untracked-key rule for DSD: an unusable advertisement for a key
+// never tracked must neither touch existing discoveries nor drive the
+// reconcile sweep's teardown of resolved uplinks.
+func TestApplyMUP_DSDUnusableSIDUntrackedNoop(t *testing.T) {
+	const endpoint = "192.0.2.100"
+	fh := newFakeHeadend()
+	a := newMUPApplier(t, fh)
+	a.Apply(mupDSD("65100:1", "10.0.0.1", 1, 2, "fd00:d:0:1::"))
+	a.Apply(mupT2ST("65100:1", endpoint, 0x100, 32, 1, 2, ""))
+	if _, ok := fh.mupUplink[mupUplinkKey{0, endpoint, 0x100, 32}]; !ok {
+		t.Fatal("uplink was not installed")
+	}
+
+	a.Apply(mupDSD("65100:1", "10.0.0.2", 1, 2, "::")) // different, untracked key
+	if _, ok := fh.mupUplink[mupUplinkKey{0, endpoint, 0x100, 32}]; !ok {
+		t.Error("untracked unusable DSD tore down an unrelated uplink")
+	}
+	if len(a.mupDSD) != 1 {
+		t.Errorf("tracked DSD count = %d, want 1", len(a.mupDSD))
+	}
+}
+
+func TestApplier_EVPNRT2UnusableUpdateReplaces(t *testing.T) {
+	const mac = "aa:bb:cc:00:00:01"
+	cases := []struct {
+		name   string
+		mutate func(*bgp.EVPNRoute)
+	}{
+		{"empty SID", func(r *bgp.EVPNRoute) { r.SRv6SID = "" }},
+		{"unusable SID", func(r *bgp.EVPNRoute) { r.SRv6SID = "::" }},
+		{"RTs match no binding", func(r *bgp.EVPNRoute) { r.RTs = []string{"65000:999"} }},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			a, fh := evpnApplier(t)
+			a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN, EVPN: rt2(mac, "fd00:2:2:d2::")})
+			if _, ok := fh.fdb[fdbKey{100, mac}]; !ok {
+				t.Fatal("RT2 was not installed")
+			}
+
+			replaced := rt2(mac, "fd00:2:2:d2::")
+			c.mutate(replaced)
+			a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN, EVPN: replaced})
+			if _, ok := fh.fdb[fdbKey{100, mac}]; ok {
+				t.Error("unusable RT2 update left the FDB entry installed")
+			}
+			if len(fh.bdPeers) != 0 {
+				t.Errorf("unusable RT2 update left a bd_peer installed: %v", fh.bdPeers)
+			}
+		})
+	}
+}
+
+func TestApplier_EVPNRT3UnusableUpdateReplaces(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*bgp.EVPNRoute)
+	}{
+		{"empty SID", func(r *bgp.EVPNRoute) { r.SRv6SID = "" }},
+		{"unusable SID", func(r *bgp.EVPNRoute) { r.SRv6SID = "::" }},
+		{"RTs match no binding", func(r *bgp.EVPNRoute) { r.RTs = []string{"65000:999"} }},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			a, fh := evpnApplier(t)
+			a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN, EVPN: rt3("fd00:2:2:24::")})
+			if len(fh.bdPeers) != 1 {
+				t.Fatal("RT3 was not installed")
+			}
+
+			replaced := rt3("fd00:2:2:24::")
+			c.mutate(replaced)
+			a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN, EVPN: replaced})
+			if len(fh.bdPeers) != 0 {
+				t.Errorf("unusable RT3 update left the flood bd_peer installed: %v", fh.bdPeers)
+			}
+		})
+	}
+}
+
+// An unusable claim from a DIFFERENT PE (next hop) must not clear the
+// entry the original PE's route still backs -- teardown is confined to
+// the PE that taught us the state.
+func TestApplier_EVPNRT2UnusableFromOtherPEKeepsEntry(t *testing.T) {
+	const mac = "aa:bb:cc:00:00:01"
+	a, fh := evpnApplier(t)
+	installed := rt2(mac, "fd00:2:2:d2::")
+	installed.NextHop = "2001:db8::a"
+	a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN, EVPN: installed})
+	if _, ok := fh.fdb[fdbKey{100, mac}]; !ok {
+		t.Fatal("RT2 was not installed")
+	}
+
+	other := rt2(mac, "")
+	other.NextHop = "2001:db8::b"
+	a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN, EVPN: other})
+	if _, ok := fh.fdb[fdbKey{100, mac}]; !ok {
+		t.Error("unusable claim from another PE cleared the tracked entry")
+	}
+}
+
+// A next-hop move with an unchanged SID refreshes the RT3 ledger's PE, so
+// a later unusable UPDATE from the current PE still tears the flood peer
+// down.
+func TestApplier_EVPNRT3NextHopMoveThenUnusableReplaces(t *testing.T) {
+	a, fh := evpnApplier(t)
+	first := rt3("fd00:2:2:24::")
+	first.NextHop = "2001:db8::a"
+	a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN, EVPN: first})
+	moved := rt3("fd00:2:2:24::")
+	moved.NextHop = "2001:db8::b"
+	a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN, EVPN: moved})
+	if len(fh.bdPeers) != 1 {
+		t.Fatalf("flood peer count = %d, want 1", len(fh.bdPeers))
+	}
+
+	bad := rt3("")
+	bad.NextHop = "2001:db8::b"
+	a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN, EVPN: bad})
+	if len(fh.bdPeers) != 0 {
+		t.Errorf("unusable UPDATE from the current PE left the flood peer installed: %v", fh.bdPeers)
+	}
+}
+
+// A T2ST whose re-advertisement stops matching the MUP import filter is
+// dispatched as a withdraw: the uplink F-TEID entry and its endpoint gate
+// (its only referencing session) must both go.
+func TestApplyMUP_T2STRTMismatchUpdateReplaces(t *testing.T) {
+	const endpoint = "192.0.2.100"
+	fh := newFakeHeadend()
+	vm := vrfbgp.NewManager()
+	if err := vm.Bind(vrfbgp.Binding{VRFName: "vrf-mup", Families: map[bgp.Family]vrfbgp.FamilyPolicy{
+		bgp.FamilyMUPIPv4: {RouteTargets: []vrfbgp.RouteTarget{{RT: testRTDirect, Direction: vrfbgp.DirectionImport}}},
+	}}); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	a := NewApplier(fh, testLocatorManager(t), vm, &fakeFib{}, "LOC1", 65000, zap.NewNop())
+	// The uplink installs under the vrf_id of the binding that imported it,
+	// so match on {endpoint, teid} across instances.
+	uplinks := func() int {
+		n := 0
+		for k := range fh.mupUplink {
+			if k.endpoint == endpoint && k.teid == 0x100 {
+				n++
+			}
+		}
+		return n
+	}
+	a.Apply(mupT2ST("65100:1", endpoint, 0x100, 32, 0, 0, "fd00:3:3:c::"))
+	if uplinks() != 1 {
+		t.Fatal("uplink was not installed")
+	}
+	if _, ok := fh.v4created[endpoint+"/32"]; !ok {
+		t.Fatal("endpoint gate was not installed")
+	}
+
+	replaced := mupT2ST("65100:1", endpoint, 0x100, 32, 0, 0, "fd00:3:3:c::")
+	replaced.MUP.RTs = []string{"100:9999"}
+	a.Apply(replaced)
+	if uplinks() != 0 {
+		t.Error("RT-mismatch T2ST update left the uplink installed")
+	}
+	if len(fh.v4deleted) != 1 || fh.v4deleted[0] != endpoint+"/32" {
+		t.Errorf("RT-mismatch T2ST update left the gate installed; deleted=%v", fh.v4deleted)
+	}
+}
+
+// A session route re-advertised with an unusable own Prefix-SID and no
+// covering discovery must tear down the previously installed session, not
+// re-install it toward the bad SID.
+func TestApplyMUP_SessionUnusableOwnSIDUpdateReplaces(t *testing.T) {
+	t.Run("T1ST", func(t *testing.T) {
+		const ue = "10.1.0.1/32"
+		fh := newFakeHeadend()
+		a := newMUPApplier(t, fh)
+		a.Apply(mupT1ST("65100:1", ue, "172.16.0.1", 256, 9, "fd00:a:0:1::"))
+		if _, ok := fh.v4created[ue]; !ok {
+			t.Fatal("downlink was not installed via the own SID")
+		}
+
+		a.Apply(mupT1ST("65100:1", ue, "172.16.0.1", 256, 9, "::"))
+		if len(fh.v4deleted) != 1 || fh.v4deleted[0] != ue {
+			t.Errorf("unusable own-SID T1ST update left the downlink installed; deleted=%v", fh.v4deleted)
+		}
+	})
+
+	t.Run("T2ST", func(t *testing.T) {
+		const endpoint = "192.0.2.100"
+		fh := newFakeHeadend()
+		a := newMUPApplier(t, fh)
+		a.Apply(mupT2ST("65100:1", endpoint, 0x100, 32, 0, 0, "fd00:3:3:c::"))
+		if _, ok := fh.mupUplink[mupUplinkKey{0, endpoint, 0x100, 32}]; !ok {
+			t.Fatal("uplink was not installed via the own SID")
+		}
+
+		a.Apply(mupT2ST("65100:1", endpoint, 0x100, 32, 0, 0, "fe80::1"))
+		if _, ok := fh.mupUplink[mupUplinkKey{0, endpoint, 0x100, 32}]; ok {
+			t.Error("unusable own-SID T2ST update left the uplink installed")
+		}
+	})
+}
+
+// The RT3 counterpart of the other-PE guard: an unusable claim from a
+// different PE must not clear the flood peer the original PE still backs.
+func TestApplier_EVPNRT3UnusableFromOtherPEKeepsPeer(t *testing.T) {
+	a, fh := evpnApplier(t)
+	installed := rt3("fd00:2:2:24::")
+	installed.NextHop = "2001:db8::a"
+	a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN, EVPN: installed})
+	if len(fh.bdPeers) != 1 {
+		t.Fatal("RT3 was not installed")
+	}
+
+	other := rt3("")
+	other.NextHop = "2001:db8::b"
+	a.Apply(bgp.RouteEvent{Family: bgp.FamilyEVPN, EVPN: other})
+	if len(fh.bdPeers) != 1 {
+		t.Error("unusable claim from another PE cleared the flood peer")
+	}
+}

--- a/pkg/bgp/apply/evpn.go
+++ b/pkg/bgp/apply/evpn.go
@@ -101,6 +101,10 @@ type evpnMcastState struct {
 	bdID  uint16
 	index uint16
 	sid   string
+	// pe is the advertising PE (the route's next hop), recorded so an
+	// unusable re-advertisement tears the flood peer down only when it
+	// comes from the same PE.
+	pe string
 }
 
 // evpnTable holds the EVPN applier's in-memory bookkeeping. peers/fdb/mcast
@@ -223,13 +227,15 @@ func (a *Applier) matchEVPNBD(rts []string) (uint16, bool) {
 	return bdID, true
 }
 
-// isUsableSRv6SID reports whether sid is a routable IPv6 SID. An unspecified
-// (::), IPv4-mapped, or unparseable address would install a black-hole or
-// wrong-target peer, so callers reject the route. The SR Policy decode
-// applies the same guard to transport SIDs.
+// isUsableSRv6SID reports whether sid is a global-scope IPv6 SID a remote
+// PE can be reached at. An unparseable, IPv4-mapped, unspecified (::),
+// loopback (::1), link-local (fe80::/10), or multicast (ff00::/8) address
+// would install a black-hole or wrong-target peer, so callers reject the
+// route -- the same shape the next-hop validator in pkg/bgp enforces.
 func isUsableSRv6SID(sid string) bool {
 	addr, err := netip.ParseAddr(sid)
-	return err == nil && addr.Is6() && !addr.Is4In6() && !addr.IsUnspecified()
+	return err == nil && addr.Is6() && !addr.Is4In6() && !addr.IsUnspecified() &&
+		!addr.IsLoopback() && !addr.IsLinkLocalUnicast() && !addr.IsMulticast()
 }
 
 func (a *Applier) applyEVPN(r *bgp.EVPNRoute, withdraw bool) {
@@ -329,20 +335,35 @@ func (a *Applier) applyEVPNMacIP(r *bgp.EVPNRoute, withdraw bool) {
 		a.logger.Error("parse EVPN MAC", zap.String("mac", r.MAC), zap.Error(err))
 		return
 	}
+	// dropTracked fails closed for an unusable re-advertisement of a
+	// tracked NLRI: a BGP UPDATE is an implicit replace, so a MAC learned
+	// from an earlier advertisement must not keep forwarding over a path
+	// the route no longer backs (same rule as the per-EVI A-D applier).
+	// Teardown is confined to the PE that taught us the MAC (the EVPN
+	// next hop survives route reflection unchanged): an unusable claim
+	// from a different PE must not move or clear another PE's entry.
+	dropTracked := func() {
+		if st, ok := a.evpn.fdb[fk]; ok && st.pe == r.NextHop {
+			a.withdrawEVPNMac(fk, st)
+		}
+	}
 	bdID, ok := a.matchEVPNBD(r.RTs)
 	if !ok {
+		dropTracked()
 		a.logger.Warn("EVPN RT2 matches no bridge-domain binding; dropping",
 			zap.String("mac", r.MAC), zap.Strings("rts", r.RTs))
 		return
 	}
 	if r.SRv6SID == "" {
-		a.logger.Warn("EVPN RT2 has no SRv6 SID; skipping",
+		dropTracked()
+		a.logger.Warn("EVPN RT2 has no SRv6 SID; removing any previous entry",
 			zap.String("mac", r.MAC), zap.String("rd", r.RD))
 		return
 	}
 	// The End.DT2U SID must be a routable IPv6 SID; see isUsableSRv6SID.
 	if !isUsableSRv6SID(r.SRv6SID) {
-		a.logger.Warn("EVPN RT2 SID is not a usable IPv6 SID; skipping",
+		dropTracked()
+		a.logger.Warn("EVPN RT2 SID is not a usable IPv6 SID; removing any previous entry",
 			zap.String("mac", r.MAC), zap.String("sid", r.SRv6SID))
 		return
 	}
@@ -530,19 +551,30 @@ func (a *Applier) applyEVPNInclusiveMulticast(r *bgp.EVPNRoute, withdraw bool) {
 		return
 	}
 
+	// Same implicit-replace rule as RT2, confined to the same advertising
+	// PE: an unusable re-advertisement of a tracked NLRI tears the flood
+	// peer down instead of leaving it stale.
+	dropTracked := func() {
+		if st, ok := a.evpn.mcast[mk]; ok && st.pe == r.NextHop {
+			a.withdrawEVPNMcast(mk, st)
+		}
+	}
 	bdID, ok := a.matchEVPNBD(r.RTs)
 	if !ok {
+		dropTracked()
 		a.logger.Warn("EVPN RT3 matches no bridge-domain binding; dropping",
 			zap.String("rd", r.RD), zap.Strings("rts", r.RTs))
 		return
 	}
 	if r.SRv6SID == "" {
-		a.logger.Warn("EVPN RT3 has no SRv6 SID; skipping", zap.String("rd", r.RD))
+		dropTracked()
+		a.logger.Warn("EVPN RT3 has no SRv6 SID; removing any previous flood peer", zap.String("rd", r.RD))
 		return
 	}
 	// The End.DT2M SID must be a routable IPv6 SID, same guard as RT2.
 	if !isUsableSRv6SID(r.SRv6SID) {
-		a.logger.Warn("EVPN RT3 SID is not a usable IPv6 SID; skipping",
+		dropTracked()
+		a.logger.Warn("EVPN RT3 SID is not a usable IPv6 SID; removing any previous flood peer",
 			zap.String("rd", r.RD), zap.String("sid", r.SRv6SID))
 		return
 	}
@@ -551,6 +583,14 @@ func (a *Applier) applyEVPNInclusiveMulticast(r *bgp.EVPNRoute, withdraw bool) {
 	// If the BD or SID moved, tear the old flood peer down before rebuilding.
 	if prev, ok := a.evpn.mcast[mk]; ok {
 		if prev.bdID == bdID && prev.sid == r.SRv6SID {
+			// The forwarding state is unchanged, but the advertising PE may
+			// have moved (a next-hop change with the same SID); refresh the
+			// ledger so a later unusable UPDATE from the current PE still
+			// matches dropTracked's same-PE confinement.
+			if prev.pe != r.NextHop {
+				prev.pe = r.NextHop
+				a.evpn.mcast[mk] = prev
+			}
 			return
 		}
 		a.withdrawEVPNMcast(mk, prev)
@@ -579,7 +619,7 @@ func (a *Applier) applyEVPNInclusiveMulticast(r *bgp.EVPNRoute, withdraw bool) {
 			zap.Uint16("bd_id", bdID), zap.Error(err))
 		return
 	}
-	a.evpn.mcast[mk] = evpnMcastState{bdID: bdID, index: idx, sid: r.SRv6SID}
+	a.evpn.mcast[mk] = evpnMcastState{bdID: bdID, index: idx, sid: r.SRv6SID, pe: r.NextHop}
 	a.logger.Info("EVPN inclusive multicast (BUM) peer installed",
 		zap.String("rd", r.RD), zap.Uint16("bd_id", bdID), zap.String("sid", r.SRv6SID))
 }

--- a/pkg/bgp/apply/mup.go
+++ b/pkg/bgp/apply/mup.go
@@ -164,10 +164,15 @@ func (a *Applier) applyMUP(fam bgp.Family, r *bgp.MUPRoute, withdraw bool) {
 	sessionRoute := r.Type == bgp.MUPRouteTypeT1ST || r.Type == bgp.MUPRouteTypeT2ST
 	if !withdraw && sessionRoute && !a.mupDefaultAllow && !a.vrfBindings.EmptyForFamily(fam) {
 		if _, _, ok := a.vrfBindings.MatchImportForFamily(r.RTs, fam); !ok {
-			a.logger.Warn("MUP route matches no VRF import RT; dropping",
+			// A BGP UPDATE is an implicit replace: a session route imported
+			// earlier must not survive a re-advertisement whose RTs no
+			// longer match any import filter. Dispatching it as a withdraw
+			// removes exactly this NLRI's tracked state (a no-op when
+			// nothing was installed).
+			a.logger.Warn("MUP route matches no VRF import RT; removing any previous session",
 				zap.String("type", r.Type.String()),
 				zap.String("rd", r.RD), zap.Strings("rts", r.RTs))
-			return
+			withdraw = true
 		}
 	}
 	switch r.Type {
@@ -196,12 +201,22 @@ func (a *Applier) applyMUPISD(r *bgp.MUPRoute, withdraw bool) {
 	key := mupISDKey{rd: r.RD, prefix: r.Prefix}
 	if withdraw {
 		delete(a.mupISD, key)
-	} else {
-		if r.SRv6SID == "" {
-			a.logger.Warn("MUP ISD has no SRv6 SID; ignoring (resolves nothing)",
-				zap.String("prefix", r.Prefix), zap.String("rd", r.RD))
+	} else if !isUsableSRv6SID(r.SRv6SID) {
+		// A BGP UPDATE is an implicit replace: a re-advertisement whose SID
+		// became unusable (empty, all-zero, or otherwise not a routable
+		// IPv6 SID -- including one invalidated on decode per RFC 9252 §7)
+		// must stop this key resolving, exactly like a withdraw -- an
+		// earlier discovery left in place would keep steering sessions
+		// over a path the route no longer backs. An untracked key returns
+		// before the sweep so a flood of unusable advertisements cannot
+		// drive the reconcile-all loop.
+		a.logger.Warn("MUP ISD has no usable SRv6 SID; removing any previous discovery",
+			zap.String("prefix", r.Prefix), zap.String("sid", r.SRv6SID), zap.String("rd", r.RD))
+		if _, tracked := a.mupISD[key]; !tracked {
 			return
 		}
+		delete(a.mupISD, key)
+	} else {
 		if _, exists := a.mupISD[key]; !exists && len(a.mupISD) >= maxMUPDiscoveryRoutes {
 			a.logger.Warn("MUP ISD table full; dropping route",
 				zap.Int("max", maxMUPDiscoveryRoutes),
@@ -225,12 +240,17 @@ func (a *Applier) applyMUPDSD(r *bgp.MUPRoute, withdraw bool) {
 	key := mupDSDKey{rd: r.RD, address: r.Address}
 	if withdraw {
 		delete(a.mupDSD, key)
-	} else {
-		if r.SRv6SID == "" {
-			a.logger.Warn("MUP DSD has no SRv6 SID; ignoring (resolves nothing)",
-				zap.String("address", r.Address), zap.String("rd", r.RD))
+	} else if !isUsableSRv6SID(r.SRv6SID) {
+		// Same implicit-replace rule as ISD: an unusable SID on a
+		// re-advertisement removes the previous discovery, and an
+		// untracked key returns before the reconcile sweep.
+		a.logger.Warn("MUP DSD has no usable SRv6 SID; removing any previous discovery",
+			zap.String("address", r.Address), zap.String("sid", r.SRv6SID), zap.String("rd", r.RD))
+		if _, tracked := a.mupDSD[key]; !tracked {
 			return
 		}
+		delete(a.mupDSD, key)
+	} else {
 		if _, exists := a.mupDSD[key]; !exists && len(a.mupDSD) >= maxMUPDiscoveryRoutes {
 			a.logger.Warn("MUP DSD table full; dropping route",
 				zap.Int("max", maxMUPDiscoveryRoutes),
@@ -356,6 +376,17 @@ func (a *Applier) applyMUPT1ST(r *bgp.MUPRoute, withdraw bool) {
 		a.logger.Warn("MUP T1ST table full; dropping route",
 			zap.Int("max", maxMUPSessions), zap.String("rd", r.RD), zap.String("ue_prefix", r.Prefix))
 		return
+	}
+	if r.SRv6SID != "" && !isUsableSRv6SID(r.SRv6SID) {
+		// An unusable own Prefix-SID (e.g. an all-zero "::") is normalized
+		// to the empty fallback: resolution then goes through discovery
+		// alone, and a session no discovery covers is torn down by the
+		// reconcile instead of being (re-)installed toward the bad SID.
+		a.logger.Warn("MUP session route has an unusable own SRv6 SID; treating as absent",
+			zap.String("rd", r.RD), zap.String("sid", r.SRv6SID))
+		rr := *r
+		rr.SRv6SID = ""
+		r = &rr
 	}
 	st.route = *r
 	a.reconcileMUPT1ST(key)
@@ -628,6 +659,17 @@ func (a *Applier) applyMUPT2ST(fam bgp.Family, r *bgp.MUPRoute, withdraw bool) {
 		a.rekeyMUPT2ST(st, vrfID)
 	} else if st.installedSID == "" {
 		st.instance = vrfID
+	}
+	if r.SRv6SID != "" && !isUsableSRv6SID(r.SRv6SID) {
+		// An unusable own Prefix-SID (e.g. an all-zero "::") is normalized
+		// to the empty fallback: resolution then goes through discovery
+		// alone, and a session no discovery covers is torn down by the
+		// reconcile instead of being (re-)installed toward the bad SID.
+		a.logger.Warn("MUP session route has an unusable own SRv6 SID; treating as absent",
+			zap.String("rd", r.RD), zap.String("sid", r.SRv6SID))
+		rr := *r
+		rr.SRv6SID = ""
+		r = &rr
 	}
 	st.route = *r
 	st.fam = fam

--- a/pkg/bgp/gobgp/e2e_test.go
+++ b/pkg/bgp/gobgp/e2e_test.go
@@ -256,8 +256,14 @@ func TestE2E_VPNv4BgpToXdpEncap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BPF_PROG_TEST_RUN: %v", err)
 	}
-	if ret != bpf.XDP_PASS {
-		t.Fatalf("XDP action = %d, want XDP_PASS (%d) after H.Encaps", ret, bpf.XDP_PASS)
+	// After H.Encaps the program hands the packet to the FIB: on a host
+	// with no route to the SID that is XDP_PASS (kernel forwards), but a
+	// host holding any covering route -- e.g. an RA-learned default on a
+	// LAN -- resolves it and returns XDP_REDIRECT. Both prove the encap
+	// happened; the verdict depends on host state this test does not own.
+	if ret != bpf.XDP_PASS && ret != bpf.XDP_REDIRECT {
+		t.Fatalf("XDP action = %d, want XDP_PASS (%d) or XDP_REDIRECT (%d) after H.Encaps",
+			ret, bpf.XDP_PASS, bpf.XDP_REDIRECT)
 	}
 
 	outerSrc := netip.MustParseAddr(e2eLocatorPfx).As16()


### PR DESCRIPTION
## Summary

Follow-up to #167. A BGP UPDATE is an implicit replace of the whole attribute set, but the MUP and EVPN appliers only honoured that for usable routes: a re-advertisement of a tracked NLRI whose SID became unusable (empty — including one that failed RFC 9252 §7 validation on decode) or whose RTs stopped matching any import filter was skipped with a warning, leaving the previously installed state forwarding over a path the route no longer backs. The L3VPN applier and the per-EVI A-D applier already follow the replace rule; this brings the remaining consumers in line.

- **EVPN RT2** tears down its FDB entry and bd_peer ref, **RT3** its flood bd_peer — confined to the PE (next hop) that taught us the state, so an unusable claim from another PE cannot clear it. The applier's per-NLRI last-write-wins model is unchanged.
- **MUP ISD/DSD** remove the discovery entry and re-reconcile the sessions it resolved, gated on the key being tracked so a flood of unusable advertisements cannot drive the reconcile-all sweep. The unusable check is `isUsableSRv6SID`, which also fixes a pre-existing black hole: an all-zero SID decodes to `"::"` (non-empty), so ISD/DSD previously stored it as a live discovery and steered sessions toward `::`.
- A **MUP session route** (T1ST/T2ST) whose re-advertisement stops matching the import filter is dispatched as a withdraw of its own NLRI.
- The VPNv4 encap E2E test now accepts `XDP_REDIRECT` alongside `XDP_PASS`: the verdict after H.Encaps depends on whether the host resolves the SID (an RA-learned default route flips it), and the packet-content verification is the real assertion.

## Testing

- `go test ./pkg/bgp/...` (replacement regression tests for every branch: ISD/DSD unusable + untracked no-op, T1ST RT-mismatch, RT2/RT3 empty/unusable/RT-mismatch, other-PE guard)
- `go test -exec sudo ./pkg/bgp/gobgp/`
- Interop regression: `evpn-2site` 13/13, `mup-2site` 7/7