### PR TITLE
refactor(bgp): separate VPN selection from application

### DIFF
--- a/docs/design/ja/cplane-plugin.md
+++ b/docs/design/ja/cplane-plugin.md
@@ -103,8 +103,23 @@ cplane manager が共有します。capability / scope の検査は plugin host 
 plugin は全量宣言、built-in は単一キーの増分更新です。behavior claim に伴う
 経路配送と既存 built-in state の撤去は demux が担います。
 
+組み込み VPN の採否と ECMP メンバー選択は、`pkg/bgp/apply/vpn_select.go` の
+副作用のない関数が担います。applier が現在の family の VRF binding から import
+可否を調べ、関数へ渡します。不一致の RT または空 SID を持つ UPDATE は以前の
+path を撤去します。採用しなかった path は applier の候補 table に残らず、
+binding の変更だけで自動再評価される保証はありません。
+
+候補は RD / peer / ADD-PATH ID を区別して保持し、ECMP は SID、RD、peer、
+数値の path ID の順に選びます。同一 SID は一つにまとめ、最大 8 path を反映します。
+保持上限は 4096 prefix、prefix ごとに 32 path です。選ばれなかった候補も
+SR Policy の参照を持ち続け、選択中の path の withdraw で昇格できます。
+group ID、SR Policy の参照、probe、map 書き込みと反映成功状態は applier が管理し、
+選択結果だけで反映済みとは扱いません。plugin の独自の選択規則は plugin が担います。
+
 転送キーは address family と masked prefix です。RD / peer / ADD-PATH ID が
 異なっても、別 owner による同じ転送キーへの宣言は競合します。
+demux と組み込み applier の経路保持には受信した prefix 文字列を使い、headend
+reconciler の書き込み境界で正規化します。
 
 排他は owner ごとです。同じ owner の全量宣言と増分更新は直列化しますが、別 owner
 の full-map scan で同期 BGP callback を待たせません。異なる owner の競合は
@@ -208,6 +223,14 @@ prefix が headend の同じ key を使うので、その prefix の path に cl
 1 本でもあれば built-in へ渡した path をすべて撤去します。通常の path の
 UPDATE でこの抑止を抜けることはできず、最後の claimed path が消えたら
 残っている通常の path を built-in に再配送します。
+この抑止は built-in の import RT / SID 検査より前なので、別 VRF 向けの claimed
+path でも同じ prefix を抑止します。plugin が停止・復元失敗していても claim を
+保持している間は built-in に切り替えません。
+
+claim の解放そのものでは replay しません。ただし、その後に同じ転送 prefix の
+別 path が更新・withdraw されると、保持中の独自 behavior の path も built-in に
+再配送され得ます。独自 path 自身の再広告は必要ありません。built-in はそれを
+通常の service SID として扱い、以前の plugin の転送規則を再現する保証はありません。
 
 claim 取得時の明示的な RIB 再走査では、現在の demux が built-in に配送した
 履歴が無くても withdraw を渡します。前の daemon が pinned map に残した
@@ -590,11 +613,12 @@ service SID として自分の owner で install します。plugin が同じ pr
 - unregister では owner の状態の flush が成功してから claim を解放します
   (lifecycle の節)。解放は取得と対称ではありません。取得時は rib を遡って
   built-in から withdraw しますが、解放時に rib を built-in へ流し直すことは
-  しません。解放後に届く advertise は built-in に配られ、素の service SID と
-  して扱われます。flush が先なので、claim が防いでいた owner 衝突 -- plugin の
+  しません。解放後の advertise や、同じ転送 prefix の別 path の更新・withdraw で
+  再評価された経路は built-in に配られ、通常の service SID として扱われます。
+  flush が先なので、claim が防いでいた owner 衝突 -- plugin の
   書き込みと built-in の install が同じ prefix を奪い合い、誤った意味の entry が
   traffic を運び続けること -- は起きません。ただし flush が保証するのは衝突が
-  無いことまでです。built-in が作るのは既定の単一 SID の H.Encaps で、plugin が
+  無いことまでです。built-in は自身の ECMP / steering / encap 規則で適用し、plugin が
   headend で宣言していたかもしれない mode や segment list や source は再現され
   ません。unregister 後の churn で入る entry は旧 plugin のものと転送の形が違い
   得るという運用上の条件は残ります。rib に残っている経路は次に churn したときに
