### PR TITLE
feat(cplane): persist local SID identities across restarts

### DIFF
--- a/cmd/vinberod/main.go
+++ b/cmd/vinberod/main.go
@@ -121,6 +121,21 @@ func run(cliCtx *cli.Context) error {
 	// server and the BGP route applier, so locators / VRF bindings
 	// created over RPC are visible to the BGP receive path.
 	locatorMgr := locator.NewManager()
+	// Reserve durable SID identities before config locators or exporters can
+	// allocate. This also protects their addresses when BGP is disabled.
+	var cplaneStore *cplane.Store
+	if cfg.Setting.CplanePlugins.Enabled {
+		cplaneStore, err = cplane.NewStore(cfg.Setting.CplanePlugins.Path)
+		if err != nil {
+			return fmt.Errorf("open control-plane plugin store: %w", err)
+		}
+		if err := cplane.ReserveStoredLocalSIDs(cplaneStore, locatorMgr); err != nil {
+			return fmt.Errorf("reserve stored local SIDs: %w", err)
+		}
+		if !cliCtx.Bool("bgp-enabled") {
+			lg.Info("control-plane SID reservations retained; BGP is disabled so plugins are not restored")
+		}
+	}
 	vrfBgpMgr := vrfbgp.NewManager()
 
 	// The BGP session is constructed (unstarted) before the RPC server
@@ -416,12 +431,7 @@ func run(cliCtx *cli.Context) error {
 		// off. A daemon that forgot them would come back holding the
 		// entries they wrote -- pinned maps outlive the process -- under
 		// an owner nothing can reconcile any more.
-		var cplaneStore *cplane.Store
-		if cfg.Setting.CplanePlugins.Enabled {
-			cplaneStore, err = cplane.NewStore(cfg.Setting.CplanePlugins.Path)
-			if err != nil {
-				return fmt.Errorf("open control-plane plugin store: %w", err)
-			}
+		if cplaneStore != nil {
 			// Their behaviors are claimed before the first route moves.
 			// Starting the demux replays everything already in the rib, so
 			// a route carrying a stored plugin's codepoint would otherwise

--- a/docs/design/ja/cplane-plugin.md
+++ b/docs/design/ja/cplane-plugin.md
@@ -459,8 +459,8 @@ scope の縮小は plugin の desired-set 宣言だけでは直りません。�
 状態が残ります。そこで登録の時点で host が範囲外の状態を prune します。再登録に
 限らず restore でも走らせます。daemon 再起動をまたいだ状態は pinned map に残って
 おり、狭い scope で restore した plugin はそれを 1 つも触れないためです。
-実装は「まだ許される部分集合を desired set として apply する」形で、残りは
-既存の reconcile が落とします。
+headend はまだ許される部分集合を desired set として apply します。local SID は
+削除する名前だけを選び、残す SID の再作成を伴わずに prune します。
 
 capability を削除した場合も、scope が変わらなくても host がその種類の状態を
 撤去します。権限を失った plugin は空集合の宣言もできないためです。
@@ -468,12 +468,11 @@ local SID を撤去する前に、その SID を参照する広告を withdraw �
 withdraw が失敗した場合は SID と割り当てを維持し、撤去の再試行に備えます。
 撤去が失敗した場合は再登録を成功扱いにせず、エラーを返します。
 
-この prune の視界は同一 run 内の再登録と restore で違います。headend は
-どちらの場合も BPF map を owner ごとに列挙して見えます。local SID と広告は
-in-memory の集合からしか見えないので、再登録では 3 面とも prune され、
-restore 直後は headend しか prune されず、local SID と広告は届かないまま
-残ります (既知の限界の節)。つまり restore を跨いだ scope の縮小は、いまは
-headend に対してだけ認可の失効として働きます。
+headend は BPF map の owner 記録から、local SID は live 集合から列挙します。
+store 有効時は SID inventory が guest より先に live 集合へ復元されるため、
+再宣言前でも scope の縮小によって local SID を撤去できます。広告の集合は
+session の再起動で失われ、plugin の宣言から作り直します。store 無効時や inventory
+導入前の local SID の制約は、既知の限界の節に記載しています。
 
 manifest の format version は 2 です。scope は認可情報なので、scope を持たない
 version 1 の manifest (scope 導入前の build が書いたもの) を空 scope で restore
@@ -634,13 +633,13 @@ service SID として自分の owner で install します。plugin が同じ pr
 
 | 保証されること | 破れる場合 | operator の対処 |
 |---|---|---|
-| 起動時は store にある behavior claim を demux の start より前に予約する。restore に失敗しても claim を保持し、実装するものが無い codepoint の経路を built-in に渡さず withhold する。 | restore 失敗そのものではこの保証は破れない。 | warning と stats の unrestored 枠を確認する。復旧させないなら forget で claim と store を落とし、map の残存 state は operator が引き受ける。 |
+| 起動時は store にある behavior claim を demux の start より前に予約する。restore に失敗しても claim を保持し、実装するものが無い codepoint の経路を built-in に渡さず withhold する。 | restore 失敗そのものではこの保証は破れない。 | warning と stats の unrestored 枠を確認する。復旧させないなら unregister で状態を撤去する。SID inventory の無い plugin を forget する場合は残存 state を operator が引き受ける。 |
 | claim 取得後の retract は plugin の build と subscribe が済んでから行い、rib にある対象 behavior の経路を built-in から withdraw して最初の宣言より前に prefix を空ける。 | admission など publish 前に失敗した module では retract を行わない。元に戻せない副作用だけが残ることを防ぐ。 | 不要。 |
 | unregister は owner state の flush が成功してから claim を解放する。flush が失敗した場合は claim と store を保持し、plugin を registry に dead として戻す。 | flush は面ごとに進み部分削除を rollback しない。また built-in が後から作るのは既定の単一 SID の H.Encaps で、plugin が宣言していた mode や segment list や source は再現されない。 | flush 失敗は unregister を retry する。unregister 後の churn で転送の形が変わり得ることは運用条件として扱う。 |
 | upgrade は behavior claim を新しい集合へ 1 回で置換し、途中で別の plugin に codepoint を取られて巻き戻せなくなる形を避ける。publish 前の失敗は前の集合へ戻す。 | behavior を減らす upgrade では、外した codepoint の claim が旧 state の reconcile より先に返り、その間に届いた経路は built-in に渡る。 | 窓を避けたい場合は unregister で flush してから新しい集合で登録し直す。address は取り直しになる。 |
-| 通常の unregister は in-memory の inventory から owner state を flush してから claim を返す。 | daemon 再起動直後、plugin が local SID を宣言し直す前に unregister すると、前の run の pinned dispatch entry が flush の視界に入らず、残したまま claim が解放される。 | plugin owner の entry は SID 削除 RPC の owner 検査が拒み、force-delete の RPC も無いので、operator が消す手段はいま無い。残存を確認したら、その slot と locator を再利用しないでおく。owner ごとの inventory から flush する形は繰越し。 |
+| store 有効時は、再起動後の再宣言前でも SID inventory から owner state を撤去できる。 | inventory 導入前の SID 名は復元できない。owner 記録も失われた旧 entry は sweep できない。 | inventory を持つ plugin は WASM が読めなくても unregister する。旧 entry の残存を確認した場合は slot と locator を再利用しない。 |
 | manifest と state が揃っていれば、再起動時にも claim を予約して pinned state と built-in の対応を保つ。 | 新規登録や behavior を足す upgrade が manifest の rename 前に persist で失敗すると、その run は instance と claim と state を持って動くが、再起動時は manifest が無いので claim が予約されず、pinned state の codepoint が built-in へ流れる。 | persist 失敗の error を受けたら、登録を retry して manifest を揃えるか、unregister で state ごと flush する。 |
-| claim の寿命は plugin の状態の寿命に合わせる、が全体の不変条件である。 | forget は operator が明示的にこの対応を破る操作で、daemon が消し方を知らない状態を残したまま claim と予約を返す。 | 残存 state を確認し、force-delete の経路が入るまでは返された slot と locator を再利用しない。以後の残存 state は operator が引き受ける (既知の限界の節)。 |
+| claim の寿命は plugin の状態の寿命に合わせる、が全体の不変条件である。 | local SID inventory の無い plugin の forget は、残存 state を残したまま claim と scope の予約を返す。 | 残存 state を確認し、force-delete の経路が入るまでは返された slot と locator を再利用しない。以後の残存 state は operator が引き受ける (既知の限界の節)。 |
 
 ## 広告の所有権
 
@@ -706,32 +705,32 @@ prefix が locator に含まれるかと、VRF に binding があるかは daemo
 prefix や範囲外の slot) は harness でも拒否され、harness が daemon より緩くなる
 のを防ぎます。
 
-restore-time の prune は headend map しか読みません。`LiveSIDs` と `LiveRoutes` は
-in-memory の集合を読むので、再起動直後は空で、前の run が確保した local SID や
-広告経路は prune の視界に入らず orphan になります。local SID は plugin が次に
-local SID を宣言したときの sweep で片付きますが、scope を狭められた plugin は
-その宣言をしなくなるので、それまで残ります。map から owner ごとに読む形へ広げるのは
-繰越しです。
+cplane store が有効な場合、local SID の inventory は guest の起動前に復元され、
+restore-time の scope prune からも見えます。prune は権限を失った SID だけを削除し、
+残す SID の再作成は plugin の再宣言まで待ちます。広告の集合は session とともに
+失われるため、plugin の宣言で作り直します。store が無効な場合や inventory 導入前の
+SID は名前を復元できず、記録された owner から判定できる entry だけが sweep の対象です。
 
 どの surface がどこで追跡され、prune と flush のどこから見えるかをまとめます。
 
 | surface | 追跡場所 | restore 直後の prune | 再登録の prune | unregister の flush |
 |---|---|---|---|---|
-| headend | BPF map。owner ごとに全走査する | 見える。restore-time prune が扱える唯一の surface | 見える | 見える。広告と local SID の後に消し、失敗した entry と lease は残る |
-| local SID | in-memory の live 集合。dispatch entry 自体は pinned map に残り得る | 見えない。再起動直後は空で、前の run の entry は次の宣言時の sweep まで残る | 見える | 通常は見える。restore 直後で再宣言前の pinned entry だけ視界に入らない |
+| headend | BPF map。owner ごとに全走査する | owner 記録がある entry は見える | 見える | 見える。広告と local SID の後に消し、失敗した entry と lease は残る |
+| local SID | cplane store の inventory と、それを復元した live 集合 | store 有効時は見える。削除対象だけを撤去する | 見える | 再宣言前でも inventory から削除できる。予約は map 撤去と inventory 更新の完了後に解放する |
 | 広告 | in-memory の live 集合。wire の所有は gobgp session の producer が追跡する | 見えない。再起動直後は空で、wire 側も session ごと消えている | 見える | 見える。最初に withdraw する |
 | behavior claim | demux の claim registry。withdraw の判定は path 単位の ledger も使う | prune の対象外。起動時に manifest から demux start より先に予約する | prune の対象外。upgrade は instantiate より前に新集合へ置換する | flush の対象外。flush 成功後に解放する |
 | lease | in-memory の lease table。per-entry の owner map が最終 enforcement | headend の owner 走査からは見え、local SID と広告の分は見えない | owner state と一緒に見え、prune に伴って減る | owner state と一緒に消える。消せなかった entry の lease は残す |
 
-forget は claim と store と slot / locator の予約を返しますが、map の状態は
-残します。daemon はそれが何のためのものかを知らないためです。返った slot を
-別の plugin に渡すと、残った dispatch entry の SID がその新しい program へ
-dispatch し、新 program は旧 plugin の aux bytes を自分の layout として読み
-ます。予約が防いでいた取り違えを forget は operator の判断で外すことになり
-ますが、plugin owner の entry は SID 削除 RPC の owner 検査が拒み、force-delete
-の RPC も公開していないので、operator に消す手段がいまはありません。できるのは
-残存 state を確認して、その slot と locator を再利用しないでおくことだけです。
-owner ごとの inventory から強制的に片付ける形と force-delete 経路は繰越しです。
+local SID の inventory を持つ plugin は、WASM が読み込めなくても `unregister` で
+owner の状態を削除できます。inventory が残る間の `forget` は拒否します。
+別 owner の entry との衝突や map 操作の失敗はエラーとして残し、claim と予約を保持します。
+衝突先の正しい owner を確認して解消してから `unregister` を再試行してください。
+
+inventory を持たない unrestored plugin の `forget` は、従来どおり claim と登録と
+slot / locator の scope 予約を返し、map の状態を残します。名前を復元できない旧 SID や
+headend の残存 state はこの操作では削除できません。残存 entry が参照する slot を
+別の program に渡すと旧 aux bytes を新しい layout として読むため、その slot と
+locator を再利用しないでください。inventory の無い state の強制 cleanup は未実装です。
 
 control plane half と data plane half は機構としては結ばれていません。同一
 plugin であることの照合も、slot に program が載っているかの readiness 確認も、
@@ -854,11 +853,11 @@ section は spec 上 instantiate 中に実行されるので、これも guest �
 | 遷移 | behavior claim | store | running registry | map の状態と広告 |
 |---|---|---|---|---|
 | register (新規) | 取得。instantiate 前の失敗では巻き戻す | 成立後に persist | 追加 | 宣言に従って作る |
-| restore 成功 | 起動時の予約のまま | 保持 | 追加 | map は pinned のまま、replay 後の宣言が差分を吸収。広告は宣言で作り直す |
-| restore 失敗 | 保持 (withhold 継続) | 保持 | publish 前の失敗は載せず unrestored に記録。publish 後の persist 失敗は動いたまま unrestored にも載る (下記) | prune 前の失敗は触らない。prune まで進んだ失敗は削除できた分だけ減る。slot と locator の予約は manifest から scope が読めた分だけ残る |
+| restore 成功 | 起動時の予約のまま | 保持 | 追加 | local SID は inventory から予約し、再宣言で同じ address に再作成。広告も宣言で作り直す |
+| restore 失敗 | 保持 (withhold 継続) | 保持 | publish 前の失敗は載せず unrestored に記録。publish 後の persist 失敗は動いたまま unrestored にも載る (下記) | prune 前の失敗は触らない。prune まで進んだ失敗は削除できた分だけ減る。slot と locator の予約は manifest の scope と SID inventory から残る |
 | upgrade (同名再登録) | 新しい集合に置換。外した codepoint は旧 state の reconcile より先に返る | 更新 | instance を入れ替え (owner tag は同一) | 残したまま新 module の宣言が差分を吸収 |
-| unregister | flush 成功後に解放 | flush 成功後に削除を試みる。失敗は warning で unregister は成功のまま | 削除。flush 失敗時は戻す | owner の状態を削除し広告を withdraw |
-| forget (未走行のみ) | 解放 | 削除 | unrestored から削除 | 触らない。slot と locator の予約は返る |
+| unregister | flush 成功後に解放 | flush 成功後に削除を試みる。running plugin の削除失敗は warning。unrestored plugin の削除失敗は error として再試行できる | 削除。flush 失敗時は dead または unrestored として残す | guest が起動しなくても owner の状態を削除し広告を withdraw |
+| forget (未走行かつ local SID inventory 無し) | 解放 | 削除 | unrestored から削除 | 触らない。slot と locator の予約は返る |
 
 部分失敗はそれぞれ次の形で残ります。
 
@@ -880,10 +879,12 @@ section は spec 上 instantiate 中に実行されるので、これも guest �
 - restore と再登録の prune は面ごと・entry ごとに進み、途中の失敗を
   rollback しません。prune で失敗した restore の map は「触らない」では
   なく、削除できた分だけ減った状態で残ります。
-- unregister の flush は広告の withdraw、local SID、headend の順に進み、
-  失敗した面を飛ばして残りも試みます。消せなかった分は lease ごと残り、
-  rollback はしません。plugin は registry に dead として戻るので operator が
-  retry できます。flush 成功後の store 削除の失敗は warning に留めます。
+- unregister の flush は広告の withdraw、local SID、headend の順に進みます。
+  withdraw が失敗した場合は SID と headend の削除へ進みません。それ以降の削除は
+  失敗した面を保持して残りも試み、削除済みの entry は rollback しません。
+  running plugin は dead として戻り、unrestored plugin はそのまま残るので retry
+  できます。running plugin の flush 成功後の store 削除失敗は warning に留めます。
+  unrestored plugin では store 削除の失敗も error とし、claim と管理情報を保持します。
   削除は manifest、module、directory の sync の順に進むので、どの段階で
   失敗したかで結果が分かれます。manifest の unlink 前なら restart が
   plugin を持ち帰り (状態は flush 済みなので空から再開するだけです)、
@@ -939,7 +940,7 @@ stateDiagram-v2
     Stored --> RunningUnrestored: restore の publish 後 persist 失敗
 
     Unrestored --> Running: 再登録または次回 restore の成功で unrestored を消す
-    Unrestored --> Forgotten: forget 成功。claim と store と slot / locator の予約を解放
+    Unrestored --> Forgotten: SID inventory 無しで forget 成功。claim と store と scope の予約を解放
     Unrestored --> ForgetPartial: forget の途中失敗。claim だけ先に失う
 
     RunningUnrestored --> Running: 登録の retry 成功で unrestored を消す
@@ -1040,17 +1041,54 @@ host から呼ばれている間だけ動き、定期処理には tick を使い
 
 ## local SID と daemon 再起動
 
-local SID の名前は host の memory にしかありません。pin された map では
-前回起動の entry が残りますが、どの宣言がその address を入れたのかを
-辿る手段がありません。同じ名前を宣言し直した plugin に同じ address が
-戻る保証は無く、別の address になった古い entry は誰も dispatch せず
-誰も消せないまま残ります。
+`settings.cplane_plugins.enabled: true` では、store の `local-sids/state.json` に
+plugin 名、SID 名、address、locator 定義と function、slot、aux bytes、DecapVRF を
+保存します。`local-sids.version` は inventory の導入済み marker です。
+plugin の manifest や WASM を更新しても、この inventory は置き換えません。
 
-そこで owner ごとに 1 回だけ sweep します。その owner のもので、今回の
-run が入れたのではない entry を消します。address の安定性は 1 回の daemon
-実行の中では保たれ、再起動を跨ぐと保証されません。allocator は空から
-作り直すので、割り当ての順が同じなら偶然同じ address が戻ることもあり、
-それを当てにはできません。
+同じ plugin 名・SID 名・locator の address 構造なら、daemon 再起動後も同じ SID を
+返します。`pin_maps` が無効でも割り当ては維持します。prefix、block / node / function /
+argument の長さ、behavior が変わった locator は拒否します。auto-allocation の範囲変更は
+許可し、既存の function は範囲外になっても予約します。
+
+起動時は config の locator と exporter より先に inventory を読み、address を予約します。
+未登録の locator を自動で作ることはなく、後から同じ定義で登録された際に予約した
+function を先に確保します。通常の SID 解放ではこの予約を返せません。locator の force
+削除は locator 自体を消しても予約を保留として残し、同じ定義での再登録を可能にします。
+BGP 無効時にも予約を保護しますが、その run では plugin の起動と SID の再作成は行いません。
+
+inventory は割り当ての記録であり、map への適用成功の記録ではありません。再起動直後の
+SID は未確認として扱い、plugin が再宣言した際に dispatch を撤去して再作成します。
+この間に短い転送断があります。aux index と VRF ifindex は保存せず、現在の entry と
+VRF から求め直します。locator や VRF が未登録なら宣言をエラーにし、予約を保持します。
+依存を登録した後は plugin の tick または次の宣言で再試行します。
+
+pin 有効時は `sid_function_owner_map` も dispatch とともに保存します。owner 記録が
+無い残存 entry は、復元済み inventory の exact /128 と slot・flavor が一致した場合だけ
+撤去・再作成します。別 owner の entry や内容の異なる ownerless entry は変更しません。
+新規割り当てで既存 entry に衝突した場合は、inventory を作る前に拒否します。
+
+割り当ては inventory の atomic write と file / directory の fsync が成功してから
+map に入れ、map と grant の作成に成功してから guest に address を返します。保存または
+install が失敗した場合は成功通知せず、予約を保持して再試行します。内容変更時は参照広告を
+withdraw し、古い dispatch を撤去してから新しい宣言を保存・適用します。同じ locator 内の
+更新は address を維持します。変更途中の失敗でも割り当ては返しません。
+
+削除は参照広告の withdraw、dispatch と grant の撤去、inventory からの削除を保存・同期、
+allocator の予約解放の順です。途中失敗では追跡を保持します。rename 後の fsync 失敗では
+新版が見えている可能性があるため、失敗を未書き込みとみなして address を返しません。
+同じ内容の宣言がこの run で適用済みなら、map の書き換えも inventory の保存もしません。
+
+inventory と marker が無い旧 store は空の inventory へ移行します。旧 entry から SID 名を
+推測して復元することはありません。記録された owner が一致する未知の entry は最初の宣言時に
+sweep しますが、inventory 導入前に owner 記録も失われた entry は自動削除できません。
+導入後の inventory 欠落、破損、未知の version、重複・不整合な割り当ては daemon の起動を
+拒否します。空として起動すると他の allocator 利用者が使用中の SID を再取得するためです。
+store をバックアップから復旧して再起動してください。store 全体の削除や永続化の無効化は
+割り当ての維持対象外です。複数 daemon で同じ store を共有する構成はサポートしません。
+
+store 無効時の SID 名は memory のみで保持し、address の安定性は一回の daemon 実行内に
+限られます。永続化の有無にかかわらず、data plane half の program の登録は別途必要です。
 
 ## まだ無いもの
 
@@ -1092,8 +1130,7 @@ Copilot が行数上限でレビューできないためです。以後の追加
 - EVPN advertise の producer 分離。exporter と operator の RPC の 2 つの書き手が
   あるのに無名の producer を共有しています。EVPN の withdraw は producer を
   見ずに path を消すので、名前を付けるだけでは足りません。
-- restore-time prune の local SID / 広告への拡張。いまは map から読める headend
-  しか片付けられません。
+- inventory 導入前の local SID と、再起動を跨ぐ広告の追跡。
 - binding 再導出を RPC の critical section の外へ出し、retry と counter を足す。
   いま commitBinding は共有 mutex を握ったまま全 plugin の経路を再広告し、失敗は
   log するだけです。
@@ -1101,7 +1138,7 @@ Copilot が行数上限でレビューできないためです。以後の追加
   reconcile (data plane 境界の節)。
 - control plane half と data plane half の identity と readiness の結合
   (既知の限界の節)。
-- owner ごとの inventory による、forget 後の残存 state の強制 cleanup
+- inventory の無い旧 state に対する強制 cleanup
   (既知の限界の節)。
 - restore 中の persist 失敗で plugin が running と unrestored の両方に載る
   二重表示の解消 (lifecycle の節)。

--- a/docs/design/ja/cplane-plugin.md
+++ b/docs/design/ja/cplane-plugin.md
@@ -1079,8 +1079,9 @@ allocator の予約解放の順です。途中失敗では追跡を保持しま�
 新版が見えている可能性があるため、失敗を未書き込みとみなして address を返しません。
 同じ内容の宣言がこの run で適用済みなら、map の書き換えも inventory の保存もしません。
 
-inventory と marker が無い旧 store は空の inventory へ移行します。旧 entry から SID 名を
-推測して復元することはありません。記録された owner が一致する未知の entry は最初の宣言時に
+inventory と marker が無い旧 store は空の inventory へ移行します。marker 保存前に
+初期化が停止した場合は、snapshot が無ければ初期化を再開し、既存の snapshot があれば
+その内容を保持します。旧 entry から SID 名を推測して復元することはありません。記録された owner が一致する未知の entry は最初の宣言時に
 sweep しますが、inventory 導入前に owner 記録も失われた entry は自動削除できません。
 導入後の inventory 欠落、破損、未知の version、重複・不整合な割り当ては daemon の起動を
 拒否します。空として起動すると他の allocator 利用者が使用中の SID を再取得するためです。

--- a/docs/design/ja/persistence.md
+++ b/docs/design/ja/persistence.md
@@ -8,7 +8,8 @@
 |---|---|---|---|
 | `vinbero.yml` (設定ファイル) | 残る (disk) | 残る | そのまま再ロード |
 | XDP プログラムの attach | **消える** | **消える** | daemon 起動時に `internal.devices` に attach し直す |
-| SID function / aux | **消える** | **残る** (bpffs pin) | default: RPC / CLI で再投入 |
+| SID function / aux | **消える** | **残る** (bpffs pin)。SID owner も保存 | RPC / CLI で再投入。cplane plugin の SID は保存済み割り当てと再宣言で復旧 |
+| cplane plugin の SID 名と割り当て | cplane store 有効なら残る | 同左 | locator 登録より前に予約を復元。dispatch と grant は再宣言で作り直す |
 | Headend v4 / v6 / L2 | **消える** | **残る** (bpffs pin) | default: RPC / CLI で再投入 |
 | BD peer / VLAN table / FDB | **消える** | **残る** (bpffs pin) | default: RPC / CLI (FDB は学習でも埋まる) |
 | Bridge / VRF デバイス | カーネル netlink に残る / netns 単位 | 同左 | `state.json` から **自動 reconcile** |
@@ -22,9 +23,12 @@
 `state.json` に永続化するのは **Network Resource (Bridge / VRF) のみ** です。保存先は `settings.state_path` (デフォルト `/var/lib/vinbero/state.json`)。
 
 control-plane plugin の module と登録内容は別の [cplane store](cplane-plugin.md)
-に保存されます。local SID の名前と address の対応は daemon の memory にのみ保持され、
-daemon 再起動を跨ぐ SID の安定性は保証されません
-([local SID と daemon 再起動](cplane-plugin.md#local-sid-と-daemon-再起動))。
+に保存されます。store 有効時は `local-sids/state.json` に local SID の名前と address、
+locator 定義、dispatch 宣言も保存し、`local-sids.version` で導入済みを記録します。
+`pin_maps` の有無にかかわらず、起動時に割り当てを予約し、plugin の再宣言で同じ SID に
+entry を再作成します。aux index と VRF ifindex はその時点で求め直します。inventory が
+欠落・破損している場合は起動を拒否します。store 無効時の SID 名は memory のみです。
+詳細は [local SID と daemon 再起動](cplane-plugin.md#local-sid-と-daemon-再起動) を参照してください。
 
 `pkg/netresource/manager.go` の ResourceManager が:
 1. 起動時に `state.json` を読み込み、記録されていた Bridge / VRF デバイスを netlink で確認

--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -18,6 +18,7 @@ import (
 // across processes.
 var pinnedControlMaps = []string{
 	"sid_function_map",
+	"sid_function_owner_map", // ownership must survive with the dispatch entries
 	"sid_aux_map",
 	"aux_owner_map", // persistent owner tags paired with sid_aux_map
 	"headend_v4_map",

--- a/pkg/bpf/maps.go
+++ b/pkg/bpf/maps.go
@@ -1358,12 +1358,13 @@ func (m *MapOperations) deleteSidFunctionInternal(triggerPrefix string, requeste
 		}
 	}
 
-	// Read entry first so aux can be cleaned up after successful delete.
-	// The lookup is a longest-prefix match, so it can answer with a broader
-	// entry that merely covers this prefix; the delete below decides whether
-	// what we read was really this prefix's own entry.
-	var entry SidFunctionEntry
-	hasEntry := m.objs.SidFunctionMap.Lookup(key, &entry) == nil
+	// A retry can find an absent entry with a remaining owner row. An LPM
+	// lookup alone would then return a covering SID and revoke its grant
+	// before the delete discovers the miss. Resolve the exact prefix first.
+	auxIndex, err := m.exactSidFunctionAuxIndex(key, false)
+	if err != nil {
+		return err
+	}
 
 	// Withdraw any decap-VRF grant keyed by this aux index first, while the SID
 	// entry and its owner are still present. The grant is keyed by aux index,
@@ -1378,9 +1379,9 @@ func (m *MapOperations) deleteSidFunctionInternal(triggerPrefix string, requeste
 	// delete re-enters this path. Deleting the entry first and failing here
 	// would strand the grant and the index forever, because hasEntry would then
 	// be false on every retry.
-	if hasEntry && entry.AuxIndex != 0 {
-		if err := m.DeleteEndtVRFGrant(uint32(entry.AuxIndex)); err != nil {
-			return fmt.Errorf("withdraw decap-VRF grant for aux %d: %w", entry.AuxIndex, err)
+	if auxIndex != 0 {
+		if err := m.DeleteEndtVRFGrant(uint32(auxIndex)); err != nil {
+			return fmt.Errorf("withdraw decap-VRF grant for aux %d: %w", auxIndex, err)
 		}
 	}
 
@@ -1388,7 +1389,6 @@ func (m *MapOperations) deleteSidFunctionInternal(triggerPrefix string, requeste
 	if err != nil {
 		return fmt.Errorf("failed to delete SID function entry: %w", err)
 	}
-	hasEntry = hasEntry && existed
 	if err := m.sidFunctionOwners.Delete(key); err != nil {
 		return fmt.Errorf("failed to delete SID function owner: %w", err)
 	}
@@ -1398,8 +1398,8 @@ func (m *MapOperations) deleteSidFunctionInternal(triggerPrefix string, requeste
 	// Builtin aux is freed in lockstep with the zero-write so a racing
 	// PluginAuxFree → PluginAuxAlloc cannot reassign idx between the
 	// owner check and the map op.
-	if hasEntry && entry.AuxIndex != 0 {
-		idx := uint32(entry.AuxIndex)
+	if existed && auxIndex != 0 {
+		idx := uint32(auxIndex)
 		_ = m.auxAlloc.WithOwnerLocked(idx, AuxOwnerBuiltin, func() error {
 			var zero SidAuxEntry
 			_ = m.objs.SidAuxMap.Put(idx, &zero)

--- a/pkg/bpf/maps.go
+++ b/pkg/bpf/maps.go
@@ -1144,7 +1144,7 @@ func (m *MapOperations) CreateSidFunction(triggerPrefix string, entry *SidFuncti
 	}
 	// This is an upsert. Whatever aux the superseded entry pointed at goes
 	// unreferenced the moment the new entry lands, so remember it now.
-	supersededAux, err := m.exactSidFunctionAuxIndex(key, alreadyOwned)
+	supersededAux, err := m.exactSidFunctionAuxIndex(key)
 	if err != nil {
 		return err
 	}
@@ -1168,23 +1168,17 @@ func (m *MapOperations) CreateSidFunction(triggerPrefix string, entry *SidFuncti
 // exactSidFunctionAuxIndex returns the aux index of the entry stored under
 // exactly key, or 0 when this prefix has no entry of its own.
 //
-// sid_function_map is an LPM trie, so Lookup answers with a covering entry
-// rather than this one. Two cheap facts settle almost every call: a miss
-// means nothing covers the key, so nothing sits on it either; and when the
-// owner map (a hash on the exact prefix) says this prefix is owned, the
-// entry exists, which makes the longest-prefix answer the exact one. Only
-// an entry with no owner record -- pinned before owner tracking existed --
-// needs the scan.
-func (m *MapOperations) exactSidFunctionAuxIndex(key *LpmKeyV6, alreadyOwned bool) (uint16, error) {
+// sid_function_map is an LPM trie, so Lookup may return a covering entry.
+// An owner row is not proof of an exact dispatch: an interrupted deletion
+// can leave only the owner behind. A hit therefore needs an exact-key scan,
+// both when deleting and when finding the aux superseded by an upsert.
+func (m *MapOperations) exactSidFunctionAuxIndex(key *LpmKeyV6) (uint16, error) {
 	var covering SidFunctionEntry
 	if err := m.objs.SidFunctionMap.Lookup(key, &covering); err != nil {
 		if errors.Is(err, ebpf.ErrKeyNotExist) {
 			return 0, nil
 		}
 		return 0, fmt.Errorf("lookup SID function entry: %w", err)
-	}
-	if alreadyOwned {
-		return covering.AuxIndex, nil
 	}
 	var k LpmKeyV6
 	var e SidFunctionEntry
@@ -1247,7 +1241,7 @@ func (m *MapOperations) CreateSidFunctionWithAuxIndex(triggerPrefix string, entr
 	}
 	// Binding a plugin aux over an entry that carried a builtin one leaves
 	// that builtin index unreferenced, same as any other upsert.
-	supersededAux, err := m.exactSidFunctionAuxIndex(key, alreadyOwned)
+	supersededAux, err := m.exactSidFunctionAuxIndex(key)
 	if err != nil {
 		return err
 	}
@@ -1361,7 +1355,7 @@ func (m *MapOperations) deleteSidFunctionInternal(triggerPrefix string, requeste
 	// A retry can find an absent entry with a remaining owner row. An LPM
 	// lookup alone would then return a covering SID and revoke its grant
 	// before the delete discovers the miss. Resolve the exact prefix first.
-	auxIndex, err := m.exactSidFunctionAuxIndex(key, false)
+	auxIndex, err := m.exactSidFunctionAuxIndex(key)
 	if err != nil {
 		return err
 	}
@@ -1389,9 +1383,6 @@ func (m *MapOperations) deleteSidFunctionInternal(triggerPrefix string, requeste
 	if err != nil {
 		return fmt.Errorf("failed to delete SID function entry: %w", err)
 	}
-	if err := m.sidFunctionOwners.Delete(key); err != nil {
-		return fmt.Errorf("failed to delete SID function owner: %w", err)
-	}
 
 	// Plugin-owned aux is NOT freed here — the plugin path (PluginAuxFree
 	// RPC) owns that lifecycle, so SID delete just unbinds the reference.
@@ -1406,6 +1397,11 @@ func (m *MapOperations) deleteSidFunctionInternal(triggerPrefix string, requeste
 			m.auxAlloc.freeOwnerLocked(idx)
 			return nil
 		})
+	}
+	// Cleanup follows the successful main-map deletion even if removing its
+	// owner row fails. A retry can no longer recover the removed aux index.
+	if err := m.sidFunctionOwners.Delete(key); err != nil {
+		return fmt.Errorf("failed to delete SID function owner: %w", err)
 	}
 	return nil
 }

--- a/pkg/bpf/maps.go
+++ b/pkg/bpf/maps.go
@@ -1173,25 +1173,46 @@ func (m *MapOperations) CreateSidFunction(triggerPrefix string, entry *SidFuncti
 // can leave only the owner behind. A hit therefore needs an exact-key scan,
 // both when deleting and when finding the aux superseded by an upsert.
 func (m *MapOperations) exactSidFunctionAuxIndex(key *LpmKeyV6) (uint16, error) {
+	entry, _, err := m.exactSidFunctionEntry(key)
+	return entry.AuxIndex, err
+}
+
+// GetSidFunctionExact distinguishes an exact SID from a covering LPM entry.
+// A lookup miss avoids a map walk; a hit is verified against the stored key.
+func (m *MapOperations) GetSidFunctionExact(triggerPrefix string) (*SidFunctionEntry, bool, error) {
+	key, err := buildLpmKeyV6(triggerPrefix)
+	if err != nil {
+		return nil, false, err
+	}
+	m.sidLifecycle.Lock()
+	defer m.sidLifecycle.Unlock()
+	entry, exists, err := m.exactSidFunctionEntry(key)
+	if err != nil || !exists {
+		return nil, false, err
+	}
+	return &entry, true, nil
+}
+
+func (m *MapOperations) exactSidFunctionEntry(key *LpmKeyV6) (SidFunctionEntry, bool, error) {
 	var covering SidFunctionEntry
 	if err := m.objs.SidFunctionMap.Lookup(key, &covering); err != nil {
 		if errors.Is(err, ebpf.ErrKeyNotExist) {
-			return 0, nil
+			return SidFunctionEntry{}, false, nil
 		}
-		return 0, fmt.Errorf("lookup SID function entry: %w", err)
+		return SidFunctionEntry{}, false, fmt.Errorf("lookup SID function entry: %w", err)
 	}
 	var k LpmKeyV6
 	var e SidFunctionEntry
 	iter := m.objs.SidFunctionMap.Iterate()
 	for iter.Next(&k, &e) {
 		if k == *key {
-			return e.AuxIndex, nil
+			return e, true, nil
 		}
 	}
 	if err := iter.Err(); err != nil {
-		return 0, fmt.Errorf("scan SID function map: %w", err)
+		return SidFunctionEntry{}, false, fmt.Errorf("scan SID function map: %w", err)
 	}
-	return 0, nil
+	return SidFunctionEntry{}, false, nil
 }
 
 // releaseSupersededBuiltinAux frees the aux index an upsert left behind.

--- a/pkg/bpf/maps_test.go
+++ b/pkg/bpf/maps_test.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/cilium/ebpf"
 	"github.com/takehaya/vinbero/pkg/config"
 )
 
@@ -452,6 +453,88 @@ func TestDeleteMissingSIDPreservesCoveringGrant(t *testing.T) {
 	}
 	if _, ok, err := h.mapOps.GetSidFunctionOwner("fd00:1::1/128"); err != nil || ok {
 		t.Fatalf("stale owner not cleaned: %v %v", ok, err)
+	}
+}
+
+func TestSIDRecreationAfterPartialDeletePreservesCoveringAux(t *testing.T) {
+	for _, pluginAux := range []bool{false, true} {
+		t.Run(fmt.Sprint("plugin aux=", pluginAux), func(t *testing.T) {
+			h := newXDPTestHelper(t)
+			parent := &SidFunctionEntry{Action: 32}
+			if err := h.mapOps.CreateSidFunction("fd00:1::/64", parent, NewSidAuxPluginRaw([]byte{42}), OwnerRPC); err != nil {
+				t.Fatal(err)
+			}
+			key, err := buildLpmKeyV6("fd00:1::1/128")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := h.mapOps.sidFunctionOwners.Put(key, OwnerRPC); err != nil {
+				t.Fatal(err)
+			}
+			child := &SidFunctionEntry{Action: 33}
+			if pluginAux {
+				owner := AuxOwnerPluginTag("endpoint", 33)
+				idx, err := h.mapOps.auxAlloc.AllocOwner(owner)
+				if err != nil {
+					t.Fatal(err)
+				}
+				child.AuxIndex = uint16(idx)
+				err = h.mapOps.CreateSidFunctionWithAuxIndex("fd00:1::1/128", child, owner, OwnerRPC)
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else if err := h.mapOps.CreateSidFunction("fd00:1::1/128", child, nil, OwnerRPC); err != nil {
+				t.Fatal(err)
+			}
+			if got := h.mapOps.auxAlloc.OwnerOf(uint32(parent.AuxIndex)); got != AuxOwnerBuiltin {
+				t.Fatalf("recreation freed covering aux: %q", got)
+			}
+		})
+	}
+}
+
+func TestSIDDeleteOwnerFailureStillReleasesBuiltinAux(t *testing.T) {
+	h := newXDPTestHelper(t)
+	// The collection is pooled across tests. Freeze a dedicated owner map,
+	// not the pool's map, so the next test can still reset its own state.
+	spec, err := LoadBpf()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownerSpec := spec.Maps["sid_function_owner_map"].Copy()
+	ownerSpec.Pinning = ebpf.PinNone
+	owners, err := ebpf.NewMap(ownerSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = owners.Close() })
+	h.mapOps.sidFunctionOwners = newEntryOwnerMap(owners)
+	entry := &SidFunctionEntry{Action: 32}
+	prefix := "fd00:1::1/128"
+	if err := h.mapOps.CreateSidFunction(prefix, entry, NewSidAuxPluginRaw([]byte{42}), OwnerRPC); err != nil {
+		t.Fatal(err)
+	}
+	// Freeze leaves owner lookup readable but makes owner deletion fail,
+	// after the independently writable dispatch map has been deleted.
+	if err := owners.Freeze(); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.mapOps.DeleteSidFunction(prefix, OwnerRPC); err == nil {
+		t.Fatal("frozen owner map accepted deletion")
+	}
+	entries, err := h.mapOps.ListSidFunctions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := entries[prefix]; exists {
+		t.Fatal("dispatch was not removed before owner deletion")
+	}
+	if got := h.mapOps.auxAlloc.OwnerOf(uint32(entry.AuxIndex)); got != "" {
+		t.Fatalf("owner-delete failure leaked builtin aux: %q", got)
+	}
+	fresh := NewMapOperations(h.objs)
+	if got := fresh.auxAlloc.OwnerOf(uint32(entry.AuxIndex)); got != "" {
+		t.Fatalf("leaked aux survived allocator reconstruction: %q", got)
 	}
 }
 

--- a/pkg/bpf/maps_test.go
+++ b/pkg/bpf/maps_test.go
@@ -444,6 +444,9 @@ func TestDeleteMissingSIDPreservesCoveringGrant(t *testing.T) {
 	if err := h.mapOps.sidFunctionOwners.Put(key, OwnerRPC); err != nil {
 		t.Fatal(err)
 	}
+	if entry, exists, err := h.mapOps.GetSidFunctionExact("fd00:1::1/128"); err != nil || exists || entry != nil {
+		t.Fatalf("exact lookup returned covering SID: %v %v %v", entry, exists, err)
+	}
 	if err := h.mapOps.DeleteSidFunction("fd00:1::1/128", OwnerRPC); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/bpf/maps_test.go
+++ b/pkg/bpf/maps_test.go
@@ -419,6 +419,39 @@ func TestBpfLoad_PinMapsRoundTrip(t *testing.T) {
 		if got.AuxIndex == 0 {
 			t.Errorf("aux_index should be preserved across reload, got 0")
 		}
+		owner, ok, err := mapOps.GetSidFunctionOwner("fc00:1::1/128")
+		if err != nil || !ok || owner != OwnerRPC {
+			t.Fatalf("SID owner lost across pinned reload: %q %v %v", owner, ok, err)
+		}
+	}
+}
+
+func TestDeleteMissingSIDPreservesCoveringGrant(t *testing.T) {
+	h := newXDPTestHelper(t)
+	entry := &SidFunctionEntry{Action: 32}
+	if err := h.mapOps.CreateSidFunction("fd00:1::/64", entry, NewSidAuxPluginRaw(nil), OwnerRPC); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.mapOps.PutEndtVRFGrant(uint32(entry.AuxIndex), 99); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate an interrupted delete that removed the /128 before its owner.
+	key, err := buildLpmKeyV6("fd00:1::1/128")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := h.mapOps.sidFunctionOwners.Put(key, OwnerRPC); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.mapOps.DeleteSidFunction("fd00:1::1/128", OwnerRPC); err != nil {
+		t.Fatal(err)
+	}
+	var grant BpfPluginEndtVrf
+	if err := h.objs.PluginEndtVrfMap.Lookup(uint32(entry.AuxIndex), &grant); err != nil {
+		t.Fatalf("missing /128 revoked covering /64 grant: %v", err)
+	}
+	if _, ok, err := h.mapOps.GetSidFunctionOwner("fd00:1::1/128"); err != nil || ok {
+		t.Fatalf("stale owner not cleaned: %v %v", ok, err)
 	}
 }
 

--- a/pkg/cplane/localsid.go
+++ b/pkg/cplane/localsid.go
@@ -89,7 +89,9 @@ type AllocatedSID struct {
 	// declaration coming back would be seen as already-installed and the
 	// grant-less entry would drop forever -- so matches always fails for it
 	// and the next reconcile removes the entry by prefix and reinstalls.
-	stranded bool
+	stranded         bool
+	reservation      locator.SIDReservation
+	recoverOwnerless bool
 }
 
 // matches reports whether an installed SID already carries what a
@@ -111,20 +113,20 @@ func (a AllocatedSID) matches(want LocalSID) bool {
 //
 // Allocation is the one part of the capability surface that is not purely
 // declarative -- an address has to come from somewhere and be remembered.
-// Naming each SID is what keeps even that idempotent within a daemon run:
-// a plugin instance that comes back with no memory declares the same names
-// and is handed the same addresses, because the host still holds them.
-//
-// A daemon restart is different. The names live only here, in memory, so
-// nothing can map a surviving pinned entry back to the name it was
-// installed for. What the host does instead is sweep: the first time an
-// owner declares anything, entries under that owner which this run did not
-// install are removed, and the plugin is handed fresh addresses. Leaving
-// them would be worse -- nothing dispatches to them and nothing can ever
-// remove them again.
+// Naming each SID makes redeclaration idempotent. With a cplane store, the
+// inventory persists these identities and restores their reservations before
+// ordinary allocation. Dispatch and VRF grants are rebuilt on redeclaration;
+// recorded addresses are not proof that forwarding has been installed.
+// Without a store, names live only for this daemon run. Unknown entries whose
+// owner can be verified are swept once; ownerless legacy entries are left alone.
 type LocalSIDSet struct {
-	alloc SIDAllocator
-	sids  SIDFunctionOps
+	// opMu serializes complete reconciles, including inventory snapshots shared
+	// by different owners. mu below only protects short in-memory reads.
+	opMu            sync.Mutex
+	inventory       *sidInventoryStore
+	persistentAlloc PersistentSIDAllocator
+	alloc           SIDAllocator
+	sids            SIDFunctionOps
 	// grants records the VRF a plugin-dispatched decap is allowed into. Nil
 	// leaves a DecapVRF declaration refused rather than silently ungranted --
 	// which would install a SID the data plane then drops on.
@@ -200,6 +202,8 @@ func (l *LocalSIDSet) prepareDesired(desired []LocalSID, quota int) (map[string]
 // before any new one is taken, so a plugin cycling through names does not
 // hold two allocations for one purpose.
 func (l *LocalSIDSet) Apply(owner bpf.OwnerTag, desired []LocalSID, quota int) ([]AllocatedSID, ApplyResult, error) {
+	l.opMu.Lock()
+	defer l.opMu.Unlock()
 	var res ApplyResult
 	if owner == "" {
 		return nil, res, bpf.ErrEmptyOwner
@@ -211,6 +215,9 @@ func (l *LocalSIDSet) Apply(owner bpf.OwnerTag, desired []LocalSID, quota int) (
 
 	if err := l.sweepLeftovers(owner); err != nil {
 		return nil, res, err
+	}
+	if l.inventory != nil {
+		return l.applyPersistent(owner, byName, names)
 	}
 
 	l.mu.Lock()
@@ -422,6 +429,13 @@ func (l *LocalSIDSet) sweepLeftovers(owner bpf.OwnerTag) error {
 // ReleaseOwner removes every local SID an owner holds. It is what
 // unregistering runs.
 func (l *LocalSIDSet) ReleaseOwner(owner bpf.OwnerTag) error {
+	l.opMu.Lock()
+	defer l.opMu.Unlock()
+	if l.inventory != nil {
+		if err := l.sweepLeftovers(owner); err != nil {
+			return err
+		}
+	}
 	l.mu.Lock()
 	current := l.live[owner]
 	names := make([]string, 0, len(current))
@@ -439,7 +453,11 @@ func (l *LocalSIDSet) ReleaseOwner(owner bpf.OwnerTag) error {
 		if !ok {
 			continue
 		}
-		if err := l.remove(owner, got); err != nil {
+		remove := l.remove
+		if l.inventory != nil {
+			remove = l.removePersistent
+		}
+		if err := remove(owner, got); err != nil {
 			// Kept, not forgotten. The address and the name are what a
 			// retry needs, and dropping them here would leave a dispatch
 			// entry in the map that nothing knows about and nothing can
@@ -515,7 +533,7 @@ func (l *LocalSIDSet) OwnsSID(owner bpf.OwnerTag, sid netip.Addr) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	for _, got := range l.live[owner] {
-		if got.SID == sid {
+		if got.SID == sid && (l.inventory == nil || !got.stranded) {
 			return true
 		}
 	}

--- a/pkg/cplane/localsid.go
+++ b/pkg/cplane/localsid.go
@@ -31,6 +31,8 @@ type SIDAllocator interface {
 // *bpf.MapOperations satisfies it.
 type SIDFunctionOps interface {
 	CreateSidFunction(triggerPrefix string, entry *bpf.SidFunctionEntry, aux *bpf.SidAuxEntry, owner bpf.OwnerTag) error
+	// Delete must check ownership and withdraw the exact entry's VRF grant
+	// before freeing its aux index, including on retries after partial deletion.
 	DeleteSidFunction(triggerPrefix string, requester bpf.OwnerTag) error
 	ListSidFunctions() (map[string]*bpf.SidFunctionEntry, error)
 	GetSidFunctionOwner(triggerPrefix string) (bpf.OwnerTag, bool, error)

--- a/pkg/cplane/localsid_persistent.go
+++ b/pkg/cplane/localsid_persistent.go
@@ -1,0 +1,305 @@
+package cplane
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/takehaya/vinbero/pkg/bpf"
+)
+
+func (l *LocalSIDSet) enablePersistence(store *Store) error {
+	if store == nil {
+		return nil
+	}
+	records, err := store.sids.load()
+	if err != nil {
+		return err
+	}
+	alloc, ok := l.alloc.(PersistentSIDAllocator)
+	if !ok && (l.alloc != nil || len(records) > 0) {
+		return fmt.Errorf("local SID inventory requires a persistent allocator")
+	}
+	if err := ReserveStoredLocalSIDs(store, alloc); err != nil {
+		return err
+	}
+	l.inventory, l.persistentAlloc = store.sids, alloc
+	for _, r := range records {
+		if l.live[r.Owner] == nil {
+			l.live[r.Owner] = make(map[string]AllocatedSID)
+		}
+		l.live[r.Owner][r.Name] = AllocatedSID{
+			Name: r.Name, SID: r.SID, Locator: r.Locator.Name, slot: r.Slot,
+			auxRaw: append([]byte(nil), r.AuxRaw...), decapVRF: r.DecapVRF,
+			reservation: r.reservation(), stranded: true, recoverOwnerless: true,
+		}
+	}
+	return nil
+}
+
+func (l *LocalSIDSet) inventoryRecords(skipOwner bpf.OwnerTag, skipName string) []sidRecord {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	var records []sidRecord
+	for owner, held := range l.live {
+		for name, got := range held {
+			if owner == skipOwner && name == skipName {
+				continue
+			}
+			records = append(records, sidRecord{
+				Owner: owner, Name: name, SID: got.SID, Locator: got.reservation.Locator,
+				Function: got.reservation.Function, Slot: got.slot,
+				AuxRaw: got.auxRaw, DecapVRF: got.decapVRF,
+			})
+		}
+	}
+	return records
+}
+
+// Keep the candidate in memory even if saving fails: rename may already have
+// happened. A retry persists the allocation before installing its entry.
+func (l *LocalSIDSet) saveSID(owner bpf.OwnerTag, got AllocatedSID) error {
+	l.mu.Lock()
+	if l.live[owner] == nil {
+		l.live[owner] = make(map[string]AllocatedSID)
+	}
+	l.live[owner][got.Name] = got
+	l.mu.Unlock()
+	return l.inventory.save(l.inventoryRecords("", ""))
+}
+
+func (l *LocalSIDSet) applyPersistent(owner bpf.OwnerTag, byName map[string]LocalSID, names []string) ([]AllocatedSID, ApplyResult, error) {
+	var res ApplyResult
+	l.mu.Lock()
+	var stale []AllocatedSID
+	for name, got := range l.live[owner] {
+		if _, ok := byName[name]; !ok {
+			stale = append(stale, got)
+		}
+	}
+	l.mu.Unlock()
+	sort.Slice(stale, func(i, j int) bool { return stale[i].Name < stale[j].Name })
+	for _, got := range stale {
+		if err := l.removePersistent(owner, got); err != nil {
+			return nil, res, err
+		}
+		res.Pruned++
+	}
+	sort.Strings(names)
+	out := make([]AllocatedSID, 0, len(names))
+	for _, name := range names {
+		want := byName[name]
+		l.mu.Lock()
+		got, held := l.live[owner][name]
+		l.mu.Unlock()
+		if held && got.Locator != want.Locator {
+			if err := l.removePersistent(owner, got); err != nil {
+				return nil, res, err
+			}
+			held = false
+		}
+		if l.persistentAlloc == nil {
+			return nil, res, fmt.Errorf("local SID inventory requires a persistent allocator")
+		}
+		sid, reservation, err := l.persistentAlloc.AllocateReservedSID(sidReservationKey(owner, name), want.Locator)
+		if err != nil {
+			return nil, res, fmt.Errorf("local sid %q: reserve: %w", name, err)
+		}
+		if held && got.matches(want) {
+			out = append(out, got)
+			res.Updated++
+			continue
+		}
+		if !held {
+			// Do not persist a new claim over an existing dispatch. Otherwise
+			// an error followed by a restart could turn that new record into
+			// authority to recover somebody else's ownerless entry.
+			if err := l.checkSIDAvailable(sid.String() + "/128"); err != nil {
+				l.persistentAlloc.ReleaseReservedSID(reservation.Key)
+				return nil, res, err
+			}
+		}
+		if held {
+			// The previous durable record remains authoritative while its
+			// entry is removed. Only then may the replacement be persisted.
+			l.markSIDUnconfirmed(owner, got)
+			if err := l.removePersistentEntry(owner, got); err != nil {
+				return nil, res, err
+			}
+		}
+		pending := AllocatedSID{Name: name, SID: sid, Locator: want.Locator,
+			slot: want.Slot, auxRaw: append([]byte(nil), want.AuxRaw...), decapVRF: want.DecapVRF,
+			reservation: reservation, stranded: true,
+		}
+		if err := l.saveSID(owner, pending); err != nil {
+			return nil, res, err
+		}
+		// A partial map write can leave dispatch without its owner row. The
+		// durable record now authorizes recovery of this install attempt too.
+		pending.recoverOwnerless = true
+		l.mu.Lock()
+		l.live[owner][name] = pending
+		l.mu.Unlock()
+		// Rebuild using the current map's aux index and current VRF resolver.
+		// Even an installed record loaded from disk is unconfirmed this run.
+		auxIndex, err := l.install(owner, sid, want)
+		if err != nil {
+			return nil, res, err
+		}
+		installed := pending
+		installed.auxIndex = auxIndex
+		installed.stranded = false
+		installed.recoverOwnerless = false
+		l.mu.Lock()
+		l.live[owner][name] = installed
+		l.mu.Unlock()
+		out = append(out, installed)
+		if held {
+			res.Updated++
+		} else {
+			res.Created++
+		}
+	}
+	return out, res, nil
+}
+
+func (l *LocalSIDSet) checkSIDAvailable(prefix string) error {
+	entries, err := l.sids.ListSidFunctions()
+	if err != nil {
+		return err
+	}
+	_, exists := entries[prefix]
+	_, owned, err := l.sids.GetSidFunctionOwner(prefix)
+	if err != nil {
+		return err
+	}
+	if exists || owned {
+		return fmt.Errorf("local sid %s is already present: %w", prefix, bpf.ErrEntryOwnerMismatch)
+	}
+	return nil
+}
+
+func (l *LocalSIDSet) removePersistentEntry(owner bpf.OwnerTag, got AllocatedSID) error {
+	if l.sids == nil {
+		return fmt.Errorf("local sid %q: SID maps unavailable for cleanup", got.Name)
+	}
+	prefix := got.SID.String() + "/128"
+	entries, err := l.sids.ListSidFunctions()
+	if err != nil {
+		return err
+	}
+	entry, exists := entries[prefix]
+	actual, owned, err := l.sids.GetSidFunctionOwner(prefix)
+	if err != nil {
+		return err
+	}
+	if owned && actual != owner {
+		return fmt.Errorf("local sid %q at %s: %w", got.Name, prefix, bpf.ErrEntryOwnerMismatch)
+	}
+	if exists && !owned {
+		// Older pinned maps may have no owner metadata. Only a recovered
+		// inventory record may identify such an entry, and its dispatch
+		// must agree with the last persisted declaration.
+		if entry == nil || !got.recoverOwnerless {
+			return fmt.Errorf("local sid %q: %w", got.Name, bpf.ErrEntryOwnerMismatch)
+		}
+		plain := *entry
+		plain.AuxIndex = 0
+		if plain != (bpf.SidFunctionEntry{Action: uint8(got.slot)}) {
+			return fmt.Errorf("local sid %q: unowned dispatch differs from inventory", got.Name)
+		}
+	}
+	if !owned && !exists {
+		return nil
+	}
+	// Never use a persisted aux index. A live exact entry's index belongs to
+	// this owner; an absent /128 must not touch a covering entry's grant.
+	if exists && entry != nil && entry.AuxIndex != 0 && l.grants != nil {
+		if err := l.grants.DeleteEndtVRFGrant(uint32(entry.AuxIndex)); err != nil {
+			return err
+		}
+	}
+	if err := l.sids.DeleteSidFunction(prefix, owner); err != nil {
+		return fmt.Errorf("local sid %q: remove %s: %w", got.Name, prefix, err)
+	}
+	return nil
+}
+
+func (l *LocalSIDSet) removePersistent(owner bpf.OwnerTag, got AllocatedSID) error {
+	l.markSIDUnconfirmed(owner, got)
+	if err := l.removePersistentEntry(owner, got); err != nil {
+		return err
+	}
+	if err := l.inventory.save(l.inventoryRecords(owner, got.Name)); err != nil {
+		return err
+	}
+	l.persistentAlloc.ReleaseReservedSID(got.reservation.Key)
+	l.mu.Lock()
+	delete(l.live[owner], got.Name)
+	l.mu.Unlock()
+	return nil
+}
+
+func (l *LocalSIDSet) markSIDUnconfirmed(owner bpf.OwnerTag, got AllocatedSID) {
+	got.stranded, got.auxIndex = true, 0
+	l.mu.Lock()
+	l.live[owner][got.Name] = got
+	l.mu.Unlock()
+}
+
+func (l *LocalSIDSet) inventoryScopes() map[string]Scope {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make(map[string]Scope)
+	if l.inventory == nil {
+		return out
+	}
+	for owner, held := range l.live {
+		plugin, _, _ := bpf.ParsePluginOwnerTag(string(owner))
+		scope := Scope{}
+		for _, got := range held {
+			scope.Locators = append(scope.Locators, got.Locator)
+			scope.EndpointSlots = append(scope.EndpointSlots, got.slot)
+			if got.decapVRF != "" {
+				scope.VRFs = append(scope.VRFs, got.decapVRF)
+			}
+		}
+		out[plugin.Bundle] = scope
+	}
+	return out
+}
+
+// PruneExcept only retires removed names; retained records are not declarations
+// to reinstall. Restore-time scope pruning can therefore complete while a kept
+// SID is still waiting for its locator or VRF to be registered.
+func (l *LocalSIDSet) PruneExcept(owner bpf.OwnerTag, keep []LocalSID) (ApplyResult, error) {
+	l.opMu.Lock()
+	defer l.opMu.Unlock()
+	var res ApplyResult
+	names := make(map[string]bool, len(keep))
+	for _, s := range keep {
+		names[s.Name] = true
+	}
+	l.mu.Lock()
+	var stale []AllocatedSID
+	for name, got := range l.live[owner] {
+		if !names[name] {
+			stale = append(stale, got)
+		}
+	}
+	l.mu.Unlock()
+	sort.Slice(stale, func(i, j int) bool { return stale[i].Name < stale[j].Name })
+	for _, got := range stale {
+		remove := l.remove
+		if l.inventory != nil {
+			remove = l.removePersistent
+		}
+		if err := remove(owner, got); err != nil {
+			return res, err
+		}
+		l.mu.Lock()
+		delete(l.live[owner], got.Name)
+		l.mu.Unlock()
+		res.Pruned++
+	}
+	return res, nil
+}

--- a/pkg/cplane/localsid_persistent.go
+++ b/pkg/cplane/localsid_persistent.go
@@ -162,17 +162,37 @@ func (l *LocalSIDSet) applyPersistent(owner bpf.OwnerTag, byName map[string]Loca
 	return out, res, nil
 }
 
-func (l *LocalSIDSet) checkSIDAvailable(prefix string) error {
+// The daemon supplies an exact lookup; embedders implementing only the
+// original SIDFunctionOps surface retain the full-snapshot fallback.
+type exactSIDFunctionOps interface {
+	GetSidFunctionExact(string) (*bpf.SidFunctionEntry, bool, error)
+}
+
+func (l *LocalSIDSet) exactSIDEntry(prefix string) (*bpf.SidFunctionEntry, bool, error) {
+	if exact, ok := l.sids.(exactSIDFunctionOps); ok {
+		return exact.GetSidFunctionExact(prefix)
+	}
 	entries, err := l.sids.ListSidFunctions()
 	if err != nil {
-		return err
+		return nil, false, err
 	}
-	_, exists := entries[prefix]
+	entry, exists := entries[prefix]
+	return entry, exists, nil
+}
+
+func (l *LocalSIDSet) checkSIDAvailable(prefix string) error {
 	_, owned, err := l.sids.GetSidFunctionOwner(prefix)
 	if err != nil {
 		return err
 	}
-	if exists || owned {
+	if owned {
+		return fmt.Errorf("local sid %s is already owned: %w", prefix, bpf.ErrEntryOwnerMismatch)
+	}
+	_, exists, err := l.exactSIDEntry(prefix)
+	if err != nil {
+		return err
+	}
+	if exists {
 		return fmt.Errorf("local sid %s is already present: %w", prefix, bpf.ErrEntryOwnerMismatch)
 	}
 	return nil
@@ -183,11 +203,6 @@ func (l *LocalSIDSet) removePersistentEntry(owner bpf.OwnerTag, got AllocatedSID
 		return fmt.Errorf("local sid %q: SID maps unavailable for cleanup", got.Name)
 	}
 	prefix := got.SID.String() + "/128"
-	entries, err := l.sids.ListSidFunctions()
-	if err != nil {
-		return err
-	}
-	entry, exists := entries[prefix]
 	actual, owned, err := l.sids.GetSidFunctionOwner(prefix)
 	if err != nil {
 		return err
@@ -195,10 +210,15 @@ func (l *LocalSIDSet) removePersistentEntry(owner bpf.OwnerTag, got AllocatedSID
 	if owned && actual != owner {
 		return fmt.Errorf("local sid %q at %s: %w", got.Name, prefix, bpf.ErrEntryOwnerMismatch)
 	}
-	if exists && !owned {
-		// Older pinned maps may have no owner metadata. Only a recovered
-		// inventory record may identify such an entry, and its dispatch
-		// must agree with the last persisted declaration.
+	if !owned {
+		entry, exists, err := l.exactSIDEntry(prefix)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return nil
+		}
+		// Only a durable install attempt can identify ownerless state.
 		if entry == nil || !got.recoverOwnerless {
 			return fmt.Errorf("local sid %q: %w", got.Name, bpf.ErrEntryOwnerMismatch)
 		}
@@ -208,16 +228,9 @@ func (l *LocalSIDSet) removePersistentEntry(owner bpf.OwnerTag, got AllocatedSID
 			return fmt.Errorf("local sid %q: unowned dispatch differs from inventory", got.Name)
 		}
 	}
-	if !owned && !exists {
-		return nil
-	}
-	// Never use a persisted aux index. A live exact entry's index belongs to
-	// this owner; an absent /128 must not touch a covering entry's grant.
-	if exists && entry != nil && entry.AuxIndex != 0 && l.grants != nil {
-		if err := l.grants.DeleteEndtVRFGrant(uint32(entry.AuxIndex)); err != nil {
-			return err
-		}
-	}
+	// The map layer checks ownership again, resolves the exact entry and
+	// removes its grant before freeing aux. Do not walk the map again here
+	// or attempt grant cleanup with a separately observed, possibly stale index.
 	if err := l.sids.DeleteSidFunction(prefix, owner); err != nil {
 		return fmt.Errorf("local sid %q: remove %s: %w", got.Name, prefix, err)
 	}

--- a/pkg/cplane/localsid_test.go
+++ b/pkg/cplane/localsid_test.go
@@ -66,6 +66,7 @@ type fakeSIDOps struct {
 	installs  int
 	auxNext   uint16 // next aux index to stamp when an entry carries aux
 	ops       []string
+	grants    EndtVRFGrantOps // optional map-layer grant cleanup, as in MapOperations
 }
 
 func newFakeSIDOps() *fakeSIDOps {
@@ -109,6 +110,11 @@ func (f *fakeSIDOps) DeleteSidFunction(prefix string, requester bpf.OwnerTag) er
 	if cur, ok := f.owners[prefix]; ok && cur != requester {
 		return bpf.ErrEntryOwnerMismatch
 	}
+	if e := f.entries[prefix]; e != nil && e.AuxIndex != 0 && f.grants != nil {
+		if err := f.grants.DeleteEndtVRFGrant(uint32(e.AuxIndex)); err != nil {
+			return err
+		}
+	}
 	delete(f.entries, prefix)
 	delete(f.owners, prefix)
 	f.ops = append(f.ops, "delete "+prefix)
@@ -130,6 +136,17 @@ func (f *fakeSIDOps) GetSidFunctionOwner(prefix string) (bpf.OwnerTag, bool, err
 	defer f.mu.Unlock()
 	o, ok := f.owners[prefix]
 	return o, ok, nil
+}
+
+func (f *fakeSIDOps) GetSidFunctionExact(prefix string) (*bpf.SidFunctionEntry, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	e, ok := f.entries[prefix]
+	if !ok {
+		return nil, false, nil
+	}
+	copyEntry := *e
+	return &copyEntry, true, nil
 }
 
 // installCount and log record what was actually written, so a test can

--- a/pkg/cplane/manager.go
+++ b/pkg/cplane/manager.go
@@ -317,6 +317,15 @@ func NewManager(cfg ManagerConfig) (*Manager, error) {
 	// Share the grant lease with the local-SID tracker so install serializes
 	// against VrfDelete on the same lock the server also takes.
 	m.localSIDs.grantLease = &m.endtVRFGrantLease
+	if err := m.localSIDs.enablePersistence(cfg.Store); err != nil {
+		return nil, fmt.Errorf("cplane manager: %w", err)
+	}
+	// A crash during first publication can leave inventory before the
+	// registration manifest exists. Keep those owners visible and their
+	// grants reserved, including when their WASM cannot be loaded.
+	for name, scope := range m.localSIDs.inventoryScopes() {
+		m.recordUnrestored(Registration{Name: name, Scope: scope}, fmt.Errorf("local SID inventory awaiting plugin registration"))
+	}
 	return m, nil
 }
 
@@ -428,6 +437,14 @@ func (m *Manager) checkGrantsExclusive(name string, scope Scope) error {
 		held = append(held, grantsOf(other+" (unrestored)", u.scope))
 	}
 	m.unrestoredMu.Unlock()
+
+	// Inventory can retain grants missing from an unreadable or narrowed
+	// manifest, including records left before first publication was saved.
+	for other, scope := range m.localSIDs.inventoryScopes() {
+		if other != name {
+			held = append(held, grantsOf(other+" (SID inventory)", scope))
+		}
+	}
 
 	for _, h := range held {
 		for _, s := range scope.HeadendV4Slots {
@@ -862,9 +879,9 @@ func (m *Manager) Unrestored() []UnrestoredPlugin {
 // was holding, drops it from the store, and stops reporting it.
 //
 // It is the counterpart of Unregister for something that never ran. The
-// state it left in the maps is not touched, because nothing here knows
-// what that state was for; releasing the claim is what an operator does
-// once they have decided the plugin is not coming back.
+// state it left in the maps is not touched. Plugins with tracked local SIDs
+// must use Unregister, which can clean up without loading their WASM. Forget
+// remains available for legacy state that has no SID inventory.
 func (m *Manager) Forget(name string) error {
 	m.registerMu.Lock()
 	defer m.registerMu.Unlock()
@@ -887,6 +904,9 @@ func (m *Manager) Forget(name string) error {
 	m.mu.Unlock()
 	if running {
 		return fmt.Errorf("cplane: plugin %q is running; Unregister it rather than Forget", name)
+	}
+	if m.localSIDs.LiveCount(bpf.OwnerPluginBundle(name)) > 0 {
+		return fmt.Errorf("cplane: plugin %q still holds local SID inventory; Unregister it to clean up its state", name)
 	}
 	if m.claims != nil {
 		m.claims.Release(name)
@@ -1007,7 +1027,7 @@ func (m *Manager) Unregister(ctx context.Context, name string) error {
 	delete(m.plugins, name)
 	m.mu.Unlock()
 	if !ok {
-		return fmt.Errorf("cplane: %w: %q", ErrPluginNotRegistered, name)
+		return m.unregisterUnrestored(name)
 	}
 
 	// Order matters. Delivery stops first so nothing new is declared, then

--- a/pkg/cplane/manager_inventory.go
+++ b/pkg/cplane/manager_inventory.go
@@ -1,0 +1,37 @@
+package cplane
+
+import (
+	"fmt"
+
+	"github.com/takehaya/vinbero/pkg/bpf"
+)
+
+// Called under registerMu. No guest is instantiated: all cleanup surfaces know
+// their owner independently of executable WASM or a currently granted scope.
+func (m *Manager) unregisterUnrestored(name string) error {
+	m.unrestoredMu.Lock()
+	_, held := m.unrestored[name]
+	m.unrestoredMu.Unlock()
+	if !held {
+		return fmt.Errorf("cplane: %w: %q", ErrPluginNotRegistered, name)
+	}
+	ops, err := NewPluginOps(PluginOpsConfig{
+		Owner: bpf.OwnerPluginBundle(name), HeadendReconciler: m.headend,
+		Advertise: m.advertise, LocalSIDs: m.localSIDs, Leases: m.leases,
+		ApplyMutex: &m.applyMu,
+	})
+	if err != nil {
+		return err
+	}
+	if err := ops.Flush(); err != nil {
+		return fmt.Errorf("cplane: flush unrestored plugin %q: %w", name, err)
+	}
+	if err := m.store.Remove(name); err != nil {
+		return err
+	}
+	if m.claims != nil {
+		m.claims.Release(name)
+	}
+	m.clearUnrestored(name)
+	return nil
+}

--- a/pkg/cplane/ops.go
+++ b/pkg/cplane/ops.go
@@ -1054,7 +1054,7 @@ func (p *PluginOps) PruneOutOfScope(ctx context.Context) (int, error) {
 				}
 				return removed, firstErr
 			}
-			_, res, err := p.localSIDs.Apply(p.owner, keep, p.quotas.MaxLocalSIDs)
+			res, err := p.localSIDs.PruneExcept(p.owner, keep)
 			removed += res.Pruned
 			if err != nil && firstErr == nil {
 				firstErr = err
@@ -1234,7 +1234,7 @@ func (p *PluginOps) Flush() error {
 		// advertised for state that is gone is a blackhole its peers keep
 		// sending into.
 		if err := p.advertise.WithdrawOwner(context.Background(), p.owner); err != nil {
-			firstErr = err
+			return err
 		}
 	}
 	if p.localSIDs != nil {

--- a/pkg/cplane/sid_inventory.go
+++ b/pkg/cplane/sid_inventory.go
@@ -63,14 +63,19 @@ func openSIDInventory(dir string) (*sidInventoryStore, error) {
 		if err := syncDir(dir); err != nil {
 			return nil, err
 		}
-		if err := s.save(nil); err != nil {
-			return nil, err
-		}
 	} else if err != nil {
 		return nil, err
 	}
 	if _, err := s.load(); err != nil {
-		return nil, err
+		// Before the enrollment marker is durable, no successful store
+		// open can have installed a SID. Resume an interrupted first open
+		// only when its snapshot is absent; never overwrite existing data.
+		if !errors.Is(markerErr, os.ErrNotExist) || !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+		if err := s.save(nil); err != nil {
+			return nil, err
+		}
 	}
 	if errors.Is(markerErr, os.ErrNotExist) {
 		if err := writeFileAtomic(marker, []byte("1\n")); err != nil {

--- a/pkg/cplane/sid_inventory.go
+++ b/pkg/cplane/sid_inventory.go
@@ -1,0 +1,199 @@
+package cplane
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/takehaya/vinbero/pkg/bpf"
+	"github.com/takehaya/vinbero/pkg/locator"
+)
+
+const sidInventoryVersion = 1
+
+type sidRecord struct {
+	Owner    bpf.OwnerTag    `json:"-"`
+	Plugin   string          `json:"plugin"`
+	Name     string          `json:"name"`
+	SID      netip.Addr      `json:"sid"`
+	Locator  locator.Locator `json:"locator"`
+	Function uint32          `json:"function"`
+	Slot     uint32          `json:"slot"`
+	AuxRaw   []byte          `json:"aux_raw,omitempty"`
+	DecapVRF string          `json:"decap_vrf,omitempty"`
+}
+
+type sidInventory struct {
+	Version int         `json:"version"`
+	Records []sidRecord `json:"records"`
+}
+
+// A separate directory keeps allocation cleanup independent of registration
+// replacement and of Store.Remove. An empty inventory is retained as well.
+type sidInventoryStore struct {
+	path  string
+	write func(string, []byte) error
+}
+
+func openSIDInventory(dir string) (*sidInventoryStore, error) {
+	invDir := filepath.Join(dir, "local-sids")
+	s := &sidInventoryStore{path: filepath.Join(invDir, "state.json"), write: writeFileAtomic}
+	marker := filepath.Join(dir, "local-sids.version")
+	version, markerErr := os.ReadFile(marker)
+	if markerErr != nil && !errors.Is(markerErr, os.ErrNotExist) {
+		return nil, markerErr
+	}
+	if markerErr == nil && string(version) != "1\n" {
+		return nil, fmt.Errorf("unsupported local SID inventory marker")
+	}
+	_, err := os.Stat(invDir)
+	if errors.Is(err, os.ErrNotExist) {
+		if markerErr == nil {
+			return nil, fmt.Errorf("local SID inventory directory is missing")
+		}
+		if err := os.Mkdir(invDir, 0o700); err != nil {
+			return nil, err
+		}
+		if err := syncDir(dir); err != nil {
+			return nil, err
+		}
+		if err := s.save(nil); err != nil {
+			return nil, err
+		}
+	} else if err != nil {
+		return nil, err
+	}
+	if _, err := s.load(); err != nil {
+		return nil, err
+	}
+	if errors.Is(markerErr, os.ErrNotExist) {
+		if err := writeFileAtomic(marker, []byte("1\n")); err != nil {
+			return nil, err
+		}
+	}
+	return s, nil
+}
+
+func (s *sidInventoryStore) load() ([]sidRecord, error) {
+	body, err := os.ReadFile(s.path)
+	if err != nil {
+		return nil, fmt.Errorf("read local SID inventory: %w", err)
+	}
+	var inv sidInventory
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&inv); err != nil {
+		return nil, fmt.Errorf("decode local SID inventory: %w", err)
+	}
+	if err := dec.Decode(new(any)); err != io.EOF {
+		return nil, fmt.Errorf("local SID inventory has trailing data")
+	}
+	if inv.Version != sidInventoryVersion {
+		return nil, fmt.Errorf("local SID inventory version %d is unsupported", inv.Version)
+	}
+	names := make(map[string]bool)
+	addresses := make(map[netip.Addr]bool)
+	reservations := make([]locator.SIDReservation, 0, len(inv.Records))
+	for i := range inv.Records {
+		r := &inv.Records[i]
+		if err := bpf.ValidatePluginBundleName(r.Plugin); err != nil {
+			return nil, err
+		}
+		r.Owner = bpf.OwnerPluginBundle(r.Plugin)
+		if err := validateLocalSID(r.desired()); err != nil {
+			return nil, err
+		}
+		if err := r.Locator.Validate(); err != nil {
+			return nil, err
+		}
+		sid, err := r.Locator.BuildSID(r.Function)
+		if err != nil || sid != r.SID || r.SID.Zone() != "" {
+			return nil, fmt.Errorf("local SID inventory %q/%q has inconsistent address", r.Owner, r.Name)
+		}
+		key := sidReservationKey(r.Owner, r.Name)
+		if names[key] || addresses[r.SID] {
+			return nil, fmt.Errorf("local SID inventory duplicates %q/%q or address %s", r.Owner, r.Name, r.SID)
+		}
+		names[key], addresses[r.SID] = true, true
+		reservations = append(reservations, r.reservation())
+	}
+	if err := locator.NewManager().RestoreSIDReservations(reservations); err != nil {
+		return nil, err
+	}
+	return inv.Records, nil
+}
+
+func (s *sidInventoryStore) save(records []sidRecord) error {
+	for i := range records {
+		owner, ok, err := bpf.ParsePluginOwnerTag(string(records[i].Owner))
+		if err != nil || !ok || !owner.IsBundle() {
+			return fmt.Errorf("local SID inventory has invalid owner %q", records[i].Owner)
+		}
+		records[i].Plugin = owner.Bundle
+	}
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].Owner != records[j].Owner {
+			return records[i].Owner < records[j].Owner
+		}
+		return records[i].Name < records[j].Name
+	})
+	body, err := json.MarshalIndent(sidInventory{Version: sidInventoryVersion, Records: records}, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := s.write(s.path, body); err != nil {
+		return fmt.Errorf("save local SID inventory: %w", err)
+	}
+	return nil
+}
+
+func (r sidRecord) desired() LocalSID {
+	return LocalSID{Name: r.Name, Locator: r.Locator.Name, Slot: r.Slot, AuxRaw: r.AuxRaw, DecapVRF: r.DecapVRF}
+}
+
+func sidReservationKey(owner bpf.OwnerTag, name string) string {
+	// Length framing is unambiguous even if a guest name contains separators.
+	return fmt.Sprintf("cplane/%d:%s%s", len(owner), owner, name)
+}
+
+func (r sidRecord) reservation() locator.SIDReservation {
+	return locator.SIDReservation{Key: sidReservationKey(r.Owner, r.Name), Locator: r.Locator, Function: r.Function}
+}
+
+// PersistentSIDAllocator protects caller-keyed allocations even before locators
+// are registered. The daemon's locator.Manager implements this interface.
+type PersistentSIDAllocator interface {
+	SIDAllocator
+	RestoreSIDReservations([]locator.SIDReservation) error
+	AllocateReservedSID(key, locatorName string) (netip.Addr, locator.SIDReservation, error)
+	ReleaseReservedSID(key string)
+}
+
+// ReserveStoredLocalSIDs must run before config locators, exporters or RPC can
+// allocate. It restores reservations without requiring a guest or a live locator.
+func ReserveStoredLocalSIDs(store *Store, alloc PersistentSIDAllocator) error {
+	if store == nil {
+		return nil
+	}
+	records, err := store.sids.load()
+	if err != nil {
+		return err
+	}
+	if len(records) == 0 {
+		return nil
+	}
+	if alloc == nil {
+		return fmt.Errorf("local SID inventory requires a persistent allocator")
+	}
+	reservations := make([]locator.SIDReservation, 0, len(records))
+	for _, r := range records {
+		reservations = append(reservations, r.reservation())
+	}
+	return alloc.RestoreSIDReservations(reservations)
+}

--- a/pkg/cplane/sid_inventory.go
+++ b/pkg/cplane/sid_inventory.go
@@ -97,6 +97,9 @@ func (s *sidInventoryStore) load() ([]sidRecord, error) {
 	if inv.Version != sidInventoryVersion {
 		return nil, fmt.Errorf("local SID inventory version %d is unsupported", inv.Version)
 	}
+	if inv.Records == nil {
+		return nil, fmt.Errorf("local SID inventory is missing its records array")
+	}
 	names := make(map[string]bool)
 	addresses := make(map[netip.Addr]bool)
 	reservations := make([]locator.SIDReservation, 0, len(inv.Records))
@@ -130,6 +133,9 @@ func (s *sidInventoryStore) load() ([]sidRecord, error) {
 }
 
 func (s *sidInventoryStore) save(records []sidRecord) error {
+	if records == nil {
+		records = []sidRecord{}
+	}
 	for i := range records {
 		owner, ok, err := bpf.ParsePluginOwnerTag(string(records[i].Owner))
 		if err != nil || !ok || !owner.IsBundle() {

--- a/pkg/cplane/sid_inventory_test.go
+++ b/pkg/cplane/sid_inventory_test.go
@@ -32,11 +32,45 @@ func inventoryAllocator(t *testing.T) *locator.Manager {
 
 func persistentSet(t *testing.T, store *Store, alloc *locator.Manager, sids SIDFunctionOps, grants EndtVRFGrantOps, resolve func(string) (uint32, error)) *LocalSIDSet {
 	t.Helper()
+	switch f := sids.(type) {
+	case *fakeSIDOps:
+		f.grants = grants
+	case *interruptedSIDInstall:
+		f.grants = grants
+	}
 	s := NewLocalSIDSet(alloc, sids, grants, resolve)
 	if err := s.enablePersistence(store); err != nil {
 		t.Fatal(err)
 	}
 	return s
+}
+
+type countingSIDOps struct {
+	*fakeSIDOps
+	lists int
+}
+
+func (f *countingSIDOps) ListSidFunctions() (map[string]*bpf.SidFunctionEntry, error) {
+	f.lists++
+	return f.fakeSIDOps.ListSidFunctions()
+}
+
+func TestSIDInventoryAvoidsRedundantMapWalks(t *testing.T) {
+	ops := &countingSIDOps{fakeSIDOps: newFakeSIDOps()}
+	set := persistentSet(t, newTestStore(t), inventoryAllocator(t), ops, nil, nil)
+	var desired []LocalSID
+	for _, name := range []string{"a", "b", "c", "d"} {
+		desired = append(desired, LocalSID{Name: name, Locator: "main", Slot: 33})
+	}
+	if _, _, err := set.Apply(ownerA, desired, unlimited); err != nil {
+		t.Fatal(err)
+	}
+	if err := set.ReleaseOwner(ownerA); err != nil {
+		t.Fatal(err)
+	}
+	if ops.lists != 1 {
+		t.Fatalf("walked map %d times; only initial legacy sweep requires a full snapshot", ops.lists)
+	}
 }
 
 func reopenInventory(t *testing.T, store *Store) *Store {
@@ -403,6 +437,12 @@ func TestLocalSIDInventoryUnregistersWithoutGuestOrManifest(t *testing.T) {
 			}
 			if err := m.Restore(context.Background()); err != nil {
 				t.Fatal(err)
+			}
+			if err := m.checkGrantsExclusive("other", Scope{EndpointSlots: []uint32{33}}); !errors.Is(err, ErrGrantHeld) {
+				t.Fatalf("unrestored inventory lost slot reservation: %v", err)
+			}
+			if err := m.checkGrantsExclusive("other", Scope{Locators: []string{"main"}}); !errors.Is(err, ErrGrantHeld) {
+				t.Fatalf("unrestored inventory lost locator reservation: %v", err)
 			}
 			if err := m.Forget("a"); err == nil {
 				t.Fatal("forget released inventory without cleanup")

--- a/pkg/cplane/sid_inventory_test.go
+++ b/pkg/cplane/sid_inventory_test.go
@@ -1,0 +1,506 @@
+package cplane
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/takehaya/vinbero/pkg/bpf"
+	"github.com/takehaya/vinbero/pkg/locator"
+)
+
+func inventoryLocator() locator.Locator {
+	return locator.Locator{Name: "main", Prefix: netip.MustParsePrefix("fd00:1:1::/48"),
+		BlockLen: 32, NodeLen: 16, FunctionLen: 16, ArgumentLen: 64, Behavior: locator.BehaviorClassic,
+		FunctionAutoStart: 1, FunctionAutoEnd: 16,
+	}
+}
+
+func inventoryAllocator(t *testing.T) *locator.Manager {
+	t.Helper()
+	a := locator.NewManager()
+	loc := inventoryLocator()
+	if err := a.Add(&loc); err != nil {
+		t.Fatal(err)
+	}
+	return a
+}
+
+func persistentSet(t *testing.T, store *Store, alloc *locator.Manager, sids SIDFunctionOps, grants EndtVRFGrantOps, resolve func(string) (uint32, error)) *LocalSIDSet {
+	t.Helper()
+	s := NewLocalSIDSet(alloc, sids, grants, resolve)
+	if err := s.enablePersistence(store); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func reopenInventory(t *testing.T, store *Store) *Store {
+	t.Helper()
+	s, err := NewStore(store.Dir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func TestLocalSIDInventoryRestoresIdentityAndRebuildsGrants(t *testing.T) {
+	for _, mode := range []string{"pinned", "legacy ownerless", "unpinned"} {
+		t.Run(mode, func(t *testing.T) {
+			store := newTestStore(t)
+			a := inventoryAllocator(t)
+			maps := newFakeSIDOps()
+			first := persistentSet(t, store, a, maps, newFakeGrantOps(), func(string) (uint32, error) { return 19, nil })
+			want := []LocalSID{{Name: "z", Locator: "main", Slot: 33, AuxRaw: []byte{1, 2}, DecapVRF: "blue"}}
+			initial, _, err := first.Apply(ownerA, want, unlimited)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want = append(want, LocalSID{Name: "a", Locator: "main", Slot: 34})
+			if _, _, err := first.Apply(ownerA, want, unlimited); err != nil {
+				t.Fatal(err)
+			}
+			switch mode {
+			case "unpinned":
+				maps = newFakeSIDOps()
+			case "legacy ownerless":
+				maps.owners = map[string]bpf.OwnerTag{}
+			}
+			store = reopenInventory(t, store)
+			nextAlloc := locator.NewManager()
+			grants := newFakeGrantOps()
+			next := persistentSet(t, store, nextAlloc, maps, grants, func(string) (uint32, error) { return 99, nil })
+			if next.OwnsSID(ownerA, initial[0].SID) {
+				t.Fatal("unconfirmed inventory authorized advertisement")
+			}
+			if _, _, err := next.Apply(ownerA, want, unlimited); !errors.Is(err, locator.ErrLocatorNotFound) {
+				t.Fatalf("missing locator: %v", err)
+			}
+			loc := inventoryLocator()
+			if err := nextAlloc.Add(&loc); err != nil {
+				t.Fatal(err)
+			}
+			fn := uint32(1)
+			if _, _, err := nextAlloc.AllocateSID("main", &fn); !errors.Is(err, locator.ErrFunctionInUse) {
+				t.Fatalf("startup reused saved SID: %v", err)
+			}
+			got, _, err := next.Apply(ownerA, want, unlimited)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got[1].Name != "z" || got[1].SID != initial[0].SID {
+				t.Fatalf("identity changed: %+v -> %+v", initial, got)
+			}
+			if grants.grants[got[1].auxIndex] != 99 {
+				t.Fatalf("grant was not resolved again: %v", grants.grants)
+			}
+			writes := maps.installCount()
+			if _, _, err := next.Apply(ownerA, want, unlimited); err != nil {
+				t.Fatal(err)
+			}
+			if maps.installCount() != writes {
+				t.Fatal("unchanged live SID was reinstalled")
+			}
+		})
+	}
+}
+
+func TestLocalSIDInventoryWriteFailureRetainsReservation(t *testing.T) {
+	for _, afterRename := range []bool{false, true} {
+		t.Run(map[bool]string{false: "before rename", true: "after rename"}[afterRename], func(t *testing.T) {
+			store := newTestStore(t)
+			a := inventoryAllocator(t)
+			maps := newFakeSIDOps()
+			set := persistentSet(t, store, a, maps, nil, nil)
+			store.sids.write = func(path string, body []byte) error {
+				if afterRename {
+					if err := writeFileAtomic(path, body); err != nil {
+						return err
+					}
+				}
+				return errors.New("injected write or directory sync failure")
+			}
+			want := []LocalSID{{Name: "self", Locator: "main", Slot: 33}}
+			if out, _, err := set.Apply(ownerA, want, unlimited); err == nil || len(out) != 0 {
+				t.Fatalf("failed save reported success: %v %v", out, err)
+			}
+			got := set.live[ownerA]["self"]
+			if set.OwnsSID(ownerA, got.SID) || maps.count() != 0 {
+				t.Fatal("failed save installed or advertised SID")
+			}
+			fn := got.reservation.Function
+			if _, _, err := a.AllocateSID("main", &fn); !errors.Is(err, locator.ErrFunctionInUse) {
+				t.Fatalf("failed save released SID: %v", err)
+			}
+			// A new process sees whichever complete snapshot reached disk.
+			reloaded := reopenInventory(t, store)
+			records, err := reloaded.sids.load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if (len(records) == 1) != afterRename {
+				t.Fatalf("disk outcome: %v", records)
+			}
+			store.sids.write = writeFileAtomic
+			out, _, err := set.Apply(ownerA, want, unlimited)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if out[0].SID != got.SID {
+				t.Fatal("retry changed reserved address")
+			}
+		})
+	}
+}
+
+func TestLocalSIDInventoryCleanupFailureRetainsAddress(t *testing.T) {
+	for _, failure := range []string{"map delete", "snapshot before rename", "snapshot after rename"} {
+		t.Run(failure, func(t *testing.T) {
+			store := newTestStore(t)
+			a := inventoryAllocator(t)
+			maps := newFakeSIDOps()
+			set := persistentSet(t, store, a, maps, nil, nil)
+			want := []LocalSID{{Name: "self", Locator: "main", Slot: 33}}
+			out, _, err := set.Apply(ownerA, want, unlimited)
+			if err != nil {
+				t.Fatal(err)
+			}
+			sid := out[0].SID
+			fn := out[0].reservation.Function
+			if failure == "map delete" {
+				maps.delFailOn = sid.String() + "/128"
+			} else {
+				store.sids.write = func(path string, body []byte) error {
+					if failure == "snapshot after rename" {
+						if err := writeFileAtomic(path, body); err != nil {
+							return err
+						}
+					}
+					return errors.New("injected snapshot failure")
+				}
+			}
+			if err := set.ReleaseOwner(ownerA); err == nil {
+				t.Fatal("cleanup unexpectedly succeeded")
+			}
+			if set.LiveCount(ownerA) != 1 || set.OwnsSID(ownerA, sid) {
+				t.Fatal("failed cleanup lost tracking or remained confirmed")
+			}
+			if _, _, err := a.AllocateSID("main", &fn); !errors.Is(err, locator.ErrFunctionInUse) {
+				t.Fatalf("failed cleanup returned address: %v", err)
+			}
+			// Restart at the failed boundary. A pre-rename failure still
+			// reserves the address; a committed removal may release it only
+			// because the exact dispatch has already been removed.
+			bootStore := reopenInventory(t, store)
+			bootAlloc := locator.NewManager()
+			if err := ReserveStoredLocalSIDs(bootStore, bootAlloc); err != nil {
+				t.Fatal(err)
+			}
+			loc := inventoryLocator()
+			if err := bootAlloc.Add(&loc); err != nil {
+				t.Fatal(err)
+			}
+			_, _, bootErr := bootAlloc.AllocateSID("main", &fn)
+			if failure == "snapshot after rename" {
+				if bootErr != nil || maps.count() != 0 {
+					t.Fatalf("committed cleanup restart: %v", bootErr)
+				}
+			} else if !errors.Is(bootErr, locator.ErrFunctionInUse) {
+				t.Fatalf("restart released incomplete cleanup: %v", bootErr)
+			}
+			maps.delFailOn = ""
+			store.sids.write = writeFileAtomic
+			if err := set.ReleaseOwner(ownerA); err != nil {
+				t.Fatal(err)
+			}
+			if _, _, err := a.AllocateSID("main", &fn); err != nil {
+				t.Fatalf("successful cleanup did not return address: %v", err)
+			}
+			records, err := reopenInventory(t, store).sids.load()
+			if err != nil || len(records) != 0 {
+				t.Fatalf("cleanup disk state: %v %v", records, err)
+			}
+		})
+	}
+}
+
+type interruptedSIDInstall struct {
+	*fakeSIDOps
+	afterCreate bool
+	dropOwner   bool
+}
+
+func (f *interruptedSIDInstall) CreateSidFunction(prefix string, e *bpf.SidFunctionEntry, aux *bpf.SidAuxEntry, owner bpf.OwnerTag) error {
+	if f.afterCreate {
+		if err := f.fakeSIDOps.CreateSidFunction(prefix, e, aux, owner); err != nil {
+			return err
+		}
+		if f.dropOwner {
+			delete(f.owners, prefix)
+		}
+	}
+	return errors.New("interrupted SID installation")
+}
+
+func TestLocalSIDInventoryRecoversInterruptedInstallation(t *testing.T) {
+	for _, point := range []string{"before create", "after create", "owner write and rollback failure", "grant and rollback failure", "missing VRF"} {
+		t.Run(point, func(t *testing.T) {
+			store := newTestStore(t)
+			a := inventoryAllocator(t)
+			maps := newFakeSIDOps()
+			grants := newFakeGrantOps()
+			var ops SIDFunctionOps = maps
+			resolve := func(string) (uint32, error) { return 19, nil }
+			switch point {
+			case "before create":
+				ops = &interruptedSIDInstall{fakeSIDOps: maps}
+			case "after create":
+				ops = &interruptedSIDInstall{fakeSIDOps: maps, afterCreate: true}
+			case "owner write and rollback failure":
+				ops = &interruptedSIDInstall{fakeSIDOps: maps, afterCreate: true, dropOwner: true}
+			case "grant and rollback failure":
+				grants.putErr = errors.New("grant write failed")
+				loc := inventoryLocator()
+				sid, _ := loc.BuildSID(1)
+				maps.delFailOn = sid.String() + "/128"
+			case "missing VRF":
+				resolve = func(string) (uint32, error) { return 0, errors.New("VRF unavailable") }
+			}
+			set := persistentSet(t, store, a, ops, grants, resolve)
+			want := []LocalSID{{Name: "self", Locator: "main", Slot: 33, DecapVRF: "blue"}}
+			if out, _, err := set.Apply(ownerA, want, unlimited); err == nil || len(out) != 0 {
+				t.Fatal("interrupted install reported success")
+			}
+			held := set.live[ownerA]["self"]
+			if set.OwnsSID(ownerA, held.SID) {
+				t.Fatal("unfinished SID authorized advertisement")
+			}
+			if _, _, err := a.AllocateSID("main", &held.reservation.Function); !errors.Is(err, locator.ErrFunctionInUse) {
+				t.Fatalf("interrupted install freed its address: %v", err)
+			}
+			maps.delFailOn = ""
+			if point == "owner write and rollback failure" {
+				set.sids = maps
+				if _, _, err := set.Apply(ownerA, want, unlimited); err != nil {
+					t.Fatalf("retry of ownerless partial write: %v", err)
+				}
+			}
+			next := persistentSet(t, reopenInventory(t, store), inventoryAllocator(t), maps, newFakeGrantOps(), func(string) (uint32, error) { return 99, nil })
+			out, _, err := next.Apply(ownerA, want, unlimited)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if out[0].SID != held.SID || !next.OwnsSID(ownerA, held.SID) {
+				t.Fatal("restart did not recover reserved SID")
+			}
+		})
+	}
+}
+
+func TestNewSIDCannotClaimUnownedDispatchThroughInventory(t *testing.T) {
+	store := newTestStore(t)
+	maps := newFakeSIDOps()
+	loc := inventoryLocator()
+	sid, _ := loc.BuildSID(1)
+	prefix := sid.String() + "/128"
+	maps.entries[prefix] = &bpf.SidFunctionEntry{Action: 33}
+	set := persistentSet(t, store, inventoryAllocator(t), maps, nil, nil)
+	if _, _, err := set.Apply(ownerA, []LocalSID{{Name: "self", Locator: "main", Slot: 33}}, unlimited); err == nil {
+		t.Fatal("claimed preexisting unowned dispatch")
+	}
+	records, err := reopenInventory(t, store).sids.load()
+	if err != nil || len(records) != 0 {
+		t.Fatalf("failed claim became durable recovery authority: %v %v", records, err)
+	}
+	if maps.entries[prefix].Action != 33 {
+		t.Fatal("existing dispatch was modified")
+	}
+}
+
+func TestLocalSIDInventoryRejectsForeignDispatch(t *testing.T) {
+	for _, kind := range []string{"foreign owner", "ownerless wrong slot", "ownerless wrong flavor"} {
+		t.Run(kind, func(t *testing.T) {
+			store := newTestStore(t)
+			maps := newFakeSIDOps()
+			set := persistentSet(t, store, inventoryAllocator(t), maps, nil, nil)
+			want := []LocalSID{{Name: "self", Locator: "main", Slot: 33}}
+			out, _, err := set.Apply(ownerA, want, unlimited)
+			if err != nil {
+				t.Fatal(err)
+			}
+			prefix := out[0].SID.String() + "/128"
+			switch kind {
+			case "foreign owner":
+				maps.owners[prefix] = ownerB
+			case "ownerless wrong slot":
+				delete(maps.owners, prefix)
+				maps.entries[prefix].Action = 34
+			case "ownerless wrong flavor":
+				delete(maps.owners, prefix)
+				maps.entries[prefix].Flavor = 1
+			}
+			before := *maps.entries[prefix]
+			next := persistentSet(t, reopenInventory(t, store), inventoryAllocator(t), maps, nil, nil)
+			if _, _, err := next.Apply(ownerA, want, unlimited); err == nil {
+				t.Fatal("accepted foreign dispatch")
+			}
+			if err := next.ReleaseOwner(ownerA); err == nil {
+				t.Fatal("deleted foreign dispatch")
+			}
+			if *maps.entries[prefix] != before {
+				t.Fatal("foreign dispatch changed")
+			}
+		})
+	}
+}
+
+func TestLocalSIDInventoryPrunesWithoutRestoringKeptSID(t *testing.T) {
+	store := newTestStore(t)
+	maps := newFakeSIDOps()
+	first := persistentSet(t, store, inventoryAllocator(t), maps, nil, nil)
+	if _, _, err := first.Apply(ownerA, []LocalSID{{Name: "keep", Locator: "main", Slot: 33}, {Name: "drop", Locator: "main", Slot: 34}}, unlimited); err != nil {
+		t.Fatal(err)
+	}
+	next := persistentSet(t, reopenInventory(t, store), locator.NewManager(), maps, nil, nil)
+	ops, err := NewPluginOps(PluginOpsConfig{Owner: ownerA, Headend: newFakeHeadendOps(), LocalSIDs: next, Capabilities: testCaps(), Guard: NewGuard(Scope{Locators: []string{"main"}, EndpointSlots: []uint32{33}}, nil, nil)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, err := ops.PruneOutOfScope(context.Background())
+	if err != nil || n != 1 {
+		t.Fatalf("prune: %d %v", n, err)
+	}
+	if next.LiveCount(ownerA) != 1 || next.LiveSIDs(ownerA)[0].Name != "keep" || maps.count() != 1 {
+		t.Fatal("prune changed retained pending SID")
+	}
+	if err := next.ReleaseOwner(ownerA); err != nil {
+		t.Fatalf("unregister needed a locator: %v", err)
+	}
+}
+
+func TestLocalSIDInventoryUnregistersWithoutGuestOrManifest(t *testing.T) {
+	for _, hasManifest := range []bool{false, true} {
+		t.Run(map[bool]string{false: "orphan inventory", true: "unloadable guest"}[hasManifest], func(t *testing.T) {
+			store := newTestStore(t)
+			maps := newFakeSIDOps()
+			first := persistentSet(t, store, inventoryAllocator(t), maps, nil, nil)
+			out, _, err := first.Apply(ownerA, []LocalSID{{Name: "self", Locator: "main", Slot: 33}}, unlimited)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if hasManifest {
+				if err := store.Save(Registration{Name: "a", Module: []byte("bad wasm")}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			m, err := NewManager(ManagerConfig{Store: reopenInventory(t, store), Headend: newFakeHeadendOps(), Locators: locator.NewManager(), SIDFunctions: maps, Source: newFakeSource()})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := m.Restore(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+			if err := m.Forget("a"); err == nil {
+				t.Fatal("forget released inventory without cleanup")
+			}
+			maps.delFailOn = out[0].SID.String() + "/128"
+			if err := m.Unregister(context.Background(), "a"); err == nil {
+				t.Fatal("unregister ignored failed cleanup")
+			}
+			maps.delFailOn = ""
+			if err := m.Unregister(context.Background(), "a"); err != nil {
+				t.Fatal(err)
+			}
+			if m.localSIDs.LiveCount(ownerA) != 0 || maps.count() != 0 || len(m.Unrestored()) != 0 {
+				t.Fatal("cleanup left owner state")
+			}
+			records, err := reopenInventory(t, store).sids.load()
+			if err != nil || len(records) != 0 {
+				t.Fatalf("inventory: %v %v", records, err)
+			}
+		})
+	}
+}
+
+func TestLocalSIDInventoryRefusesMissingAndCorruptState(t *testing.T) {
+	for _, kind := range []string{"missing file", "missing directory", "invalid JSON", "unknown version", "duplicate", "wrong address", "unknown field"} {
+		t.Run(kind, func(t *testing.T) {
+			store := newTestStore(t)
+			set := persistentSet(t, store, inventoryAllocator(t), newFakeSIDOps(), nil, nil)
+			if _, _, err := set.Apply(ownerA, []LocalSID{{Name: "self", Locator: "main", Slot: 33}}, unlimited); err != nil {
+				t.Fatal(err)
+			}
+			if err := store.Save(Registration{Name: "a", Module: []byte("module")}); err != nil {
+				t.Fatal(err)
+			}
+			path := store.sids.path
+			switch kind {
+			case "missing file":
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+			case "missing directory":
+				if err := os.RemoveAll(filepath.Dir(path)); err != nil {
+					t.Fatal(err)
+				}
+			default:
+				body, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var doc map[string]any
+				if err := json.Unmarshal(body, &doc); err != nil {
+					t.Fatal(err)
+				}
+				switch kind {
+				case "invalid JSON":
+					body = []byte("{")
+				case "unknown version":
+					doc["version"] = 99
+				case "duplicate":
+					r := doc["records"].([]any)
+					doc["records"] = append(r, r[0])
+				case "wrong address":
+					doc["records"].([]any)[0].(map[string]any)["sid"] = "fd00::1234"
+				case "unknown field":
+					doc["mystery"] = true
+				}
+				if kind != "invalid JSON" {
+					body, err = json.Marshal(doc)
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+				if err := os.WriteFile(path, body, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if _, err := NewStore(store.Dir()); err == nil {
+				t.Fatal("started with an empty or invalid inventory")
+			}
+		})
+	}
+}
+
+func TestFlushRetainsSIDWhenAdvertisementWithdrawalFails(t *testing.T) {
+	f := newSIDDependencyFixture(t)
+	f.advertiser.failWithdraw = "10.7.0.0/24"
+	if err := f.ops.Flush(); err == nil {
+		t.Fatal("flush ignored failed withdrawal")
+	}
+	f.assertReferencesOwned(t)
+	if !f.sids.OwnsSID(ownerA, f.oldSID) {
+		t.Fatal("flush removed the advertised SID")
+	}
+	f.advertiser.failWithdraw = ""
+	if err := f.ops.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	if f.sids.LiveCount(ownerA) != 0 {
+		t.Fatal("flush retry retained SID")
+	}
+}

--- a/pkg/cplane/sid_inventory_test.go
+++ b/pkg/cplane/sid_inventory_test.go
@@ -427,7 +427,7 @@ func TestLocalSIDInventoryUnregistersWithoutGuestOrManifest(t *testing.T) {
 }
 
 func TestLocalSIDInventoryRefusesMissingAndCorruptState(t *testing.T) {
-	for _, kind := range []string{"missing file", "missing directory", "invalid JSON", "unknown version", "duplicate", "wrong address", "unknown field"} {
+	for _, kind := range []string{"missing file", "missing directory", "invalid JSON", "unknown version", "missing records", "null records", "duplicate", "wrong address", "unknown field"} {
 		t.Run(kind, func(t *testing.T) {
 			store := newTestStore(t)
 			set := persistentSet(t, store, inventoryAllocator(t), newFakeSIDOps(), nil, nil)
@@ -461,6 +461,10 @@ func TestLocalSIDInventoryRefusesMissingAndCorruptState(t *testing.T) {
 					body = []byte("{")
 				case "unknown version":
 					doc["version"] = 99
+				case "missing records":
+					delete(doc, "records")
+				case "null records":
+					doc["records"] = nil
 				case "duplicate":
 					r := doc["records"].([]any)
 					doc["records"] = append(r, r[0])

--- a/pkg/cplane/sid_inventory_test.go
+++ b/pkg/cplane/sid_inventory_test.go
@@ -508,3 +508,42 @@ func TestFlushRetainsSIDWhenAdvertisementWithdrawalFails(t *testing.T) {
 		t.Fatal("flush retry retained SID")
 	}
 }
+
+func TestSIDInventoryResumesFirstInitialization(t *testing.T) {
+	for _, point := range []string{"directory only", "empty snapshot", "populated snapshot"} {
+		t.Run(point, func(t *testing.T) {
+			store := newTestStore(t)
+			if point == "populated snapshot" {
+				set := persistentSet(t, store, inventoryAllocator(t), newFakeSIDOps(), nil, nil)
+				if _, _, err := set.Apply(ownerA, []LocalSID{{Name: "self", Locator: "main", Slot: 33}}, unlimited); err != nil {
+					t.Fatal(err)
+				}
+			}
+			// No successful NewStore can install a SID before this marker is
+			// durable. Existing snapshots must still never be overwritten.
+			if err := os.Remove(filepath.Join(store.Dir(), "local-sids.version")); err != nil {
+				t.Fatal(err)
+			}
+			if point == "directory only" {
+				if err := os.Remove(store.sids.path); err != nil {
+					t.Fatal(err)
+				}
+			}
+			reopened, err := NewStore(store.Dir())
+			if err != nil {
+				t.Fatalf("initialization did not resume: %v", err)
+			}
+			records, err := reopened.sids.load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := 0
+			if point == "populated snapshot" {
+				want = 1
+			}
+			if len(records) != want {
+				t.Fatalf("initialization overwrote snapshot: %v", records)
+			}
+		})
+	}
+}

--- a/pkg/cplane/store.go
+++ b/pkg/cplane/store.go
@@ -33,7 +33,8 @@ import (
 // is that the logic lives here. An operator who prefers the other model
 // can disable the store and re-register on boot.
 type Store struct {
-	dir string
+	dir  string
+	sids *sidInventoryStore
 }
 
 // storeManifestVersion is stamped into every manifest so a future format
@@ -104,7 +105,11 @@ func NewStore(dir string) (*Store, error) {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("cplane store: %w", err)
 	}
-	return &Store{dir: dir}, nil
+	sids, err := openSIDInventory(dir)
+	if err != nil {
+		return nil, fmt.Errorf("cplane store: %w", err)
+	}
+	return &Store{dir: dir, sids: sids}, nil
 }
 
 // Dir is where the store keeps its files.

--- a/pkg/cplane/store.go
+++ b/pkg/cplane/store.go
@@ -105,6 +105,21 @@ func NewStore(dir string) (*Store, error) {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("cplane store: %w", err)
 	}
+	// MkdirAll can create several parent links. Flush those too, including
+	// links visible after a previously interrupted initialization, before a
+	// successful open lets callers install state backed by this directory.
+	absolute, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+	for parent := filepath.Dir(absolute); ; parent = filepath.Dir(parent) {
+		if err := syncDir(parent); err != nil {
+			return nil, fmt.Errorf("cplane store: sync parent %q: %w", parent, err)
+		}
+		if filepath.Dir(parent) == parent {
+			break
+		}
+	}
 	sids, err := openSIDInventory(dir)
 	if err != nil {
 		return nil, fmt.Errorf("cplane store: %w", err)

--- a/pkg/locator/manager.go
+++ b/pkg/locator/manager.go
@@ -40,16 +40,20 @@ type managerEntry struct {
 // table. It is the single object the RPC handler and the SidFunction
 // handler talk to.
 type Manager struct {
-	mu       sync.RWMutex
-	entries  map[string]*managerEntry
-	bindings BindingTable
+	mu           sync.RWMutex
+	entries      map[string]*managerEntry
+	bindings     BindingTable
+	reservations map[string]SIDReservation
+	reservedSIDs map[netip.Addr]string
 }
 
 // NewManager returns a manager backed by an in-memory binding table.
 func NewManager() *Manager {
 	return &Manager{
-		entries:  make(map[string]*managerEntry),
-		bindings: NewBindingTable(),
+		entries:      make(map[string]*managerEntry),
+		bindings:     NewBindingTable(),
+		reservations: make(map[string]SIDReservation),
+		reservedSIDs: make(map[netip.Addr]string),
 	}
 }
 
@@ -67,14 +71,26 @@ func (m *Manager) Add(loc *Locator) error {
 		return fmt.Errorf("%w: %q", ErrLocatorExists, loc.Name)
 	}
 	for _, e := range m.entries {
-		if e.loc.Prefix == loc.Prefix {
+		if e.loc.Prefix.Masked() == loc.Prefix.Masked() {
 			return fmt.Errorf("%w: %s already used by %q", ErrLocatorPrefixInUse, loc.Prefix, e.loc.Name)
 		}
 	}
 	// Copy so external callers cannot mutate the registered definition
 	// out from under the allocator.
 	copyLoc := *loc
-	m.entries[loc.Name] = &managerEntry{loc: &copyLoc, alloc: NewBitmapAllocator(&copyLoc)}
+	copyLoc.Prefix = copyLoc.Prefix.Masked()
+	if err := m.checkReservationLocatorLocked(copyLoc); err != nil {
+		return err
+	}
+	e := &managerEntry{loc: &copyLoc, alloc: NewBitmapAllocator(&copyLoc)}
+	for _, r := range m.reservations {
+		if r.Locator.Name == loc.Name {
+			if _, err := e.alloc.Allocate(&r.Function); err != nil {
+				return fmt.Errorf("restore SID reservation %q: %w", r.Key, err)
+			}
+		}
+	}
+	m.entries[loc.Name] = e
 	return nil
 }
 
@@ -82,10 +98,15 @@ func (m *Manager) Add(loc *Locator) error {
 // bindings still reference it (returning ErrLocatorInUse). With
 // force=true the manager only drops its own state; the caller is
 // responsible for tearing down the upstream SIDs (sid_function_map
-// entries) first.
+// entries) first. Durable reservations remain pending and are restored on Add.
 func (m *Manager) Delete(name string, force bool) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	for _, r := range m.reservations {
+		if r.Locator.Name == name && !force {
+			return fmt.Errorf("%w: %q holds SID reservation %q; release its owner first", ErrLocatorInUse, name, r.Key)
+		}
+	}
 	if _, ok := m.entries[name]; !ok {
 		return fmt.Errorf("%w: %q", ErrLocatorNotFound, name)
 	}
@@ -99,7 +120,9 @@ func (m *Manager) Delete(name string, force bool) error {
 	// that locator would then fail on ErrBindingExists for every SID it
 	// still covers.
 	for _, sid := range used {
-		m.bindings.Forget(sid)
+		if _, reserved := m.reservedSIDs[sid]; !reserved {
+			m.bindings.Forget(sid)
+		}
 	}
 	delete(m.entries, name)
 	return nil
@@ -158,9 +181,13 @@ func (m *Manager) List() []Locator {
 // alive until ReleaseSID is called. requested=nil triggers
 // auto-allocation, otherwise the value is pinned manually.
 func (m *Manager) AllocateSID(locatorName string, requested *uint32) (netip.Addr, Binding, error) {
-	m.mu.RLock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.allocateSIDLocked(locatorName, requested)
+}
+
+func (m *Manager) allocateSIDLocked(locatorName string, requested *uint32) (netip.Addr, Binding, error) {
 	e, ok := m.entries[locatorName]
-	m.mu.RUnlock()
 	if !ok {
 		return netip.Addr{}, Binding{}, fmt.Errorf("%w: %q", ErrLocatorNotFound, locatorName)
 	}
@@ -189,13 +216,20 @@ func (m *Manager) AllocateSID(locatorName string, requested *uint32) (netip.Addr
 // were never recorded) are silent no-ops so SidFunctionDelete can call
 // this unconditionally.
 func (m *Manager) ReleaseSID(sid netip.Addr) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, reserved := m.reservedSIDs[sid]; reserved {
+		return
+	}
+	m.releaseSIDLocked(sid)
+}
+
+func (m *Manager) releaseSIDLocked(sid netip.Addr) {
 	b, ok := m.bindings.Forget(sid)
 	if !ok {
 		return
 	}
-	m.mu.RLock()
 	e := m.entries[b.LocatorName]
-	m.mu.RUnlock()
 	if e != nil {
 		e.alloc.Release(b.Function)
 	}
@@ -204,5 +238,7 @@ func (m *Manager) ReleaseSID(sid netip.Addr) {
 // BindingOf returns the recorded (locator, function) for a sid, if any.
 // Used by /vbctl sid list to render the locator origin of each entry.
 func (m *Manager) BindingOf(sid netip.Addr) (Binding, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	return m.bindings.Lookup(sid)
 }

--- a/pkg/locator/manager.go
+++ b/pkg/locator/manager.go
@@ -102,11 +102,6 @@ func (m *Manager) Add(loc *Locator) error {
 func (m *Manager) Delete(name string, force bool) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	for _, r := range m.reservations {
-		if r.Locator.Name == name && !force {
-			return fmt.Errorf("%w: %q holds SID reservation %q; release its owner first", ErrLocatorInUse, name, r.Key)
-		}
-	}
 	if _, ok := m.entries[name]; !ok {
 		return fmt.Errorf("%w: %q", ErrLocatorNotFound, name)
 	}

--- a/pkg/locator/reservation.go
+++ b/pkg/locator/reservation.go
@@ -1,0 +1,158 @@
+package locator
+
+import (
+	"fmt"
+	"net/netip"
+)
+
+// SIDReservation keeps an allocation tied to a caller's durable identity. The
+// caller persists it before installing forwarding state and releases it only
+// after both that state and its durable record have been removed.
+type SIDReservation struct {
+	Key      string  `json:"key"`
+	Locator  Locator `json:"locator"`
+	Function uint32  `json:"function"`
+}
+
+// SameSIDLayout compares the address format, excluding the auto-allocation
+// range. A restored manual reservation remains valid when that range changes.
+func (l Locator) SameSIDLayout(other Locator) bool {
+	return l.Name == other.Name && l.Prefix.Masked() == other.Prefix.Masked() &&
+		l.BlockLen == other.BlockLen && l.NodeLen == other.NodeLen &&
+		l.FunctionLen == other.FunctionLen && l.ArgumentLen == other.ArgumentLen &&
+		l.Behavior == other.Behavior
+}
+
+func (m *Manager) checkReservationLocatorLocked(loc Locator) error {
+	for _, r := range m.reservations {
+		if r.Locator.Name == loc.Name && !loc.SameSIDLayout(r.Locator) {
+			return fmt.Errorf("locator %q differs from SID reservation %q", loc.Name, r.Key)
+		}
+		if r.Locator.Name != loc.Name && r.Locator.Prefix.Masked() == loc.Prefix.Masked() {
+			return fmt.Errorf("%w: %s reserved by %q", ErrLocatorPrefixInUse, loc.Prefix, r.Locator.Name)
+		}
+	}
+	return nil
+}
+
+// RestoreSIDReservations reserves the complete batch before ordinary allocation
+// can run. Locators may be absent: their bindings are held immediately and Add
+// restores their function bitmaps before publishing them. An identical batch
+// may be replayed; conflicting records leave the manager unchanged.
+func (m *Manager) RestoreSIDReservations(records []SIDReservation) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	added := make([]SIDReservation, 0, len(records))
+	rollback := func() {
+		for _, r := range added {
+			m.releaseReservationLocked(r.Key)
+		}
+	}
+	for _, r := range records {
+		_, existed := m.reservations[r.Key]
+		if err := m.restoreReservationLocked(r); err != nil {
+			rollback()
+			return err
+		}
+		if !existed {
+			added = append(added, r)
+		}
+	}
+	return nil
+}
+
+func (m *Manager) restoreReservationLocked(r SIDReservation) error {
+	if r.Key == "" {
+		return fmt.Errorf("SID reservation: empty key")
+	}
+	if err := r.Locator.Validate(); err != nil {
+		return err
+	}
+	r.Locator.Prefix = r.Locator.Prefix.Masked()
+	sid, err := r.Locator.BuildSID(r.Function)
+	if err != nil {
+		return err
+	}
+	if old, ok := m.reservations[r.Key]; ok {
+		if old.Function == r.Function && old.Locator.SameSIDLayout(r.Locator) {
+			return nil
+		}
+		return fmt.Errorf("SID reservation %q already names another allocation", r.Key)
+	}
+	if err := m.checkReservationLocatorLocked(r.Locator); err != nil {
+		return err
+	}
+	for _, e := range m.entries {
+		if e.loc.Name == r.Locator.Name && !e.loc.SameSIDLayout(r.Locator) {
+			return fmt.Errorf("SID reservation %q differs from locator %q", r.Key, e.loc.Name)
+		}
+		if e.loc.Name != r.Locator.Name && e.loc.Prefix.Masked() == r.Locator.Prefix {
+			return fmt.Errorf("%w: SID reservation %q", ErrLocatorPrefixInUse, r.Key)
+		}
+	}
+	if _, ok := m.bindings.Lookup(sid); ok {
+		return fmt.Errorf("%w: SID reservation %q at %s", ErrBindingExists, r.Key, sid)
+	}
+	e := m.entries[r.Locator.Name]
+	if e != nil {
+		if _, err := e.alloc.Allocate(&r.Function); err != nil {
+			return err
+		}
+	}
+	if err := m.bindings.Record(sid, Binding{LocatorName: r.Locator.Name, Function: r.Function}); err != nil {
+		if e != nil {
+			e.alloc.Release(r.Function)
+		}
+		return err
+	}
+	m.reservations[r.Key] = r
+	m.reservedSIDs[sid] = r.Key
+	return nil
+}
+
+// AllocateReservedSID returns the allocation already held by key, or allocates
+// and reserves a new one atomically. It never creates a missing locator.
+func (m *Manager) AllocateReservedSID(key, locatorName string) (netip.Addr, SIDReservation, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if key == "" {
+		return netip.Addr{}, SIDReservation{}, fmt.Errorf("SID reservation: empty key")
+	}
+	if _, ok := m.entries[locatorName]; !ok {
+		return netip.Addr{}, SIDReservation{}, fmt.Errorf("%w: %q", ErrLocatorNotFound, locatorName)
+	}
+	if r, ok := m.reservations[key]; ok {
+		if r.Locator.Name != locatorName {
+			return netip.Addr{}, SIDReservation{}, fmt.Errorf("SID reservation %q belongs to locator %q", key, r.Locator.Name)
+		}
+		sid, err := r.Locator.BuildSID(r.Function)
+		return sid, r, err
+	}
+	sid, b, err := m.allocateSIDLocked(locatorName, nil)
+	if err != nil {
+		return netip.Addr{}, SIDReservation{}, err
+	}
+	r := SIDReservation{Key: key, Locator: *m.entries[locatorName].loc, Function: b.Function}
+	m.reservations[key] = r
+	m.reservedSIDs[sid] = key
+	return sid, r, nil
+}
+
+// ReleaseReservedSID gives up key after the caller's durable cleanup. Ordinary
+// ReleaseSID and even a forced locator deletion cannot drop these reservations.
+func (m *Manager) ReleaseReservedSID(key string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.releaseReservationLocked(key)
+}
+
+func (m *Manager) releaseReservationLocked(key string) {
+	r, ok := m.reservations[key]
+	if !ok {
+		return
+	}
+	sid, _ := r.Locator.BuildSID(r.Function)
+	delete(m.reservations, key)
+	delete(m.reservedSIDs, sid)
+	m.releaseSIDLocked(sid)
+}

--- a/pkg/locator/reservation_test.go
+++ b/pkg/locator/reservation_test.go
@@ -16,6 +16,9 @@ func TestSIDReservationsPrecedeLocatorRegistration(t *testing.T) {
 	if _, ok := m.Get(loc.Name); ok {
 		t.Fatal("reservation created a locator")
 	}
+	if err := m.Delete(loc.Name, false); !errors.Is(err, ErrLocatorNotFound) {
+		t.Fatalf("pending locator delete: %v", err)
+	}
 	if _, _, err := m.AllocateReservedSID(r.Key, loc.Name); !errors.Is(err, ErrLocatorNotFound) {
 		t.Fatalf("pending reservation: %v", err)
 	}

--- a/pkg/locator/reservation_test.go
+++ b/pkg/locator/reservation_test.go
@@ -1,0 +1,145 @@
+package locator
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+func TestSIDReservationsPrecedeLocatorRegistration(t *testing.T) {
+	loc := makeClassic48(t)
+	r := SIDReservation{Key: "plugin/name", Locator: loc, Function: loc.FunctionAutoStart}
+	m := NewManager()
+	if err := m.RestoreSIDReservations([]SIDReservation{r}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := m.Get(loc.Name); ok {
+		t.Fatal("reservation created a locator")
+	}
+	if _, _, err := m.AllocateReservedSID(r.Key, loc.Name); !errors.Is(err, ErrLocatorNotFound) {
+		t.Fatalf("pending reservation: %v", err)
+	}
+	alias := loc
+	alias.Name = "alias"
+	if err := m.Add(&alias); !errors.Is(err, ErrLocatorPrefixInUse) {
+		t.Fatalf("alias stole pending prefix: %v", err)
+	}
+	changed := loc
+	changed.BlockLen--
+	changed.NodeLen++
+	if err := m.Add(&changed); err == nil {
+		t.Fatal("accepted changed SID structure")
+	}
+	// Allocation-range changes do not change the address format.
+	loc.FunctionAutoStart++
+	if err := m.Add(&loc); err != nil {
+		t.Fatal(err)
+	}
+	sid, _, err := m.AllocateReservedSID(r.Key, loc.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.ReleaseSID(sid)
+	if _, _, err := m.AllocateSID(loc.Name, &r.Function); !errors.Is(err, ErrFunctionInUse) {
+		t.Fatalf("ordinary release dropped reservation: %v", err)
+	}
+	if err := m.Delete(loc.Name, false); !errors.Is(err, ErrLocatorInUse) {
+		t.Fatalf("delete reserved locator: %v", err)
+	}
+	// Forced rollback removes the live locator, retaining its pending holds.
+	if err := m.Delete(loc.Name, true); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := m.BindingOf(sid); !ok {
+		t.Fatal("forced deletion forgot durable reservation")
+	}
+	if err := m.Add(&loc); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := m.AllocateSID(loc.Name, &r.Function); !errors.Is(err, ErrFunctionInUse) {
+		t.Fatalf("re-add lost reservation: %v", err)
+	}
+	m.ReleaseReservedSID(r.Key)
+	if _, _, err := m.AllocateSID(loc.Name, &r.Function); err != nil {
+		t.Fatalf("explicit release did not return function: %v", err)
+	}
+}
+
+func TestSIDReservationBatchRollsBackOnlyNewReservations(t *testing.T) {
+	for _, registered := range []bool{false, true} {
+		t.Run(map[bool]string{false: "pending", true: "registered"}[registered], func(t *testing.T) {
+			loc := makeClassic48(t)
+			m := NewManager()
+			if registered {
+				if err := m.Add(&loc); err != nil {
+					t.Fatal(err)
+				}
+			}
+			a := SIDReservation{Key: "a", Locator: loc, Function: loc.FunctionAutoStart}
+			b := a
+			b.Key = "b"
+			b.Function++
+			bad := a
+			bad.Key = "collision"
+			if err := m.RestoreSIDReservations([]SIDReservation{a}); err != nil {
+				t.Fatal(err)
+			}
+			if err := m.RestoreSIDReservations([]SIDReservation{a, b, bad}); err == nil {
+				t.Fatal("accepted duplicate address")
+			}
+			if !registered {
+				if err := m.Add(&loc); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if _, _, err := m.AllocateSID(loc.Name, &a.Function); !errors.Is(err, ErrFunctionInUse) {
+				t.Fatalf("rollback dropped existing reservation: %v", err)
+			}
+			if _, _, err := m.AllocateSID(loc.Name, &b.Function); err != nil {
+				t.Fatalf("rollback leaked new reservation: %v", err)
+			}
+		})
+	}
+}
+
+func TestSIDReservationsShareAllocationLock(t *testing.T) {
+	m := NewManager()
+	loc := makeClassic48(t)
+	if err := m.Add(&loc); err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	for i := range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				if i%2 == 0 {
+					sid, _, err := m.AllocateSID(loc.Name, nil)
+					if err != nil {
+						t.Error(err)
+						return
+					}
+					m.ReleaseSID(sid)
+				} else {
+					// Each goroutine holds a distinct caller identity.
+					key := string(rune('a' + i))
+					sid, _, err := m.AllocateReservedSID(key, loc.Name)
+					if err != nil {
+						t.Error(err)
+						return
+					}
+					m.ReleaseSID(sid)
+					if _, ok := m.BindingOf(sid); !ok {
+						t.Error("reservation disappeared")
+					}
+					m.ReleaseReservedSID(key)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if got := m.bindings.ListByLocator(loc.Name); len(got) != 0 {
+		t.Fatalf("leaked bindings: %v", got)
+	}
+}


### PR DESCRIPTION
daemon 再起動で local SID の名前と address の対応が失われ、再宣言前の unregister でも残存 entry を発見できませんでした。cplane store が有効な場合は割り当てを永続化し、同じ plugin 名・SID 名・locator の address 構造なら、再起動後も同じ SID を返します。

- config locator / exporter より先に reservation を復元します。locator が未登録でも address を保持し、後から登録された locator に予約を適用します。pin_maps 無効時にも割り当てを維持します。
- inventory を同期してから dispatch を作成します。再起動後は宣言時に entry を再作成し、aux index と VRF ifindex を求め直します。保存・install・cleanup の失敗時は予約を保持し、map 撤去と inventory 更新が完了してから解放します。
- restore-time prune は削除対象だけを扱います。WASM または manifest が無くても inventory を発見でき、unregister で cleanup できます。inventory が残る間の forget は拒否します。
- SID owner map を dispatch とともに pin します。欠落した /128 の削除が covering /64 の VRF grant を消す問題と、広告 withdraw 失敗後に SID を消してしまう flush も修正します。

inventory は `local-sids/state.json`、導入済み marker は `local-sids.version` です。欠落・破損時は address の再利用を避けるため起動を拒否します。復旧時の dispatch 再作成には短い転送断があります。inventory 導入前に名前と owner を失った entry の自動移行と、無停止での adopt は対象外です。SDK / WASM ABI は変更しません。

Validation:

- `go test -race ./pkg/cplane ./pkg/locator ./pkg/cplane/wasm -count=1 -timeout=20m` 成功。
- 保存の rename 前後、map / grant / rollback 失敗、ownerless / foreign dispatch、遅延 locator、scope 縮小、guest 無し cleanup を含む追加 regression と locator の並行割り当てテスト成功。
- 実 BPF map の delete / grant regression と `TestBpfLoad_PinMapsRoundTrip` 成功。pin 復元後の owner を確認。
- `go test -race -exec sudo ./pkg/server -run 'Locator|Usid' -count=1`、`go build -buildvcs=false ./...`、`golangci-lint run ./...` 成功。
- 標準 Go WASM SDK の SID retry / cleanup / locator 変更 / 50 回の restart テスト成功。
- Copilot の指摘 5 件（inline 4 件、suppressed 1 件）を修正し、修正前の再現と修正後の成功を確認。最新 head の再レビューは追加指摘 0 件（18/18 files reviewed）。総評は永続化・障害復旧・BPF map lifecycle に関する人手での最終確認を推奨しています。
- 最新 head (`a063df3158d0`) の CI は 91/91 件すべて成功（Unit Test、interop、build、lint を含む）。

Base は `feature/cplane-plugin`。#175、#176、#177 とは独立した変更です。


Copilot review 対応:

- owner 行だけが残った SID の再作成が covering entry の aux を解放しないよう、両 create API でも exact prefix を確認します。
- main entry 削除後の owner map 削除失敗で aux が漏れないよう、builtin aux cleanup を先に行います。専用 owner map の Freeze で失敗を再現しています。
- marker 保存前の初期化中断は snapshot 欠落時だけ再開し、既存 snapshot を保持します。store の parent directory も同期します。
- pending reservation のみで locator 自体が無い場合は、既存契約どおり `ErrLocatorNotFound` を返します。
- owner が分かる SID の cleanup と grant 撤去を map 層に委譲し、空き address の検査は exact lookup を使います。4 SID の作成・撤去で host の全件列挙は 9 回から初回 sweep の 1 回へ減りました。ownerless entry の照合と BPF 層で必要な exact-key scan は維持します。

#175 → #176 → #177 → この PR の順に local で競合なく適用し、`go test -race ./pkg/bgp/apply ./pkg/bgp/demux ./pkg/cplane ./pkg/locator ./pkg/cplane/wasm -count=1 -timeout=20m` の成功を確認しました。
