### PR TITLE
refactor(bgp): separate built-in delivery transitions from callbacks

### DIFF
--- a/docs/design/ja/cplane-plugin.md
+++ b/docs/design/ja/cplane-plugin.md
@@ -119,6 +119,12 @@ current=true の WatchEvent が開き、2 回目は loc-rib を後から attach 
 consumer へ replay してしまいます。そこで daemon が唯一の subscription を
 持ち、consumer は demux (`pkg/bgp/demux`) に登録します。
 
+組み込み consumer の配送履歴は `builtinDeliveryState` が保持し、live 更新、
+withdraw、claim 巻き戻し、RIB 走査結果から順序付きの配送 action を返します。
+`builtinView` は既存の lock 内で状態遷移と callback 呼び出しを直列化します。
+配送履歴は callback へ渡す判断の記録であり、kernel への反映成功を示しません。
+VPN は family / prefix、他 family は NLRI を集約キーとして同じ遷移処理を使います。
+
 demux が引き受ける規則は 2 つです。
 
 - local-origin path を live stream と snapshot replay の両方で落とします。

--- a/pkg/bgp/demux/builtin.go
+++ b/pkg/bgp/demux/builtin.go
@@ -1,87 +1,47 @@
 package demux
 
 import (
-	"sort"
 	"sync"
 
 	"github.com/takehaya/vinbero/pkg/bgp"
 )
 
-type routePath struct {
-	nlri   string
-	source bgp.PathSource
-}
-
-type builtinGroup struct {
-	routes    map[routePath]bgp.RouteEvent
-	delivered map[routePath]bgp.RouteEvent
-}
-
-// builtinView tracks both the paths a built-in was given and those a claim
-// withholds. An UPDATE can change its consumer without a wire withdrawal;
-// that transition needs a synthetic withdrawal of the previous delivery.
-// VPN paths share a headend key across RDs, so one claimed path withholds
-// the whole forwarding prefix. Retained ordinary paths can be replayed
-// when the last claimed path disappears.
+// builtinView serializes delivery-state transitions with their resulting
+// callbacks. Its lock also orders on-demand replay against live events.
 type builtinView struct {
 	mu      sync.Mutex
-	groups  map[string]*builtinGroup
+	state   builtinDeliveryState
 	claimed func(uint16) bool
 	handler bgp.RouteHandler
-	scans   map[*builtinScan]struct{}
 }
 