@@ -636,7 +660,7 @@ service SID として自分の owner で install します。plugin が同じ pr
 |---|---|---|
 | 起動時は store にある behavior claim を demux の start より前に予約する。restore に失敗しても claim を保持し、実装するものが無い codepoint の経路を built-in に渡さず withhold する。 | restore 失敗そのものではこの保証は破れない。 | warning と stats の unrestored 枠を確認する。復旧させないなら forget で claim と store を落とし、map の残存 state は operator が引き受ける。 |
 | claim 取得後の retract は plugin の build と subscribe が済んでから行い、rib にある対象 behavior の経路を built-in から withdraw して最初の宣言より前に prefix を空ける。 | admission など publish 前に失敗した module では retract を行わない。元に戻せない副作用だけが残ることを防ぐ。 | 不要。 |
-| unregister は owner state の flush が成功してから claim を解放する。flush が失敗した場合は claim と store を保持し、plugin を registry に dead として戻す。 | flush は面ごとに進み部分削除を rollback しない。また built-in が後から作るのは既定の単一 SID の H.Encaps で、plugin が宣言していた mode や segment list や source は再現されない。 | flush 失敗は unregister を retry する。unregister 後の churn で転送の形が変わり得ることは運用条件として扱う。 |
+| unregister は owner state の flush が成功してから claim を解放する。flush が失敗した場合は claim と store を保持し、plugin を registry に dead として戻す。 | flush は面ごとに進み部分削除を rollback しない。また built-in は自身の ECMP / steering / encap 規則で適用し、plugin が宣言していた mode や segment list や source は再現されない。 | flush 失敗は unregister を retry する。unregister 後の churn で転送の形が変わり得ることは運用条件として扱う。 |
 | upgrade は behavior claim を新しい集合へ 1 回で置換し、途中で別の plugin に codepoint を取られて巻き戻せなくなる形を避ける。publish 前の失敗は前の集合へ戻す。 | behavior を減らす upgrade では、外した codepoint の claim が旧 state の reconcile より先に返り、その間に届いた経路は built-in に渡る。 | 窓を避けたい場合は unregister で flush してから新しい集合で登録し直す。address は取り直しになる。 |
 | 通常の unregister は in-memory の inventory から owner state を flush してから claim を返す。 | daemon 再起動直後、plugin が local SID を宣言し直す前に unregister すると、前の run の pinned dispatch entry が flush の視界に入らず、残したまま claim が解放される。 | plugin owner の entry は SID 削除 RPC の owner 検査が拒み、force-delete の RPC も無いので、operator が消す手段はいま無い。残存を確認したら、その slot と locator を再利用しないでおく。owner ごとの inventory から flush する形は繰越し。 |
 | manifest と state が揃っていれば、再起動時にも claim を予約して pinned state と built-in の対応を保つ。 | 新規登録や behavior を足す upgrade が manifest の rename 前に persist で失敗すると、その run は instance と claim と state を持って動くが、再起動時は manifest が無いので claim が予約されず、pinned state の codepoint が built-in へ流れる。 | persist 失敗の error を受けたら、登録を retry して manifest を揃えるか、unregister で state ごと flush する。 |

--- a/pkg/bgp/apply/applier.go
+++ b/pkg/bgp/apply/applier.go
@@ -269,51 +269,32 @@ func (a *Applier) applyVPN(vr *bgp.VPNRoute, src bgp.PathSource, withdraw bool) 
 	// received route must carry an RT some VRF imports. A Manager with no
 	// binding under fam keeps the historical default-allow, so vpnv4 /
 	// vpnv6 gate independently as bindings arrive per family.
+	importAllowed := true
 	if !a.vrfBindings.EmptyForFamily(vr.Family) {
-		if _, _, ok := a.vrfBindings.MatchImportForFamily(vr.RTs, vr.Family); !ok {
-			// A replacement UPDATE whose RTs no longer match any import
-			// filter must still replace: a path imported earlier under
-			// different RTs cannot survive it (BGP UPDATEs replace the
-			// whole attribute set).
-			a.logger.Warn("VPN route matches no VRF import RT; dropping",
-				zap.String("prefix", vr.Prefix), zap.Strings("rts", vr.RTs))
-			a.removeVPNPath(dk, pk, vr)
-			return
-		}
+		_, _, importAllowed = a.vrfBindings.MatchImportForFamily(vr.RTs, vr.Family)
 	}
