### PR TITLE
fix(bgp): retain VPN groups until trigger cleanup succeeds

### DIFF
--- a/docs/design/ja/ecmp.md
+++ b/docs/design/ja/ecmp.md
@@ -107,6 +107,15 @@ next hop が 1 本のときは multipath でなく通常の gateway 経路とし
 
 weight は 1 始まりの自然な値で扱い、netlink の境界で変換します。wire 上の `rtnh_hops` は weight より 1 小さいので、そのまま渡すと全 next hop の取り分が 1 つずつ増えてしまいます。境界で吸収しているので、上位のコードはこの差を意識しません。weight 0 は 1 と読みます。取り分ゼロの next hop を意図する呼び出し元は無いためです。
 
+## VPN group の撤去
+
+組み込み VPN の最後の path を撤去するときは、trigger の削除に成功してから
+group を削除し、両方の削除が成功した後に group ID を再利用します。trigger の
+削除失敗時は group と管理情報を残し、古い trigger が別 prefix の group を参照する
+ことを防ぎます。group の削除失敗時も ID は予約したままです。
+失敗した削除は後続の同じ prefix の withdraw で再試行できます。同じ経路が再広告
+された場合は、以前の反映成功記録で省略せず group と trigger を再構築します。
+
 ## 観測 API
 
 `HeadendGroupService` で group を読めます。`vbctl headend-group list` が group 一覧、`vbctl headend-group get <group-id>` が member の segment list と weight と policy と生死を返します。書き込み API はありません。group は BGP 受信経路が経路の到着に応じて書くので、operator が作るものではないためです。

--- a/pkg/bgp/apply/vpn_retirement_test.go
+++ b/pkg/bgp/apply/vpn_retirement_test.go
@@ -1,0 +1,126 @@
+package apply
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/takehaya/vinbero/pkg/bgp"
+	"github.com/takehaya/vinbero/pkg/bpf"
+	"github.com/takehaya/vinbero/pkg/vrfbgp"
+)
+
+type failingVPNRetirement struct {
+	*fakeHeadend
+	triggerErr error
+	groupErr   error
+	dropGroup  bool
+}
+
+func (f *failingVPNRetirement) DeleteHeadendV4(prefix string, owner bpf.OwnerTag) error {
+	if f.triggerErr != nil {
+		return f.triggerErr
+	}
+	return f.fakeHeadend.DeleteHeadendV4(prefix, owner)
+}
+
+func (f *failingVPNRetirement) DeleteHeadendV6(prefix string, owner bpf.OwnerTag) error {
+	if f.triggerErr != nil {
+		return f.triggerErr
+	}
+	return f.fakeHeadend.DeleteHeadendV6(prefix, owner)
+}
+
+func (f *failingVPNRetirement) DeleteEcmpGroup(id uint32, owner bpf.OwnerTag) error {
+	if f.groupErr != nil {
+		if f.dropGroup {
+			delete(f.ecmpGroups, id)
+		}
+		return f.groupErr
+	}
+	return f.fakeHeadend.DeleteEcmpGroup(id, owner)
+}
+
+func TestVPNRetirementFailureReservesGroupUntilCleanup(t *testing.T) {
+	for _, family := range []bgp.Family{bgp.FamilyVPNv4, bgp.FamilyVPNv6} {
+		for _, failure := range []string{"trigger", "owner", "group", "partial-group"} {
+			for _, recovery := range []string{"withdraw", "readvertise"} {
+				t.Run(fmt.Sprintf("%s/%s/%s", family, failure, recovery), func(t *testing.T) {
+					fh := &failingVPNRetirement{fakeHeadend: newFakeHeadend()}
+					a := NewApplier(fh, testLocatorManager(t), vrfbgp.NewManager(), &fakeFib{}, "LOC1", 65000, zap.NewNop())
+					fp := newFakeProber()
+					a.SetProber(fp)
+					prefixes := []string{"10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"}
+					triggers := fh.v4created
+					if family == bgp.FamilyVPNv6 {
+						prefixes, triggers = []string{"2001:db8:1::/64", "2001:db8:2::/64", "2001:db8:3::/64"}, fh.v6created
+					}
+					event := func(index int, withdraw bool) bgp.RouteEvent {
+						ev := vpnEvent(prefixes[index], "65000:1", fmt.Sprintf("fd00:1:1:%x::", index+1), "fd00::1", withdraw)
+						ev.Family, ev.VPN.Family = family, family
+						if withdraw {
+							ev.VPN.SRv6SID, ev.VPN.NextHop = "", ""
+						}
+						return ev
+					}
+					a.Apply(event(0, false))
+					original := triggers[prefixes[0]]
+					if original == nil {
+						t.Fatal("missing original trigger")
+					}
+					id := original.GroupId
+					switch failure {
+					case "trigger":
+						fh.triggerErr = errors.New("trigger delete failed")
+					case "owner":
+						fh.triggerErr = bpf.ErrEntryOwnerMismatch
+					case "group", "partial-group":
+						fh.groupErr = errors.New("group delete failed")
+						fh.dropGroup = failure == "partial-group"
+					}
+					a.Apply(event(0, true))
+					if (len(fh.ecmpGroups[id]) == 0 && !fh.dropGroup) || slices.Contains(a.vpnGroups.freeIDs, id) {
+						t.Fatal("failed retirement released the original group")
+					}
+					if a.vpnGroups.dests[vpnDestKey{family, prefixes[0]}] == nil {
+						t.Fatal("failed retirement lost retry state")
+					}
+					if len(fp.registered[id]) == 0 {
+						t.Fatal("remaining group lost its probe registration")
+					}
+					if (triggers[prefixes[0]] != nil) != (fh.triggerErr != nil) {
+						t.Fatal("trigger deletion did not match the injected failure")
+					}
+					a.Apply(event(1, false))
+					if next := triggers[prefixes[1]]; next == nil || next.GroupId == id {
+						t.Fatalf("new prefix reused a group whose retirement failed: %+v", next)
+					}
+					fh.triggerErr, fh.groupErr = nil, nil
+					if recovery == "readvertise" {
+						a.Apply(event(0, false))
+						if restored := triggers[prefixes[0]]; restored == nil || restored.GroupId != id {
+							t.Fatalf("unchanged readvertisement did not restore its trigger: %+v", restored)
+						}
+						if len(fp.registered[id]) == 0 {
+							t.Fatal("restored group has no probe registration")
+						}
+					}
+					a.Apply(event(0, true))
+					if triggers[prefixes[0]] != nil || len(fh.ecmpGroups[id]) != 0 || len(fp.registered[id]) != 0 {
+						t.Fatal("successful retry left forwarding or probe state")
+					}
+					if a.vpnGroups.dests[vpnDestKey{family, prefixes[0]}] != nil || !slices.Contains(a.vpnGroups.freeIDs, id) {
+						t.Fatal("successful cleanup did not release tracking and group ID")
+					}
+					a.Apply(event(2, false))
+					if next := triggers[prefixes[2]]; next == nil || next.GroupId != id {
+						t.Fatalf("completed retirement did not make its ID reusable: %+v", next)
+					}
+				})
+			}
+		}
+	}
+}