-// A scan only remembers paths changed during its own lifetime. This also
-// covers removed groups without keeping tombstones for every past route.
 type builtinScan struct {
-	view    *builtinView
-	changed map[routePath]struct{}
+	view  *builtinView
+	state *builtinScanState
 }
 
 func (v *builtinView) beginScan() *builtinScan {
 	v.mu.Lock()
 	defer v.mu.Unlock()
-	if v.scans == nil {
-		v.scans = make(map[*builtinScan]struct{})
-	}
-	s := &builtinScan{view: v, changed: make(map[routePath]struct{})}
-	v.scans[s] = struct{}{}
-	return s
+	return &builtinScan{view: v, state: v.state.beginScan()}
 }
 
 func (s *builtinScan) close() {
 	s.view.mu.Lock()
 	defer s.view.mu.Unlock()
-	delete(s.view.scans, s)
+	s.view.state.endScan(s.state)
 }
 
 func (s *builtinScan) retract(ev bgp.RouteEvent) {
 	v := s.view
 	v.mu.Lock()
 	defer v.mu.Unlock()
-	key := forwardingKey(ev)
-	if _, changed := s.changed[routePath{nlriKey(ev), ev.Source}]; changed {
-		return
-	}
-	if key == "" {
-		if v.claimed(ev.EndpointBehavior) {
-			ev.IsWithdraw = true
-			v.handler(ev)
-		}
-		return
-	}
-	v.updateLocked(ev, true, key, false)
-}
-
-func (v *builtinView) changedLocked(ev bgp.RouteEvent) {
-	for s := range v.scans {
-		s.changed[routePath{nlriKey(ev), ev.Source}] = struct{}{}
-	}
+	v.dispatchLocked(v.state.retract(s.state, ev, v.claimed))
 }
 
 func (d *Demux) newBuiltinView(h bgp.RouteHandler) *builtinView {
 	return &builtinView{
-		groups: make(map[string]*builtinGroup), handler: h,
+		state: newBuiltinDeliveryState(forwardingKey), handler: h,
 		claimed: func(behavior uint16) bool {
 			d.mu.RLock()
 			claims := d.claims
@@ -98,25 +58,13 @@ func forwardingKey(ev bgp.RouteEvent) string {
 	return nlriKey(ev)
 }
 
-// refresh re-evaluates current paths after a claim rollback without replaying
-// an older RIB snapshot over live updates that have already reached this view.
+// refresh uses current paths after a claim rollback, never an older snapshot
+// that could reintroduce a path withdrawn during registration.
 func (v *builtinView) refresh() {
 	v.mu.Lock()
 	defer v.mu.Unlock()
-	keys := make([]string, 0, len(v.groups))
-	for key := range v.groups {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	for _, key := range keys {
-		g := v.groups[key]
-		paths := sortedPaths(g.routes)
-		for _, path := range paths {
-			v.changedLocked(g.routes[path])
-		}
-		if len(paths) > 0 {
-			v.updateLocked(g.routes[paths[0]], false, key, false)
-		}
+	for _, key := range v.state.keys() {
+		v.dispatchLocked(v.state.refresh(key, v.claimed))
 	}
 }
 
@@ -125,7 +73,6 @@ func (v *builtinView) handle(ev bgp.RouteEvent) {
 }
 
 func (v *builtinView) handleWithClaim(ev bgp.RouteEvent, claimedWithdraw bool) {
-	// Serialize the applier's state and delivery with its on-demand replays.
 	// The built-in handler must not recursively invoke this same view.
 	v.mu.Lock()
 	defer v.mu.Unlock()
@@ -133,94 +80,11 @@ func (v *builtinView) handleWithClaim(ev bgp.RouteEvent, claimedWithdraw bool) {
 }
 
 func (v *builtinView) handleLocked(ev bgp.RouteEvent, claimedWithdraw bool) {
-	if ev.Source.IsLocal() {
-		return
-	}
-	key := forwardingKey(ev)
-	if key == "" {
-		if !claimedWithdraw && !v.claimed(ev.EndpointBehavior) {
-			v.handler(ev)
-		}
-		return
-	}
-	v.changedLocked(ev)
-	v.updateLocked(ev, false, key, claimedWithdraw)
+	v.dispatchLocked(v.state.handle(ev, claimedWithdraw, v.claimed))
 }
 
-func (v *builtinView) updateLocked(ev bgp.RouteEvent, retract bool, key string, claimedWithdraw bool) {
-	if retract && !v.claimed(ev.EndpointBehavior) {
-		return
+func (v *builtinView) dispatchLocked(actions []bgp.RouteEvent) {
+	for _, ev := range actions {
+		v.handler(ev)
 	}
-	g := v.groups[key]
-	if g == nil {
-		g = &builtinGroup{routes: make(map[routePath]bgp.RouteEvent), delivered: make(map[routePath]bgp.RouteEvent)}
-		v.groups[key] = g
-	}
-	path := routePath{nlriKey(ev), ev.Source}
-	_, known := g.routes[path]
-	if ev.IsWithdraw {
-		delete(g.routes, path)
-	} else {
-		g.routes[path] = ev
-	}
-	claimed := false
-	for _, route := range g.routes {
-		if v.claimed(route.EndpointBehavior) {
-			claimed = true
-			break
-		}
-	}
-	retracted := false
-	for _, previous := range sortedPaths(g.delivered) {
-		if _, still := g.routes[previous]; still && !claimed {
-			continue
-		}
-		gone := g.delivered[previous]
-		gone.IsWithdraw = true
-		v.handler(gone)
-		if previous == path {
-			retracted = true
-		}
-		delete(g.delivered, previous)
-	}
-	if (retract || claimed && !ev.IsWithdraw) && !retracted {
-		// The applier may have installed this path through an independent
-		// replay. Cleanup cannot depend solely on this view's history.
-		gone := ev
-		gone.IsWithdraw = true
-		v.handler(gone)
-	}
-	if !claimed {
-		if ev.IsWithdraw && !known && !claimedWithdraw {
-			// The applier can own state from an earlier daemon run or an
-			// independent replay. Preserve ordinary withdrawals even when
-			// this view never observed their advertisements.
-			v.handler(ev)
-		}
-		for _, current := range sortedPaths(g.routes) {
-			if _, sent := g.delivered[current]; sent && (ev.IsWithdraw || current != path) {
-				continue
-			}
-			route := g.routes[current]
-			v.handler(route)
-			g.delivered[current] = route
-		}
-	}
-	if len(g.routes) == 0 {
-		delete(v.groups, key)
-	}
-}
-
-func sortedPaths(routes map[routePath]bgp.RouteEvent) []routePath {
-	paths := make([]routePath, 0, len(routes))
-	for path := range routes {
-		paths = append(paths, path)
-	}
-	sort.Slice(paths, func(i, j int) bool {
-		if paths[i].nlri != paths[j].nlri {
-			return paths[i].nlri < paths[j].nlri
-		}
-		return paths[i].source.String() < paths[j].source.String()
-	})
-	return paths
 }

--- a/pkg/bgp/demux/builtin_state.go
+++ b/pkg/bgp/demux/builtin_state.go
@@ -1,0 +1,190 @@
+package demux
+
+import (
+	"sort"
+
+	"github.com/takehaya/vinbero/pkg/bgp"
+)
+
+type routePath struct {
+	nlri   string
+	source bgp.PathSource
+}
+
+type builtinGroup struct {
+	routes    map[routePath]bgp.RouteEvent
+	delivered map[routePath]bgp.RouteEvent
+}
+
+// builtinDeliveryState retains paths and the delivery decisions made for them.
+// Its transitions return ordered route actions; they never invoke an applier.
+// The view serializes transitions and action dispatch under its existing lock.
+// A delivery record is not an acknowledgement of a successful kernel write.
+// The key adapter groups VPN paths by forwarding prefix and other families by NLRI.
+type builtinDeliveryState struct {
+	groups map[string]*builtinGroup
+	key    func(bgp.RouteEvent) string
+	scans  map[*builtinScanState]struct{}
+}
+
+// Scan-local changes protect retraction from old RIB data without permanent
+// tombstones. The view closes the scan after the RIB walk, including on failure.
+type builtinScanState struct {
+	changed map[routePath]struct{}
+}
+
+func newBuiltinDeliveryState(key func(bgp.RouteEvent) string) builtinDeliveryState {
+	return builtinDeliveryState{groups: make(map[string]*builtinGroup), key: key}
+}
+
+func (s *builtinDeliveryState) beginScan() *builtinScanState {
+	if s.scans == nil {
+		s.scans = make(map[*builtinScanState]struct{})
+	}
+	scan := &builtinScanState{changed: make(map[routePath]struct{})}
+	s.scans[scan] = struct{}{}
+	return scan
+}
+
+func (s *builtinDeliveryState) endScan(scan *builtinScanState) {
+	delete(s.scans, scan)
+}
+
+func (s *builtinDeliveryState) changed(ev bgp.RouteEvent) {
+	for scan := range s.scans {
+		scan.changed[routePath{nlriKey(ev), ev.Source}] = struct{}{}
+	}
+}
+
+func (s *builtinDeliveryState) retract(scan *builtinScanState, ev bgp.RouteEvent, isClaimed func(uint16) bool) []bgp.RouteEvent {
+	key := s.key(ev)
+	if _, changed := scan.changed[routePath{nlriKey(ev), ev.Source}]; changed {
+		return nil
+	}
+	if key == "" {
+		if isClaimed(ev.EndpointBehavior) {
+			ev.IsWithdraw = true
+			return []bgp.RouteEvent{ev}
+		}
+		return nil
+	}
+	return s.update(ev, true, key, false, isClaimed)
+}
+
+func (s *builtinDeliveryState) keys() []string {
+	keys := make([]string, 0, len(s.groups))
+	for key := range s.groups {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// refresh re-evaluates one group from current retained paths after a claim
+// rollback. The view dispatches each group's actions before evaluating the next.
+func (s *builtinDeliveryState) refresh(key string, isClaimed func(uint16) bool) []bgp.RouteEvent {
+	g := s.groups[key]
+	paths := sortedPaths(g.routes)
+	for _, path := range paths {
+		s.changed(g.routes[path])
+	}
+	if len(paths) == 0 {
+		return nil
+	}
+	return s.update(g.routes[paths[0]], false, key, false, isClaimed)
+}
+
+func (s *builtinDeliveryState) handle(ev bgp.RouteEvent, claimedWithdraw bool, isClaimed func(uint16) bool) []bgp.RouteEvent {
+	if ev.Source.IsLocal() {
+		return nil
+	}
+	key := s.key(ev)
+	if key == "" {
+		if !claimedWithdraw && !isClaimed(ev.EndpointBehavior) {
+			return []bgp.RouteEvent{ev}
+		}
+		return nil
+	}
+	s.changed(ev)
+	return s.update(ev, false, key, claimedWithdraw, isClaimed)
+}
+
+func (s *builtinDeliveryState) update(ev bgp.RouteEvent, retract bool, key string, claimedWithdraw bool, isClaimed func(uint16) bool) []bgp.RouteEvent {
+	if retract && !isClaimed(ev.EndpointBehavior) {
+		return nil
+	}
+	var actions []bgp.RouteEvent
+	g := s.groups[key]
+	if g == nil {
+		g = &builtinGroup{routes: make(map[routePath]bgp.RouteEvent), delivered: make(map[routePath]bgp.RouteEvent)}
+		s.groups[key] = g
+	}
+	path := routePath{nlriKey(ev), ev.Source}
+	_, known := g.routes[path]
+	if ev.IsWithdraw {
+		delete(g.routes, path)
+	} else {
+		g.routes[path] = ev
+	}
+	claimed := false
+	for _, route := range g.routes {
+		if isClaimed(route.EndpointBehavior) {
+			claimed = true
+			break
+		}
+	}
+	retracted := false
+	for _, previous := range sortedPaths(g.delivered) {
+		if _, still := g.routes[previous]; still && !claimed {
+			continue
+		}
+		gone := g.delivered[previous]
+		gone.IsWithdraw = true
+		actions = append(actions, gone)
+		if previous == path {
+			retracted = true
+		}
+		delete(g.delivered, previous)
+	}
+	if (retract || claimed && !ev.IsWithdraw) && !retracted {
+		// The applier may have installed this path through an independent
+		// replay. Cleanup cannot depend solely on this view's history.
+		gone := ev
+		gone.IsWithdraw = true
+		actions = append(actions, gone)
+	}
+	if !claimed {
+		if ev.IsWithdraw && !known && !claimedWithdraw {
+			// The applier can own state from an earlier daemon run or an
+			// independent replay. Preserve ordinary withdrawals even when
+			// this view never observed their advertisements.
+			actions = append(actions, ev)
+		}
+		for _, current := range sortedPaths(g.routes) {
+			if _, sent := g.delivered[current]; sent && (ev.IsWithdraw || current != path) {
+				continue
+			}
+			route := g.routes[current]
+			actions = append(actions, route)
+			g.delivered[current] = route
+		}
+	}
+	if len(g.routes) == 0 {
+		delete(s.groups, key)
+	}
+	return actions
+}
+
+func sortedPaths(routes map[routePath]bgp.RouteEvent) []routePath {
+	paths := make([]routePath, 0, len(routes))
+	for path := range routes {
+		paths = append(paths, path)
+	}
+	sort.Slice(paths, func(i, j int) bool {
+		if paths[i].nlri != paths[j].nlri {
+			return paths[i].nlri < paths[j].nlri
+		}
+		return paths[i].source.String() < paths[j].source.String()
+	})
+	return paths
+}

--- a/pkg/bgp/demux/builtin_state_test.go
+++ b/pkg/bgp/demux/builtin_state_test.go
@@ -1,0 +1,149 @@
+package demux
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/takehaya/vinbero/pkg/bgp"
+)
+
+func assertDeliveryActions(t *testing.T, got []bgp.RouteEvent, want ...bgp.RouteEvent) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("actions = %+v, want %+v", got, want)
+	}
+}
+
+func withdrawal(ev bgp.RouteEvent) bgp.RouteEvent {
+	ev.IsWithdraw = true
+	return ev
+}
+
+// VPN forwarding keys collapse RDs; other families continue to use the full
+// NLRI identity. Extracting the reducer must not turn their unrelated paths
+// into siblings or change the order of synthetic cleanup actions.
+func TestBuiltinDeliveryStateFamilyGrouping(t *testing.T) {
+	for _, family := range []bgp.Family{bgp.FamilyVPNv4, bgp.FamilyVPNv6, bgp.FamilyEVPN, bgp.FamilyMUPIPv4, bgp.FamilyMUPIPv6} {
+		t.Run(string(family), func(t *testing.T) {
+			state := newBuiltinDeliveryState(forwardingKey)
+			claimed := func(code uint16) bool { return code == 0xFE01 }
+			route := func(rd string, behavior uint16) bgp.RouteEvent {
+				ev := peerEvent(family, "192.0.2.1")
+				ev.EndpointBehavior = behavior
+				prefix := "10.0.0.0/24"
+				if family == bgp.FamilyVPNv6 || family == bgp.FamilyMUPIPv6 {
+					prefix = "2001:db8::/64"
+				}
+				switch family {
+				case bgp.FamilyVPNv4, bgp.FamilyVPNv6:
+					ev.VPN = &bgp.VPNRoute{Family: family, RD: rd, Prefix: prefix}
+				case bgp.FamilyEVPN:
+					ev.EVPN = &bgp.EVPNRoute{Type: bgp.EVPNRouteTypeMACIP, RD: rd, MAC: "02:00:00:00:00:01"}
+				default:
+					ev.MUP = &bgp.MUPRoute{Type: bgp.MUPRouteTypeISD, RD: rd, Prefix: prefix}
+				}
+				return ev
+			}
+			ordinary, private := route("65000:1", 0x0013), route("65000:2", 0xFE01)
+			assertDeliveryActions(t, state.handle(ordinary, false, claimed), ordinary)
+			got := state.handle(private, false, claimed)
+			if ordinary.VPN != nil {
+				assertDeliveryActions(t, got, withdrawal(ordinary), withdrawal(private))
+			} else {
+				assertDeliveryActions(t, got, withdrawal(private))
+			}
+			gone := withdrawal(private)
+			gone.EndpointBehavior = 0
+			got = state.handle(gone, true, claimed)
+			if ordinary.VPN != nil {
+				assertDeliveryActions(t, got, ordinary)
+			} else {
+				assertDeliveryActions(t, got)
+			}
+			assertDeliveryActions(t, state.handle(withdrawal(ordinary), false, claimed), withdrawal(ordinary))
+			if len(state.groups) != 0 {
+				t.Fatal("withdrawals left retained groups")
+			}
+		})
+	}
+}
+
+// Claim release performs no replay by itself, but reevaluating a sibling can
+// deliver the retained private path even when that private path has not changed.
+func TestReleasedClaimReplaysPrivatePathOnSiblingEvent(t *testing.T) {
+	for _, withdraw := range []bool{false, true} {
+		t.Run(map[bool]string{false: "update", true: "withdraw"}[withdraw], func(t *testing.T) {
+			src := &fakeSource{}
+			d := claimedDemux(t, src)
+			var got collector
+			if _, err := d.RegisterBuiltin("applier", nil, got.handle); err != nil {
+				t.Fatal(err)
+			}
+			if err := d.Start(); err != nil {
+				t.Fatal(err)
+			}
+			defer d.Stop()
+			ordinary := vpnEvent("65000:1", "10.0.0.0/24", 0x0013)
+			private := vpnEvent("65000:2", "10.0.0.0/24", 0xFE01)
+			src.emit(ordinary)
+			src.emit(private)
+			before := got.len()
+			d.claims.Release("acl-prefix")
+			if got.len() != before {
+				t.Fatal("claim release replayed without a route event")
+			}
+			if withdraw {
+				ordinary.IsWithdraw, ordinary.EndpointBehavior = true, 0
+			}
+			src.emit(ordinary)
+			if !slices.ContainsFunc(got.got[before:], func(ev bgp.RouteEvent) bool {
+				return !ev.IsWithdraw && ev.EndpointBehavior == private.EndpointBehavior && ev.VPN.RD == private.VPN.RD
+			}) {
+				t.Fatal("sibling event did not replay the retained private path")
+			}
+		})
+	}
+}
+
+func TestBuiltinCleanupDispatchPrecedesPluginUpdate(t *testing.T) {
+	src := &fakeSource{}
+	d := claimedDemux(t, src)
+	var trace []string
+	if _, err := d.Register("plugin", nil, func(bgp.RouteEvent) { trace = append(trace, "plugin") }); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.RegisterBuiltin("applier", nil, func(ev bgp.RouteEvent) {
+		if ev.IsWithdraw {
+			trace = append(trace, "withdraw")
+		} else {
+			trace = append(trace, "advertise")
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer d.Stop()
+	src.emit(vpnEvent("65000:1", "10.0.0.0/24", 0x0013))
+	trace = nil
+	src.emit(vpnEvent("65000:1", "10.0.0.0/24", 0xFE01))
+	if !slices.Equal(trace, []string{"withdraw", "plugin"}) {
+		t.Fatalf("dispatch order = %v, want cleanup before plugin update", trace)
+	}
+}
+
+func TestBuiltinDeliveryScanDoesNotKeepWithdrawnPaths(t *testing.T) {
+	state := newBuiltinDeliveryState(forwardingKey)
+	claimed := func(code uint16) bool { return code == 0xFE01 }
+	scan := state.beginScan()
+	route := vpnEvent("65000:1", "10.0.0.0/24", 0xFE01)
+	state.handle(route, false, claimed)
+	state.handle(withdrawal(route), true, claimed)
+	assertDeliveryActions(t, state.retract(scan, route, claimed))
+	state.endScan(scan)
+	if len(state.groups) != 0 || len(state.scans) != 0 {
+		t.Fatal("completed scan retained withdrawn paths or scan history")
+	}
+}


### PR DESCRIPTION
Built-in delivery mixed path/claim bookkeeping with applier callbacks, which made the transition rules difficult to test independently. This moves the existing rules into a delivery-state reducer that returns ordered route actions. The view executes those actions under the same lock used for live delivery and replay.

VPN forwarding-prefix grouping and full NLRI grouping for other families use the existing key adapter. Scan-local change tracking, unseen pinned-state cleanup, ledger-only withdrawals, claim rollback and callback order are preserved. No additional route store, lock or asynchronous apply status is introduced; delivery decisions are explicitly distinct from successful kernel writes.

Validation:
- All existing demux tests pass unchanged with the race detector.
- New tests cover VPNv4/v6, EVPN and MUP grouping, claim-release replay triggered by sibling updates/withdrawals, cleanup before plugin delivery, and scan-history cleanup.
- `go build -buildvcs=false ./...` and `golangci-lint run` pass (0 issues).
- cplane/runtime/applier race integration passes (cplane: 204.496 seconds).
- Copilot reviewed all 4 files and generated 0 comments (no suppressed findings). GitHub CI passes **91/91 checks** on `be167ac5842ca1988f12e29649f8d940407f6745`, including both full unit-test runs and both cplane/SR Policy two-site interop runs. No rerun was needed.

- A deterministic before/after differential run matches all 32 trace hashes across 64,000 route/claim/replay operations and 854,225 callbacks. This checks sequential delivery equivalence; concurrent replay ordering is covered by the existing race tests.

Base: `feature/cplane-plugin` after #174. This is independent of #175 (VPN selection extraction) and #176 (failed retirement fix); the recommended merge order is #175, #176, then this PR. Existing design documentation describes the implemented responsibilities.


Combined validation: #175, #176 and #177 apply together without conflicts. Their combined code passes the applier/demux/cplane/runtime race suites, build and lint (0 issues). The integration branch is local only; these PRs remain independently based on `feature/cplane-plugin`.