-	if vr.SRv6SID == "" {
-		// A VPN route with no SRv6 service SID cannot be encapsulated --
-		// including one whose SID information failed RFC 9252 §7 validation
-		// on decode. A BGP UPDATE is an implicit replace, so a previously
-		// installed path for this NLRI must not survive the unusable
-		// update: tear it down exactly like a withdraw before skipping.
+	path, diagnostic := selectVPNPath(vr, importAllowed)
+	switch diagnostic {
+	case vpnImportDenied:
+		a.logger.Warn("VPN route matches no VRF import RT; dropping",
+			zap.String("prefix", vr.Prefix), zap.Strings("rts", vr.RTs))
+	case vpnSIDMissing:
 		a.logger.Warn("VPN route has no usable SRv6 SID; removing any installed path",
 			zap.String("prefix", vr.Prefix), zap.String("rd", vr.RD))
+	case vpnSteeringInvalidNextHop:
+		a.logger.Warn("colored VPN route has no parseable next hop; not steering",
+			zap.String("prefix", vr.Prefix), zap.Uint32("color", vr.Color),
+			zap.String("nexthop", vr.NextHop))
+	case vpnSteeringNonIPv6NextHop:
+		a.logger.Warn("colored VPN route next hop is not IPv6; not steering",
+			zap.String("prefix", vr.Prefix), zap.Uint32("color", vr.Color),
+			zap.String("nexthop", vr.NextHop))
+	}
+	if path == nil {
 		a.removeVPNPath(dk, pk, vr)
 		return
 	}
-	// Color-based auto-steering is decided per path: the paths aggregated
-	// onto one prefix can carry different colors, so each contributes its
-	// own SR Policy reference rather than the prefix holding a single one.
-	var want *policyKey
-	if vr.Color != 0 {
-		endpoint, perr := netip.ParseAddr(vr.NextHop)
-		switch {
-		case perr != nil:
-			a.logger.Warn("colored VPN route has no parseable next hop; not steering",
-				zap.String("prefix", vr.Prefix), zap.Uint32("color", vr.Color),
-				zap.String("nexthop", vr.NextHop))
-		case !endpoint.Is6():
-			// SR Policy endpoints are always IPv6, so an IPv4 next hop
-			// could never match. Skip steering and don't reserve a
-			// policy_id that would never resolve.
-			a.logger.Warn("colored VPN route next hop is not IPv6; not steering",
-				zap.String("prefix", vr.Prefix), zap.Uint32("color", vr.Color),
-				zap.String("nexthop", vr.NextHop))
-		default:
-			want = &policyKey{color: vr.Color, endpoint: endpoint}
-		}
-	}
+	want := path.steer
 
 	// Take the new reference before releasing the old one so a re-advertise
 	// that keeps the same target never drops the refcount to zero and lets
@@ -328,10 +309,7 @@ func (a *Applier) applyVPN(vr *bgp.VPNRoute, src bgp.PathSource, withdraw bool) 
 	if replaced != nil {
 		a.srPolicy.unref(replaced.color, replaced.endpoint)
 	}
-	d, ok := a.vpnGroups.upsert(dk, pk, &vpnPath{
-		sid: vr.SRv6SID, reduced: vr.SIDStructure.IsUSID(),
-		steer: want, nh: vr.NextHop,
-	})
+	d, ok := a.vpnGroups.upsert(dk, pk, path)
 	if !ok {
 		// Refused by a bound. The reference just taken would otherwise pin
 		// a policy no path holds.

--- a/pkg/bgp/apply/vpn_select.go
+++ b/pkg/bgp/apply/vpn_select.go
@@ -1,0 +1,112 @@
+package apply
+
+import (
+	"cmp"
+	"fmt"
+	"net/netip"
+	"slices"
+
+	"github.com/takehaya/vinbero/pkg/bgp"
+	"github.com/takehaya/vinbero/pkg/bpf"
+)
+
+type vpnDiagnostic uint8
+
+const (
+	vpnPathOK vpnDiagnostic = iota
+	vpnImportDenied
+	vpnSIDMissing
+	vpnSteeringInvalidNextHop
+	vpnSteeringNonIPv6NextHop
+)
+
+// selectVPNPath evaluates one replacement advertisement. The caller resolves
+// importAllowed from the current family bindings and removes the previous path
+// when the result is nil. Diagnostics for steering leave the path eligible for
+// unsteered forwarding. The caller manages policy references for all retained
+// candidates, including those outside the programmed ECMP set.
+func selectVPNPath(vr *bgp.VPNRoute, importAllowed bool) (*vpnPath, vpnDiagnostic) {
+	if !importAllowed {
+		return nil, vpnImportDenied
+	}
+	// Decode already removes unusable SID information. A replacement without
+	// a service SID must also remove any previously accepted version of the path.
+	if vr.SRv6SID == "" {
+		return nil, vpnSIDMissing
+	}
+	path := &vpnPath{sid: vr.SRv6SID, reduced: vr.SIDStructure.IsUSID(), nh: vr.NextHop}
+	if vr.Color == 0 {
+		return path, vpnPathOK
+	}
+	endpoint, err := netip.ParseAddr(vr.NextHop)
+	if err != nil {
+		return path, vpnSteeringInvalidNextHop
+	}
+	if !endpoint.Is6() {
+		return path, vpnSteeringNonIPv6NextHop
+	}
+	path.steer = &policyKey{color: vr.Color, endpoint: endpoint}
+	return path, vpnPathOK
+}
+
+// selectVPNMembers picks the paths to program, in a deterministic order.
+//
+// Sorting matters beyond tidiness: the data plane selects by hash modulo
+// the member list, so if the order depended on Go's map iteration the same
+// set of paths would spread flows differently on every reconcile and every
+// restart. Sorting by SID pins it.
+//
+// Two paths that resolve to the same SID are the same forwarding outcome
+// (typically one PE re-advertised under a second RD), so they are deduped:
+// programming both would silently double that PE's share of the traffic.
+func selectVPNMembers(paths map[vpnPathKey]*vpnPath) []*vpnPath {
+	type keyed struct {
+		key vpnPathKey
+		p   *vpnPath
+	}
+	all := make([]keyed, 0, len(paths))
+	for k, p := range paths {
+		all = append(all, keyed{k, p})
+	}
+	// SID orders the members, but SortFunc is not stable and two paths can
+	// share a SID, so the key breaks the tie. Without it the survivor of the
+	// dedupe below would depend on map iteration order -- and since the paths
+	// sharing a SID can carry different colors, the programmed policy id
+	// would flip between reconciles and defeat the unchanged-set skip.
+	slices.SortFunc(all, func(a, b keyed) int {
+		if c := cmp.Compare(a.p.sid, b.p.sid); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.key.rd, b.key.rd); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.key.source.Peer.String(), b.key.source.Peer.String()); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.key.source.PathID, b.key.source.PathID)
+	})
+	out := make([]*vpnPath, 0, len(all))
+	for _, k := range all {
+		out = append(out, k.p)
+	}
+	out = slices.CompactFunc(out, func(a, b *vpnPath) bool { return a.sid == b.sid })
+	if len(out) > bpf.EcmpMaxPaths {
+		out = out[:bpf.EcmpMaxPaths]
+	}
+	return out
+}
+
+// memberFingerprint renders the programmed member set so an unchanged
+// reconcile can be skipped. The steering target is part of it: a path whose
+// color changed keeps its SID but must be rewritten with a new policy id.
+func memberFingerprint(ms []*vpnPath) []string {
+	out := make([]string, len(ms))
+	for i, m := range ms {
+		if m.steer == nil {
+			out[i] = fmt.Sprintf("%s>%s;r=%t", m.sid, m.nh, m.reduced)
+			continue
+		}
+		out[i] = fmt.Sprintf("%s@%d/%s>%s;r=%t", m.sid, m.steer.color, m.steer.endpoint, m.nh, m.reduced)
+	}
+	return out
+}