--- a/pkg/bgp/apply/vpngroup.go
+++ b/pkg/bgp/apply/vpngroup.go
@@ -389,9 +389,17 @@ func (a *Applier) reconcileVPNGroup(dk vpnDestKey, d *vpnDest) {
 // returns its group id for reuse.
 func (a *Applier) retireVPNGroup(dk vpnDestKey, d *vpnDest) {
 	owner := a.vpnGroups.groupOwner()
+	// A failed retirement can remove the trigger or part of the group. An
+	// unchanged re-advertisement must rebuild both instead of taking the
+	// installed-fingerprint shortcut over that partially removed state.
+	d.installed = nil
 	if err := a.deleteTrigger(dk.family, dk.prefix); err != nil {
 		a.logger.Error("withdraw VPN trigger",
 			zap.String("prefix", dk.prefix), zap.Error(err))
+		// The old trigger still may reference this ID. Keep the group and
+		// its tracking until a later withdrawal or replacement can retry;
+		// reusing its ID for another prefix would redirect the old traffic.
+		return
 	}
 	// The trigger goes first: while the group still exists a stale trigger
 	// forwards correctly, whereas deleting the group first would leave the


### PR DESCRIPTION
When the last VPN path withdraws and deleting its trigger fails, the applier currently deletes the ECMP group and recycles its ID anyway. A later prefix can receive that ID while the stale trigger still references it. Retirement now retains the group, tracking and ID until trigger cleanup succeeds.

Retirement also invalidates the applied fingerprint before deleting anything. If group cleanup fails after removing the trigger, an unchanged readvertisement now rebuilds the group and trigger instead of incorrectly skipping the write.

Validation:
- New fault-injection regressions reproduce premature ID release and missing-trigger recovery on the previous implementation.
- `go test -race ./pkg/bgp/apply` passes after the fix, covering IPv4/IPv6, trigger deletion errors, owner refusal, group deletion errors, partial group deletion, retry and unchanged readvertisement.
- Tests verify that unrelated prefixes cannot reuse a reserved ID, probe/tracking state is retained until cleanup, and an ID becomes reusable after successful retirement.
- `go build -buildvcs=false ./...` and `golangci-lint run` pass (0 issues).
- Copilot reviewed all 3 files and generated 0 comments (no suppressed findings). GitHub CI passes **91/91 checks** on `664ed860e43df23ccf7c3eb6c7dd2ac572573b74`, including both full unit-test runs and both cplane/SR Policy two-site interop runs. No rerun was needed.

The existing ECMP design document describes the cleanup contract. This is independent of #175 and uses `feature/cplane-plugin` as its base. No periodic retry or restart inventory guarantee is added.


Combined validation: #175, #176 and #177 apply together without conflicts. Their combined code passes the applier/demux/cplane/runtime race suites, build and lint (0 issues). The integration branch is local only; these PRs remain independently based on `feature/cplane-plugin`.