--- a/pkg/bgp/apply/vpn_selection_test.go
+++ b/pkg/bgp/apply/vpn_selection_test.go
@@ -1,0 +1,154 @@
+package apply
+
+import (
+	"fmt"
+	"net/netip"
+	"slices"
+	"testing"
+
+	"go.uber.org/zap"
+
+	v1 "github.com/takehaya/vinbero/api/vinbero/v1"
+	"github.com/takehaya/vinbero/pkg/bgp"
+	"github.com/takehaya/vinbero/pkg/bpf"
+	"github.com/takehaya/vinbero/pkg/vrfbgp"
+)
+
+// Equal SIDs can carry different steering and encapsulation attributes. The
+// numeric ADD-PATH tie-break must pick a stable member without releasing the
+// unselected path's policy reference: that path can be promoted on withdrawal.
+func TestVPNSelectionDuplicateSIDKeepsStandbyPolicy(t *testing.T) {
+	for _, family := range []bgp.Family{bgp.FamilyVPNv4, bgp.FamilyVPNv6} {
+		for _, order := range [][]uint32{{10, 2}, {2, 10}} {
+			t.Run(fmt.Sprintf("%s/%v", family, order), func(t *testing.T) {
+				fh := newFakeHeadend()
+				a := NewApplier(fh, testLocatorManager(t), vrfbgp.NewManager(), &fakeFib{}, "LOC1", 65000, zap.NewNop())
+				prefix := "10.0.0.0/24"
+				triggers := fh.v4created
+				if family == bgp.FamilyVPNv6 {
+					prefix, triggers = "2001:db8:1::/64", fh.v6created
+				}
+				endpoint := netip.MustParseAddr("fd00::1")
+				event := func(id uint32, withdraw bool) bgp.RouteEvent {
+					ev := vpnEvent(prefix, "65000:1", "fd00:1:1:a::", endpoint.String(), withdraw)
+					ev.Family, ev.VPN.Family, ev.Source.PathID = family, family, id
+					if !withdraw {
+						ev.VPN.Color = id
+						if id == 2 {
+							ev.VPN.SIDStructure = bgp.SIDStructure{LocatorBlockLen: 32, LocatorNodeLen: 16, FunctionLen: 16}
+						}
+					} else {
+						ev.VPN.SRv6SID, ev.VPN.NextHop = "", ""
+					}
+					return ev
+				}
+				for _, id := range order {
+					a.Apply(event(id, false))
+				}
+				check := func(id uint32, mode v1.Srv6HeadendBehavior) {
+					t.Helper()
+					trigger := triggers[prefix]
+					if trigger == nil {
+						t.Fatal("missing trigger")
+					}
+					members := fh.ecmpGroups[trigger.GroupId]
+					policyID := a.srPolicy.idOf(id, endpoint)
+					if policyID == 0 || len(members) != 1 || members[0].Entry.PolicyId != policyID || members[0].Entry.Mode != uint8(mode) {
+						t.Fatalf("member does not use path %d's policy %d and mode %v: %+v", id, policyID, mode, members)
+					}
+					if trigger.PolicyId != policyID || trigger.Mode != uint8(mode) {
+						t.Fatalf("fallback differs from the selected member: %+v", trigger)
+					}
+				}
+				check(2, v1.Srv6HeadendBehavior_SRV6_HEADEND_BEHAVIOR_H_ENCAPS_RED)
+				standbyID := a.srPolicy.idOf(10, endpoint)
+				if standbyID == 0 {
+					t.Fatal("deduplicated path lost its policy reference")
+				}
+				a.Apply(event(2, false))
+				a.Apply(event(2, true))
+				check(10, v1.Srv6HeadendBehavior_SRV6_HEADEND_BEHAVIOR_H_ENCAPS)
+				if a.srPolicy.idOf(2, endpoint) != 0 || a.srPolicy.idOf(10, endpoint) != standbyID {
+					t.Fatal("withdraw leaked the selected reference or reallocated the standby policy")
+				}
+				a.Apply(event(10, true))
+				if a.srPolicy.idOf(10, endpoint) != 0 {
+					t.Fatal("last withdrawal leaked a policy reference")
+				}
+			})
+		}
+	}
+}
+
+func TestVPNSelectionCappedMembersPromoteStandby(t *testing.T) {
+	for _, reverse := range []bool{false, true} {
+		t.Run(fmt.Sprintf("reverse=%t", reverse), func(t *testing.T) {
+			fh := newFakeHeadend()
+			a := NewApplier(fh, testLocatorManager(t), vrfbgp.NewManager(), &fakeFib{}, "LOC1", 65000, zap.NewNop())
+			const prefix = "10.0.0.0/24"
+			endpoint := netip.MustParseAddr("fd00::1")
+			var events []bgp.RouteEvent
+			var expected []string
+			for i := 1; i <= bpf.EcmpMaxPaths+2; i++ {
+				sid := fmt.Sprintf("fd00:1:1:%x::", i)
+				ev := vpnEvent(prefix, "65000:1", sid, endpoint.String(), false)
+				ev.Source.PathID, ev.VPN.Color = uint32(i), uint32(i)
+				events = append(events, ev)
+				expected = append(expected, sid)
+			}
+			slices.Sort(expected)
+			if reverse {
+				slices.Reverse(events)
+			}
+			for _, ev := range events {
+				a.Apply(ev)
+			}
+			trigger := fh.v4created[prefix]
+			if trigger == nil {
+				t.Fatal("missing trigger")
+			}
+			if got := groupSIDs(t, fh, trigger.GroupId); !slices.Equal(got, expected[:bpf.EcmpMaxPaths]) {
+				t.Fatalf("selected %v, want %v", got, expected[:bpf.EcmpMaxPaths])
+			}
+			for _, ev := range events {
+				if a.srPolicy.idOf(ev.VPN.Color, endpoint) == 0 {
+					t.Fatalf("tracked path %d lost its reference", ev.Source.PathID)
+				}
+			}
+			withdraw := vpnEvent(prefix, "65000:1", "", endpoint.String(), true)
+			withdraw.Source.PathID = 1
+			a.Apply(withdraw)
+			if got := groupSIDs(t, fh, trigger.GroupId); !slices.Equal(got, expected[1:bpf.EcmpMaxPaths+1]) {
+				t.Fatalf("after withdrawal got %v, want standby promotion to %v", got, expected[1:bpf.EcmpMaxPaths+1])
+			}
+			if a.srPolicy.idOf(1, endpoint) != 0 {
+				t.Fatal("withdrawn path retained its reference")
+			}
+		})
+	}
+}
+
+func TestVPNSelectionInvalidSteeringReplacementKeepsForwarding(t *testing.T) {
+	for _, nextHop := range []string{"", "not-an-address", "192.0.2.1"} {
+		t.Run(nextHop, func(t *testing.T) {
+			fh := newFakeHeadend()
+			a := NewApplier(fh, testLocatorManager(t), vrfbgp.NewManager(), &fakeFib{}, "LOC1", 65000, zap.NewNop())
+			ev := vpnEvent("10.0.0.0/24", "65000:1", "fd00:1:1:a::", "fd00::1", false)
+			ev.VPN.Color = 100
+			a.Apply(ev)
+			endpoint := netip.MustParseAddr("fd00::1")
+			if a.srPolicy.idOf(100, endpoint) == 0 {
+				t.Fatal("initial path did not reserve its policy")
+			}
+			ev.VPN.NextHop = nextHop
+			a.Apply(ev)
+			trigger := fh.v4created[ev.VPN.Prefix]
+			if trigger == nil || trigger.PolicyId != 0 || netip.AddrFrom16(trigger.DstAddr).String() != ev.VPN.SRv6SID {
+				t.Fatalf("replacement did not preserve unsteered forwarding: %+v", trigger)
+			}
+			if a.srPolicy.idOf(100, endpoint) != 0 {
+				t.Fatal("replacement leaked the old steering reference")
+			}
+		})
+	}
+}

--- a/pkg/bgp/apply/vpngroup.go
+++ b/pkg/bgp/apply/vpngroup.go
@@ -1,7 +1,6 @@
 package apply
 
 import (
-	"cmp"
 	"errors"
 	"fmt"
 	"slices"
@@ -236,66 +235,8 @@ func (t *vpnGroupTable) remove(dk vpnDestKey, pk vpnPathKey) (*vpnDest, *policyK
 	return d, released
 }
 
-// members picks the paths to program, in a deterministic order.
-//
-// Sorting matters beyond tidiness: the data plane selects by hash modulo
-// the member list, so if the order depended on Go's map iteration the same
-// set of paths would spread flows differently on every reconcile and every
-// restart. Sorting by SID pins it.
-//
-// Two paths that resolve to the same SID are the same forwarding outcome
-// (typically one PE re-advertised under a second RD), so they are deduped:
-// programming both would silently double that PE's share of the traffic.
 func (d *vpnDest) members() []*vpnPath {
-	type keyed struct {
-		key vpnPathKey
-		p   *vpnPath
-	}
-	all := make([]keyed, 0, len(d.paths))
-	for k, p := range d.paths {
-		all = append(all, keyed{k, p})
-	}
-	// SID orders the members, but SortFunc is not stable and two paths can
-	// share a SID, so the key breaks the tie. Without it the survivor of the
-	// dedupe below would depend on map iteration order -- and since the paths
-	// sharing a SID can carry different colors, the programmed policy id
-	// would flip between reconciles and defeat the unchanged-set skip.
-	slices.SortFunc(all, func(a, b keyed) int {
-		if c := cmp.Compare(a.p.sid, b.p.sid); c != 0 {
-			return c
-		}
-		if c := cmp.Compare(a.key.rd, b.key.rd); c != 0 {
-			return c
-		}
-		if c := cmp.Compare(a.key.source.Peer.String(), b.key.source.Peer.String()); c != 0 {
-			return c
-		}
-		return cmp.Compare(a.key.source.PathID, b.key.source.PathID)
-	})
-	out := make([]*vpnPath, 0, len(all))
-	for _, k := range all {
-		out = append(out, k.p)
-	}
-	out = slices.CompactFunc(out, func(a, b *vpnPath) bool { return a.sid == b.sid })
-	if len(out) > bpf.EcmpMaxPaths {
-		out = out[:bpf.EcmpMaxPaths]
-	}
-	return out
-}
-
-// memberFingerprint renders the programmed member set so an unchanged
-// reconcile can be skipped. The steering target is part of it: a path whose
-// color changed keeps its SID but must be rewritten with a new policy id.
-func memberFingerprint(ms []*vpnPath) []string {
-	out := make([]string, len(ms))
-	for i, m := range ms {
-		if m.steer == nil {
-			out[i] = fmt.Sprintf("%s>%s;r=%t", m.sid, m.nh, m.reduced)
-			continue
-		}
-		out[i] = fmt.Sprintf("%s@%d/%s>%s;r=%t", m.sid, m.steer.color, m.steer.endpoint, m.nh, m.reduced)
-	}
-	return out
+	return selectVPNMembers(d.paths)
 }
 
 // reconcileVPNGroup writes the destination's current member set to the data


### PR DESCRIPTION
VPN route eligibility, steering decisions and ECMP selection were embedded in the applier alongside map writes and resource lifetime management. This extracts those decisions into private pure functions and connects the existing applier immediately. Per-path SR Policy references, group IDs, probes and applied fingerprints remain in the application layer.

Forwarding behavior is preserved: RT/SID replacement rules, numeric ADD-PATH tie-breaking, SID deduplication and member limits are unchanged. New regressions cover duplicate-SID standby promotion with distinct steering/encapsulation attributes, capped-member promotion, and invalid-steering replacements that retain unsteered forwarding. Existing design documentation describes the responsibilities and clarifies that a sibling update or withdrawal can replay retained private paths after claim release.

Validation:
- `go test -race ./pkg/bgp/apply` passes, including all existing tests and the new regressions.
- `go build -buildvcs=false ./...` and `golangci-lint run` pass (0 issues).
- The demux/cplane/runtime/harness race suite passes, including 50,000 WASM update/withdraw cycles (harness package: 587.895 seconds).
- Copilot reviewed all 5 files and generated 0 comments (no suppressed findings). GitHub CI passes **91/91 checks** on `7530b38abeb1fcbeed80469c6eb83ec120f33584`, including both full unit-test runs and both cplane/SR Policy two-site interop runs. No rerun was needed.

Base: `feature/cplane-plugin`, after #174. It adds no route store or public SDK/ABI/BPF changes.


Combined validation: #175, #176 and #177 apply together without conflicts. Their combined code passes the applier/demux/cplane/runtime race suites, build and lint (0 issues). The integration branch is local only; these PRs remain independently based on `feature/cplane-plugin`.
